### PR TITLE
fix(hud): stop usage polls being throttled to one an hour

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "ae752358b599811d1ddd95824c89a4234ce8d3c7",
-    "sourceSha256": "028473100ba187e825486330cdad79694ee12438aa37d00893b5966c8670eef6",
+    "head": "06fc4a14a3ae62888c1b247584eee744ba435ebd",
+    "sourceSha256": "2ee35f9fcc21e3a720bbe8d3ac73607542b56ba64f8aab7b1bc861cd3476f70b",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "ae752358b599811d1ddd95824c89a4234ce8d3c7",
-  "sourceSha256": "028473100ba187e825486330cdad79694ee12438aa37d00893b5966c8670eef6",
+  "head": "06fc4a14a3ae62888c1b247584eee744ba435ebd",
+  "sourceSha256": "2ee35f9fcc21e3a720bbe8d3ac73607542b56ba64f8aab7b1bc861cd3476f70b",
   "counts": {
     "public": {
       "skills": 32,
@@ -28,8 +28,8 @@
       "toolFiles": 59,
       "libFiles": 36,
       "templateHooks": 21,
-      "srcFiles": 1304,
-      "total": 1325
+      "srcFiles": 1306,
+      "total": 1327
     },
     "generated": {
       "distFiles": 4955,
@@ -34114,6 +34114,11 @@
         "path": "src/__tests__/hud/usage-api-stale.test.ts"
       },
       {
+        "id": "src/__tests__/hud/usage-api-user-agent.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/hud/usage-api-user-agent.test.ts"
+      },
+      {
         "id": "src/__tests__/hud/usage-api.test.ts",
         "kind": "src",
         "path": "src/__tests__/hud/usage-api.test.ts"
@@ -34557,6 +34562,11 @@
         "id": "src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts",
         "kind": "src",
         "path": "src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts"
+      },
+      {
+        "id": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts"
       },
       {
         "id": "src/__tests__/rate-limit-wait/daemon.test.ts",
@@ -45031,6 +45041,31 @@
         "kind": "imports"
       },
       {
+        "from": "src/__tests__/hud/usage-api-user-agent.test.ts",
+        "to": "external:events",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/hud/usage-api-user-agent.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/hud/usage-api-user-agent.test.ts",
+        "to": "external:https",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/hud/usage-api-user-agent.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/hud/usage-api-user-agent.test.ts",
+        "to": "src/hud/usage-api.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/__tests__/hud/usage-api.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -47021,6 +47056,51 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "src/features/rate-limit-wait/rate-limit-monitor.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "src/hud/stdin.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "src/hud/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/daemon-cache-context.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/__tests__/rate-limit-wait/daemon.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -47123,6 +47203,16 @@
       {
         "from": "src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts",
         "to": "src/features/rate-limit-wait/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts",
+        "to": "src/hud/stdin.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts",
+        "to": "src/hud/types.ts",
         "kind": "type-imports"
       },
       {
@@ -52529,6 +52619,11 @@
         "from": "src/features/rate-limit-wait/rate-limit-monitor.ts",
         "to": "src/features/rate-limit-wait/types.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/features/rate-limit-wait/rate-limit-monitor.ts",
+        "to": "src/hud/stdin.ts",
+        "kind": "imports"
       },
       {
         "from": "src/features/rate-limit-wait/rate-limit-monitor.ts",
@@ -75967,12 +76062,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6827,
-      "edgeCount": 7111,
-      "importEdgeCount": 5829,
+      "nodeCount": 6829,
+      "edgeCount": 7128,
+      "importEdgeCount": 5844,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "b8773e75e23058231db59e06e186a1806efa9e4707b1104149e6285eba761c38",
-  "manifestSha256": "f3702f93e8159ad9aff0b89532e1bc3ce5846809d724bf23c864393aaf56fb55"
+  "inventorySha256": "126a502711b1cf018cbe88c4a8a08d8b4b6b876e8cea1c890ce1f8563417e9f7",
+  "manifestSha256": "227dca528414e8a30a9afa31fbf6e7f3789354f1ba0db85cfb9654afe2e6eece"
 }

--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -627,6 +627,28 @@ describe('readStdinCache — env-less reader fallback to most recent session cac
     expect(got?.version).toBe('2.1.232');
   });
 
+  it('prefers a newer valid legacy cache over an older session cache', () => {
+    const stateDir = join(tmpRoot, '.omc', 'state');
+    const sessionDir = join(stateDir, 'sessions', 'session-old');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'hud-stdin-cache.json'),
+      JSON.stringify(makeStdin({ transcript_path: '/tmp/newer-legacy.jsonl', version: '2.1.232' })),
+    );
+    writeFileSync(
+      join(sessionDir, 'hud-stdin-cache.json'),
+      JSON.stringify(makeStdin({ transcript_path: '/tmp/older-session.jsonl', version: '2.1.100' })),
+    );
+
+    const now = Date.now() / 1000;
+    utimesSync(join(stateDir, 'hud-stdin-cache.json'), now, now);
+    utimesSync(join(sessionDir, 'hud-stdin-cache.json'), now - 60, now - 60);
+
+    const got = readStdinCache();
+    expect(got?.transcript_path).toBe('/tmp/newer-legacy.jsonl');
+    expect(got?.version).toBe('2.1.232');
+  });
+
   it('skips a malformed newest session cache and returns an older valid cache', () => {
     const stateDir = join(tmpRoot, '.omc', 'state');
     const oldSession = join(stateDir, 'sessions', 'session-old');

--- a/src/__tests__/hud/stdin.test.ts
+++ b/src/__tests__/hud/stdin.test.ts
@@ -601,26 +601,51 @@ describe('readStdinCache — env-less reader fallback to most recent session cac
     expect(got?.transcript_path).toBe('/tmp/new.jsonl');
   });
 
-  it('prefers the legacy flat cache over the session-scoped fallback when both exist', () => {
-    // A session wrote via the old (flat) path; an unrelated session dir
-    // also happens to sit under state/sessions/. The legacy file should
-    // win so callers that rely on the pre-session-scoping behavior keep
-    // their existing semantics.
+  it('prefers the newest valid session cache over a stale legacy flat cache', () => {
+    // A session wrote via the old (flat) path; the current session dir also
+    // exists under state/sessions/. The session cache carries the current
+    // version and must win over the stale legacy snapshot.
     const stateDir = join(tmpRoot, '.omc', 'state');
     mkdirSync(stateDir, { recursive: true });
     writeFileSync(
       join(stateDir, 'hud-stdin-cache.json'),
-      JSON.stringify(makeStdin({ transcript_path: '/tmp/legacy.jsonl' })),
+      JSON.stringify(makeStdin({ transcript_path: '/tmp/legacy.jsonl', version: '2.1.100' })),
     );
     const some = join(stateDir, 'sessions', 'session-xyz');
     mkdirSync(some, { recursive: true });
     writeFileSync(
       join(some, 'hud-stdin-cache.json'),
-      JSON.stringify(makeStdin({ transcript_path: '/tmp/scoped.jsonl' })),
+      JSON.stringify(makeStdin({ transcript_path: '/tmp/scoped.jsonl', version: '2.1.232' })),
     );
 
+    const now = Date.now() / 1000;
+    utimesSync(join(stateDir, 'hud-stdin-cache.json'), now - 60, now - 60);
+    utimesSync(join(some, 'hud-stdin-cache.json'), now, now);
+
     const got = readStdinCache();
-    expect(got?.transcript_path).toBe('/tmp/legacy.jsonl');
+    expect(got?.transcript_path).toBe('/tmp/scoped.jsonl');
+    expect(got?.version).toBe('2.1.232');
+  });
+
+  it('skips a malformed newest session cache and returns an older valid cache', () => {
+    const stateDir = join(tmpRoot, '.omc', 'state');
+    const oldSession = join(stateDir, 'sessions', 'session-old');
+    const newestSession = join(stateDir, 'sessions', 'session-newest');
+    mkdirSync(oldSession, { recursive: true });
+    mkdirSync(newestSession, { recursive: true });
+    writeFileSync(
+      join(oldSession, 'hud-stdin-cache.json'),
+      JSON.stringify(makeStdin({ transcript_path: '/tmp/older-valid.jsonl', version: '2.1.200' })),
+    );
+    writeFileSync(join(newestSession, 'hud-stdin-cache.json'), '{ malformed json');
+
+    const now = Date.now() / 1000;
+    utimesSync(join(oldSession, 'hud-stdin-cache.json'), now - 60, now - 60);
+    utimesSync(join(newestSession, 'hud-stdin-cache.json'), now, now);
+
+    const got = readStdinCache();
+    expect(got?.transcript_path).toBe('/tmp/older-valid.jsonl');
+    expect(got?.version).toBe('2.1.200');
   });
 
   it('returns null when nothing has been cached yet', () => {

--- a/src/__tests__/hud/usage-api-user-agent.test.ts
+++ b/src/__tests__/hud/usage-api-user-agent.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the User-Agent on `GET /api/oauth/usage`.
+ *
+ * The endpoint buckets its rate limit by User-Agent, and a request that does not
+ * name a Claude Code *version* lands in a bucket that allows roughly one request
+ * per hour. Measured against api.anthropic.com with a single OAuth token,
+ * requests seconds apart, recording status and `retry-after` only:
+ *
+ *   User-Agent           | HTTP | retry-after
+ *   ---------------------|------|--------------------------------------------
+ *   (header omitted)     | 429  | 348s
+ *   claude-code          | 429  | 349s / 348s - same absolute deadline
+ *   claude-code/2.1.232  | 403  | none - the endpoint's real answer
+ *   claude-code/9.9.9    | 403  | none - the endpoint's real answer
+ *
+ * The 403 is the token's own scope error, i.e. a real per-request answer rather
+ * than a throttle. Two things follow, and both are asserted below: a versioned
+ * product token is what unlocks the bucket, and a version-less one buys nothing,
+ * so we send no header at all rather than a fabricated version.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import { buildUserAgent, getUsage } from '../../hud/usage-api.js';
+
+// Mock file-lock so withFileLock always executes the callback.
+vi.mock('../../lib/file-lock.js', () => ({
+  withFileLock: vi.fn((_lockPath: string, fn: () => unknown) => fn()),
+  lockPathFor: vi.fn((p: string) => p + '.lock'),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn().mockReturnValue('{}'),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    openSync: vi.fn().mockReturnValue(1),
+    writeSync: vi.fn(),
+    closeSync: vi.fn(),
+    statSync: vi.fn().mockReturnValue({ mtimeMs: Date.now() }),
+    unlinkSync: vi.fn(),
+  };
+});
+
+// Keychain lookups must fail so the credential read falls through to the file
+// path, which is the one branch that behaves identically on macOS and Linux CI.
+vi.mock('child_process', () => ({
+  execSync: vi.fn().mockImplementation(() => { throw new Error('mock: no keychain'); }),
+  execFileSync: vi.fn().mockImplementation(() => { throw new Error('mock: no keychain'); }),
+}));
+
+vi.mock('https', () => ({
+  default: {
+    request: vi.fn(),
+  },
+}));
+
+const FAKE_CREDENTIALS = JSON.stringify({
+  claudeAiOauth: {
+    accessToken: 'test-access-token-not-a-real-secret',
+    refreshToken: 'test-refresh-token-not-a-real-secret',
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  },
+});
+
+/** Serve credentials from the file path and nothing else, so the usage cache stays absent. */
+function stubCredentialFile(): void {
+  vi.mocked(fs.existsSync).mockImplementation(
+    (p) => typeof p === 'string' && p.endsWith('.credentials.json'),
+  );
+  vi.mocked(fs.readFileSync).mockImplementation(
+    (p) => (typeof p === 'string' && p.endsWith('.credentials.json') ? FAKE_CREDENTIALS : '{}') as never,
+  );
+}
+
+/** Answer the next https.request with a minimal 200 usage payload. */
+function stubUsage200(httpsRequest: ReturnType<typeof vi.fn>): void {
+  httpsRequest.mockImplementationOnce((_options: unknown, callback: (res: unknown) => void) => {
+    const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void };
+    req.destroy = vi.fn();
+    req.end = () => {
+      const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', JSON.stringify({ five_hour: { utilization: 11 }, seven_day: { utilization: 22 } }));
+      res.emit('end');
+    };
+    return req;
+  });
+}
+
+describe('buildUserAgent', () => {
+  it('names the Claude Code version the session is actually running', () => {
+    // Mutation that fails this: drop the header, or stop interpolating the version.
+    expect(buildUserAgent('2.1.232')).toBe('claude-code/2.1.232');
+  });
+
+  it('accepts a prerelease or build suffix', () => {
+    expect(buildUserAgent('2.1.232-beta.1')).toBe('claude-code/2.1.232-beta.1');
+  });
+
+  it('returns undefined rather than "claude-code/undefined" when no version is known', () => {
+    // Mutation that fails this: template the version unconditionally.
+    expect(buildUserAgent(undefined)).toBeUndefined();
+    expect(buildUserAgent('')).toBeUndefined();
+    expect(buildUserAgent('   ')).toBeUndefined();
+  });
+
+  it('refuses a value that is not version-shaped instead of inventing one', () => {
+    // Mutation that fails this: drop the shape test and pass the string through.
+    expect(buildUserAgent('abc')).toBeUndefined();
+    expect(buildUserAgent('2.1')).toBeUndefined();
+    expect(buildUserAgent('v2.1.232')).toBeUndefined();
+  });
+
+  it('refuses a version carrying header-unsafe characters', () => {
+    // A version reaches us from a JSON payload, so an unanchored prefix match
+    // would let CR/LF or a stray token into an outgoing header.
+    // Mutation that fails this: unanchor the pattern (drop the trailing `$`).
+    expect(buildUserAgent('2.1.232\r\nX-Injected: 1')).toBeUndefined();
+    expect(buildUserAgent('2.1.232 (external, cli)')).toBeUndefined();
+  });
+});
+
+describe('GET /api/oauth/usage request headers', () => {
+  let httpsModule: { default: { request: ReturnType<typeof vi.fn> } };
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.KIMI_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
+    httpsModule = await import('https') as unknown as typeof httpsModule;
+    stubCredentialFile();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('sends the versioned product token when the statusline reports a version', async () => {
+    stubUsage200(httpsModule.default.request);
+
+    await getUsage({ clientVersion: '2.1.232' });
+
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
+    const headers = httpsModule.default.request.mock.calls[0][0].headers;
+    expect(headers['User-Agent']).toBe('claude-code/2.1.232');
+    // The headers this request already sent must be untouched by the addition.
+    expect(headers.Authorization).toBe('Bearer test-access-token-not-a-real-secret');
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('omits the header entirely when no version is known, rather than sending a made-up one', async () => {
+    stubUsage200(httpsModule.default.request);
+
+    await getUsage();
+
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(1);
+    const headers = httpsModule.default.request.mock.calls[0][0].headers;
+    // Not just falsy: the key must be absent, so nothing serializes as
+    // "User-Agent: undefined" on the wire.
+    // Mutation that fails this: fall back to a bare or hard-coded product token.
+    expect('User-Agent' in headers).toBe(false);
+    expect(headers.Authorization).toBe('Bearer test-access-token-not-a-real-secret');
+    expect(headers['anthropic-beta']).toBe('oauth-2025-04-20');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('omits the header when the reported version is unusable', async () => {
+    stubUsage200(httpsModule.default.request);
+
+    await getUsage({ clientVersion: 'not-a-version' });
+
+    const headers = httpsModule.default.request.mock.calls[0][0].headers;
+    expect('User-Agent' in headers).toBe(false);
+  });
+});

--- a/src/__tests__/hud/usage-api-user-agent.test.ts
+++ b/src/__tests__/hud/usage-api-user-agent.test.ts
@@ -236,4 +236,32 @@ describe('GET /api/oauth/usage request headers', () => {
     expect(versioned.rateLimits).not.toBeNull();
     expect(versioned.error).toBeUndefined();
   });
+
+  it('keeps active Anthropic backoffs independent for different versions', async () => {
+    const cacheFiles = new Map<string, string>();
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => String(p).endsWith('.credentials.json') || cacheFiles.has(String(p)),
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      return (path.endsWith('.credentials.json') ? FAKE_CREDENTIALS : cacheFiles.get(path) ?? '{}') as never;
+    });
+    vi.mocked(fs.writeFileSync).mockImplementation((p, content) => {
+      cacheFiles.set(String(p), String(content));
+    });
+
+    stubUsage429(httpsModule.default.request);
+    stubUsage429(httpsModule.default.request);
+
+    await Promise.all([
+      getUsage({ clientVersion: '2.1.232' }),
+      getUsage({ clientVersion: '2.1.233' }),
+    ]);
+    const firstFollowUp = await getUsage({ clientVersion: '2.1.232' });
+    const secondFollowUp = await getUsage({ clientVersion: '2.1.233' });
+
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(2);
+    expect(firstFollowUp.error).toBe('rate_limited');
+    expect(secondFollowUp.error).toBe('rate_limited');
+  });
 });

--- a/src/__tests__/hud/usage-api-user-agent.test.ts
+++ b/src/__tests__/hud/usage-api-user-agent.test.ts
@@ -24,9 +24,15 @@ import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import { buildUserAgent, getUsage } from '../../hud/usage-api.js';
 
+const lockState = vi.hoisted(() => ({ tail: Promise.resolve() }));
+
 // Mock file-lock so withFileLock always executes the callback.
 vi.mock('../../lib/file-lock.js', () => ({
-  withFileLock: vi.fn((_lockPath: string, fn: () => unknown) => fn()),
+  withFileLock: vi.fn((_lockPath: string, fn: () => unknown) => {
+    const run = lockState.tail.then(fn);
+    lockState.tail = run.then(() => undefined, () => undefined);
+    return run;
+  }),
   lockPathFor: vi.fn((p: string) => p + '.lock'),
 }));
 
@@ -93,6 +99,22 @@ function stubUsage200(httpsRequest: ReturnType<typeof vi.fn>): void {
   });
 }
 
+/** Answer the next https.request with a rate-limit response. */
+function stubUsage429(httpsRequest: ReturnType<typeof vi.fn>): void {
+  httpsRequest.mockImplementationOnce((_options: unknown, callback: (res: unknown) => void) => {
+    const req = new EventEmitter() as EventEmitter & { end: () => void; destroy: () => void };
+    req.destroy = vi.fn();
+    req.end = () => {
+      const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+      res.statusCode = 429;
+      callback(res);
+      res.emit('data', JSON.stringify({ error: { type: 'rate_limit_error' } }));
+      res.emit('end');
+    };
+    return req;
+  });
+}
+
 describe('buildUserAgent', () => {
   it('names the Claude Code version the session is actually running', () => {
     // Mutation that fails this: drop the header, or stop interpolating the version.
@@ -132,6 +154,7 @@ describe('GET /api/oauth/usage request headers', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    lockState.tail = Promise.resolve();
     process.env = { ...originalEnv };
     delete process.env.ANTHROPIC_BASE_URL;
     delete process.env.ANTHROPIC_AUTH_TOKEN;
@@ -183,5 +206,34 @@ describe('GET /api/oauth/usage request headers', () => {
 
     const headers = httpsModule.default.request.mock.calls[0][0].headers;
     expect('User-Agent' in headers).toBe(false);
+  });
+
+  it('does not let an anonymous 429 suppress a concurrent versioned request', async () => {
+    const cacheFiles = new Map<string, string>();
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => String(p).endsWith('.credentials.json') || cacheFiles.has(String(p)),
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((p) => {
+      const path = String(p);
+      return (path.endsWith('.credentials.json') ? FAKE_CREDENTIALS : cacheFiles.get(path) ?? '{}') as never;
+    });
+    vi.mocked(fs.writeFileSync).mockImplementation((p, content) => {
+      cacheFiles.set(String(p), String(content));
+    });
+
+    stubUsage429(httpsModule.default.request);
+    stubUsage200(httpsModule.default.request);
+
+    const [, versioned] = await Promise.all([
+      getUsage(),
+      getUsage({ clientVersion: '2.1.232' }),
+    ]);
+
+    expect(httpsModule.default.request).toHaveBeenCalledTimes(2);
+    const requests = httpsModule.default.request.mock.calls.map((call) => call[0].headers);
+    expect(requests.some((headers) => !('User-Agent' in headers))).toBe(true);
+    expect(requests.some((headers) => headers['User-Agent'] === 'claude-code/2.1.232')).toBe(true);
+    expect(versioned.rateLimits).not.toBeNull();
+    expect(versioned.error).toBeUndefined();
   });
 });

--- a/src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts
+++ b/src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts
@@ -59,6 +59,10 @@ describe('daemon bootstrap', () => {
 
     process.env.PATH = '/usr/bin:/bin';
     process.env.TMUX = '/tmp/tmux-1000/default,100,0';
+    process.env.OMC_STATE_DIR = '/tmp/omc-central-state';
+    process.env.CLAUDE_CONFIG_DIR = '/tmp/claude-profile';
+    process.env.CLAUDE_SESSION_ID = 'session-current';
+    process.env.CLAUDECODE_SESSION_ID = 'session-legacy-alias';
     process.env.ANTHROPIC_API_KEY = 'super-secret';
     process.env.GITHUB_TOKEN = 'token-should-not-leak';
 
@@ -93,6 +97,10 @@ describe('daemon bootstrap', () => {
     const childEnv = spawnOptions?.env as Record<string, string | undefined>;
     expect(childEnv.PATH).toBe('/usr/bin:/bin');
     expect(childEnv.TMUX).toBe('/tmp/tmux-1000/default,100,0');
+    expect(childEnv.OMC_STATE_DIR).toBe('/tmp/omc-central-state');
+    expect(childEnv.CLAUDE_CONFIG_DIR).toBe('/tmp/claude-profile');
+    expect(childEnv.CLAUDE_SESSION_ID).toBe('session-current');
+    expect(childEnv.CLAUDECODE_SESSION_ID).toBe('session-legacy-alias');
     expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
     expect(childEnv.GITHUB_TOKEN).toBeUndefined();
 

--- a/src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts
+++ b/src/__tests__/rate-limit-wait/daemon-bootstrap.test.ts
@@ -99,8 +99,11 @@ describe('daemon bootstrap', () => {
     expect(childEnv.TMUX).toBe('/tmp/tmux-1000/default,100,0');
     expect(childEnv.OMC_STATE_DIR).toBe('/tmp/omc-central-state');
     expect(childEnv.CLAUDE_CONFIG_DIR).toBe('/tmp/claude-profile');
-    expect(childEnv.CLAUDE_SESSION_ID).toBe('session-current');
-    expect(childEnv.CLAUDECODE_SESSION_ID).toBe('session-legacy-alias');
+    // A detached daemon must not pin itself to the launching session: that
+    // session's cache is removed at session end, while another live session
+    // may have the version the daemon should use on its next poll.
+    expect(childEnv.CLAUDE_SESSION_ID).toBeUndefined();
+    expect(childEnv.CLAUDECODE_SESSION_ID).toBeUndefined();
     expect(childEnv.ANTHROPIC_API_KEY).toBeUndefined();
     expect(childEnv.GITHUB_TOKEN).toBeUndefined();
 

--- a/src/__tests__/rate-limit-wait/daemon-cache-context.test.ts
+++ b/src/__tests__/rate-limit-wait/daemon-cache-context.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+
+const { getUsageMock } = vi.hoisted(() => ({
+  getUsageMock: vi.fn(),
+}));
+
+vi.mock('../../hud/usage-api.js', () => ({
+  getUsage: getUsageMock,
+}));
+
+import { checkRateLimitStatus } from '../../features/rate-limit-wait/rate-limit-monitor.js';
+import { readStdinCache, writeStdinCache } from '../../hud/stdin.js';
+import { getSessionStateDir } from '../../lib/worktree-paths.js';
+import type { StatuslineStdin } from '../../hud/types.js';
+
+describe('detached daemon HUD cache context', () => {
+  let worktreeRoot: string;
+  let centralStateRoot: string;
+  let originalCwd: string;
+  const originalStateDir = process.env.OMC_STATE_DIR;
+  const originalSessionId = process.env.CLAUDE_SESSION_ID;
+  const originalLegacySessionId = process.env.CLAUDECODE_SESSION_ID;
+
+  beforeEach(() => {
+    worktreeRoot = mkdtempSync(join(tmpdir(), 'omc-daemon-cache-context-'));
+    centralStateRoot = mkdtempSync(join(tmpdir(), 'omc-daemon-cache-central-'));
+    execSync('git init --quiet', { cwd: worktreeRoot });
+    originalCwd = process.cwd();
+    process.chdir(worktreeRoot);
+    process.env.OMC_STATE_DIR = centralStateRoot;
+    delete process.env.CLAUDE_SESSION_ID;
+    delete process.env.CLAUDECODE_SESSION_ID;
+    getUsageMock.mockReset();
+    getUsageMock.mockResolvedValue({ rateLimits: null, error: 'no_credentials' });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalStateDir === undefined) delete process.env.OMC_STATE_DIR;
+    else process.env.OMC_STATE_DIR = originalStateDir;
+    if (originalSessionId === undefined) delete process.env.CLAUDE_SESSION_ID;
+    else process.env.CLAUDE_SESSION_ID = originalSessionId;
+    if (originalLegacySessionId === undefined) delete process.env.CLAUDECODE_SESSION_ID;
+    else process.env.CLAUDECODE_SESSION_ID = originalLegacySessionId;
+    rmSync(worktreeRoot, { recursive: true, force: true });
+    rmSync(centralStateRoot, { recursive: true, force: true });
+  });
+
+  it('uses a newer live session after the daemon launch session cache is removed', async () => {
+    process.env.CLAUDE_SESSION_ID = 'session-a';
+    writeStdinCache({ cwd: worktreeRoot, version: '2.1.100' } as StatuslineStdin);
+    const sessionACache = join(
+      getSessionStateDir('session-a', worktreeRoot),
+      'hud-stdin-cache.json',
+    );
+    rmSync(sessionACache);
+
+    process.env.CLAUDE_SESSION_ID = 'session-b';
+    writeStdinCache({ cwd: worktreeRoot, version: '2.1.232' } as StatuslineStdin);
+
+    // Detached daemons intentionally run without either launch-session ID.
+    delete process.env.CLAUDE_SESSION_ID;
+    delete process.env.CLAUDECODE_SESSION_ID;
+
+    expect(readStdinCache()?.version).toBe('2.1.232');
+    await checkRateLimitStatus();
+
+    expect(getUsageMock).toHaveBeenCalledWith({ clientVersion: '2.1.232' });
+  });
+});

--- a/src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts
+++ b/src/__tests__/rate-limit-wait/rate-limit-monitor.test.ts
@@ -11,20 +11,36 @@ import {
   shouldMonitorBlockedPanes,
 } from '../../features/rate-limit-wait/rate-limit-monitor.js';
 import type { RateLimitStatus } from '../../features/rate-limit-wait/types.js';
+import type { StatuslineStdin } from '../../hud/types.js';
 
 // Mock the usage-api module
 vi.mock('../../hud/usage-api.js', () => ({
   getUsage: vi.fn(),
 }));
 
+vi.mock('../../hud/stdin.js', () => ({
+  readStdinCache: vi.fn(),
+}));
+
 import { getUsage } from '../../hud/usage-api.js';
+import { readStdinCache } from '../../hud/stdin.js';
 
 describe('rate-limit-monitor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(readStdinCache).mockReturnValue(null);
   });
 
   describe('checkRateLimitStatus', () => {
+    it('passes the cached Claude Code version to the usage API', async () => {
+      vi.mocked(readStdinCache).mockReturnValue({ version: '2.1.232' } as StatuslineStdin);
+      vi.mocked(getUsage).mockResolvedValue({ rateLimits: null, error: 'no_credentials' });
+
+      await checkRateLimitStatus();
+
+      expect(getUsage).toHaveBeenCalledWith({ clientVersion: '2.1.232' });
+    });
+
     it('should return null when getUsage returns null rateLimits', async () => {
       vi.mocked(getUsage).mockResolvedValue({ rateLimits: null, error: 'no_credentials' });
 

--- a/src/features/rate-limit-wait/daemon.ts
+++ b/src/features/rate-limit-wait/daemon.ts
@@ -64,6 +64,9 @@ const SECURE_FILE_MODE = 0o600;
 const DAEMON_ENV_ALLOWLIST = [
   // Core system paths
   'PATH', 'HOME', 'USERPROFILE',
+  // OMC state/profile context (non-secret paths and session identifiers)
+  'OMC_STATE_DIR', 'CLAUDE_CONFIG_DIR',
+  'CLAUDE_SESSION_ID', 'CLAUDECODE_SESSION_ID',
   // User identification
   'USER', 'USERNAME', 'LOGNAME',
   // Locale settings

--- a/src/features/rate-limit-wait/daemon.ts
+++ b/src/features/rate-limit-wait/daemon.ts
@@ -64,9 +64,8 @@ const SECURE_FILE_MODE = 0o600;
 const DAEMON_ENV_ALLOWLIST = [
   // Core system paths
   'PATH', 'HOME', 'USERPROFILE',
-  // OMC state/profile context (non-secret paths and session identifiers)
+  // OMC state/profile context (non-secret paths)
   'OMC_STATE_DIR', 'CLAUDE_CONFIG_DIR',
-  'CLAUDE_SESSION_ID', 'CLAUDECODE_SESSION_ID',
   // User identification
   'USER', 'USERNAME', 'LOGNAME',
   // Locale settings

--- a/src/features/rate-limit-wait/rate-limit-monitor.ts
+++ b/src/features/rate-limit-wait/rate-limit-monitor.ts
@@ -6,10 +6,24 @@
  */
 
 import { getUsage } from '../../hud/usage-api.js';
+import { readStdinCache } from '../../hud/stdin.js';
 import type { RateLimitStatus } from './types.js';
 
 /** Threshold percentage for considering rate limited */
 const RATE_LIMIT_THRESHOLD = 100;
+
+/**
+ * Last Claude Code version OMC observed on the statusline, from its own stdin
+ * cache. An observed value, not a guess; undefined when the cache is missing or
+ * unreadable, and the usage request then sends no User-Agent.
+ */
+function readCachedClientVersion(): string | undefined {
+  try {
+    return readStdinCache()?.version;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Check current rate limit status using the OAuth API
@@ -18,7 +32,11 @@ const RATE_LIMIT_THRESHOLD = 100;
  */
 export async function checkRateLimitStatus(): Promise<RateLimitStatus | null> {
   try {
-    const result = await getUsage();
+    // This monitor has no statusline payload of its own, but the usage endpoint
+    // throttles requests whose User-Agent does not name a Claude Code version
+    // (see buildUserAgent in usage-api.ts). Reuse the version the HUD last
+    // observed on stdin and cached; undefined when OMC has never seen one.
+    const result = await getUsage({ clientVersion: readCachedClientVersion() });
 
     if (!result.rateLimits) {
       // No OAuth credentials or API unavailable

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -359,7 +359,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
     // Stdin owns fresher five-hour/seven-day values, while getUsage() may provide
     // Sonnet/Opus weekly, monthly, extra, stale, and error metadata.
     const stdinRateLimits = getRateLimitsFromStdin(stdin);
-    const usageResult = config.elements.rateLimits === false ? null : await getUsage();
+    const usageResult =
+      config.elements.rateLimits === false
+        ? null
+        : await getUsage({ clientVersion: stdin.version });
     const rateLimitsResult =
       config.elements.rateLimits === false
         ? null

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -120,12 +120,11 @@ export function readStdinCache(): StatuslineStdin | null {
     return tryRead(scopedPath);
   }
 
-  // Env-less reader: prefer the most recent valid session-scoped cache as a
-  // best-effort surface of "the active session's HUD". Fall back to the
-  // legacy flat cache only when no session cache can be read. This keeps a
-  // stale legacy snapshot from hiding the versioned cache used by a current
-  // detached session.
-  return readMostRecentSessionCache(root) ?? tryRead(legacyPath);
+  // Env-less reader: compare the legacy and session-scoped caches by mtime and
+  // return the newest valid entry. This lets a current session cache outrank a
+  // stale legacy snapshot without allowing an older session cache to hide a
+  // newer flat cache written by a statusline process without session context.
+  return readMostRecentCache(root, legacyPath);
 }
 
 /** Parse only object-shaped cache entries; malformed values are not cache hits. */
@@ -136,8 +135,8 @@ function parseCachedStdin(raw: string): StatuslineStdin | null {
 }
 
 /**
- * Scan `state/sessions/{id}/hud-stdin-cache.json` and return the contents
- * of the most recently modified valid one. Only used when no session id is
+ * Scan the legacy and session-scoped cache paths and return the contents of
+ * the most recently modified valid one. Only used when no session id is
  * available in the environment (e.g. a tmux-hosted `omc hud --watch` reader
  * that did not inherit `CLAUDE_SESSION_ID`). Malformed newest entries are
  * skipped so they do not hide an older valid cache.
@@ -146,7 +145,7 @@ function parseCachedStdin(raw: string): StatuslineStdin | null {
  * `getSessionStateDir`) so this fallback honors `OMC_STATE_DIR` and any
  * other centralized-state configuration.
  */
-function readMostRecentSessionCache(root: string): StatuslineStdin | null {
+function readMostRecentCache(root: string, legacyPath: string): StatuslineStdin | null {
   let sessionIds: string[];
   try {
     sessionIds = listSessionIds(root);
@@ -154,6 +153,12 @@ function readMostRecentSessionCache(root: string): StatuslineStdin | null {
     return null;
   }
   const candidates: Array<{ path: string; mtimeMs: number }> = [];
+  try {
+    const st = statSync(legacyPath);
+    if (st.isFile()) candidates.push({ path: legacyPath, mtimeMs: st.mtimeMs });
+  } catch {
+    // The legacy cache is optional.
+  }
   for (const sid of sessionIds) {
     let candidate: string;
     try {

--- a/src/hud/stdin.ts
+++ b/src/hud/stdin.ts
@@ -95,9 +95,9 @@ export function writeStdinCache(stdin: StatuslineStdin): void {
  * path is authoritative. Otherwise — e.g. `omc hud --watch` running as a
  * detached CLI/tmux process that never inherited the parent's session
  * env — we still need a way to surface the active session's cache; we
- * fall back first to the legacy flat path, and then to the most recently
- * updated `state/sessions/{id}/hud-stdin-cache.json` so the watch pane
- * does not stay stuck on an empty/starting view.
+ * prefer the most recently updated valid `state/sessions/{id}/hud-stdin-cache.json`
+ * and then fall back to the legacy flat path so the watch pane does not stay
+ * stuck on an empty/starting view.
  *
  * Returns null if no cache exists or it is unreadable.
  */
@@ -107,32 +107,40 @@ export function readStdinCache(): StatuslineStdin | null {
   const tryRead = (p: string): StatuslineStdin | null => {
     try {
       if (!existsSync(p)) return null;
-      return JSON.parse(readFileSync(p, 'utf-8')) as StatuslineStdin;
+      return parseCachedStdin(readFileSync(p, 'utf-8'));
     } catch {
       return null;
     }
   };
 
-  const scoped = tryRead(scopedPath);
-  if (scoped) return scoped;
-
   // If the scoped path already *is* the legacy flat path (no session id
   // was available), there's no further lookup to try.
   const legacyPath = resolveOmcPath('state/hud-stdin-cache.json', root);
   if (scopedPath !== legacyPath) {
-    return null;
+    return tryRead(scopedPath);
   }
 
-  // Env-less reader: pick the most recent session-scoped cache as a
-  // best-effort surface of "the active session's HUD".
-  return readMostRecentSessionCache(root);
+  // Env-less reader: prefer the most recent valid session-scoped cache as a
+  // best-effort surface of "the active session's HUD". Fall back to the
+  // legacy flat cache only when no session cache can be read. This keeps a
+  // stale legacy snapshot from hiding the versioned cache used by a current
+  // detached session.
+  return readMostRecentSessionCache(root) ?? tryRead(legacyPath);
+}
+
+/** Parse only object-shaped cache entries; malformed values are not cache hits. */
+function parseCachedStdin(raw: string): StatuslineStdin | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return parsed as StatuslineStdin;
 }
 
 /**
  * Scan `state/sessions/{id}/hud-stdin-cache.json` and return the contents
- * of the most recently modified one. Only used as a fallback when no
- * session id is available in the environment (e.g. a tmux-hosted
- * `omc hud --watch` reader that did not inherit `CLAUDE_SESSION_ID`).
+ * of the most recently modified valid one. Only used when no session id is
+ * available in the environment (e.g. a tmux-hosted `omc hud --watch` reader
+ * that did not inherit `CLAUDE_SESSION_ID`). Malformed newest entries are
+ * skipped so they do not hide an older valid cache.
  *
  * Uses the same OMC-root helpers as the writers (`listSessionIds` /
  * `getSessionStateDir`) so this fallback honors `OMC_STATE_DIR` and any
@@ -145,8 +153,7 @@ function readMostRecentSessionCache(root: string): StatuslineStdin | null {
   } catch {
     return null;
   }
-  let bestPath: string | null = null;
-  let bestMtime = -Infinity;
+  const candidates: Array<{ path: string; mtimeMs: number }> = [];
   for (const sid of sessionIds) {
     let candidate: string;
     try {
@@ -157,20 +164,21 @@ function readMostRecentSessionCache(root: string): StatuslineStdin | null {
     try {
       const st = statSync(candidate);
       if (!st.isFile()) continue;
-      if (st.mtimeMs > bestMtime) {
-        bestMtime = st.mtimeMs;
-        bestPath = candidate;
-      }
+      candidates.push({ path: candidate, mtimeMs: st.mtimeMs });
     } catch {
       // Skip unreadable entries
     }
   }
-  if (!bestPath) return null;
-  try {
-    return JSON.parse(readFileSync(bestPath, 'utf-8')) as StatuslineStdin;
-  } catch {
-    return null;
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path));
+  for (const candidate of candidates) {
+    try {
+      const parsed = parseCachedStdin(readFileSync(candidate.path, 'utf-8'));
+      if (parsed) return parsed;
+    } catch {
+      // A corrupt newest cache must not hide an older valid session cache.
+    }
   }
+  return null;
 }
 
 // ============================================================================

--- a/src/hud/types.ts
+++ b/src/hud/types.ts
@@ -49,6 +49,13 @@ export interface StatuslineStdin {
   /** Transcript path for parsing conversation history */
   transcript_path?: string;
 
+  /**
+   * Claude Code version, e.g. "2.1.232". Claude Code puts this in every
+   * statusline payload; it is the version the session is actually running, and
+   * it is what the usage API's User-Agent must name (see buildUserAgent).
+   */
+  version?: string;
+
   /** Current working directory */
   cwd?: string;
 

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -72,6 +72,8 @@ interface UsageCache {
   rateLimitedUntil?: number;
   /** Timestamp of the last successful API fetch (drives stale data cutoff) */
   lastSuccessAt?: number;
+  /** User-Agent identity that received a rate-limit response (Anthropic only) */
+  rateLimitIdentity?: string;
 }
 
 interface OAuthCredentials {
@@ -400,6 +402,8 @@ interface WriteCacheOptions {
   rateLimitedUntil?: number;
   errorReason?: UsageErrorReason;
   lastSuccessAt?: number;
+  /** User-Agent identity associated with an Anthropic rate-limit response */
+  rateLimitIdentity?: string;
 }
 
 /**
@@ -424,6 +428,7 @@ function writeCache(opts: WriteCacheOptions): void {
       rateLimitedCount: opts.rateLimitedCount && opts.rateLimitedCount > 0 ? opts.rateLimitedCount : undefined,
       rateLimitedUntil: opts.rateLimitedUntil,
       lastSuccessAt: opts.lastSuccessAt,
+      rateLimitIdentity: opts.rateLimitIdentity,
     };
 
     writeFileSync(cachePath, JSON.stringify(cache, null, 2));
@@ -463,8 +468,14 @@ function getTransientNetworkBackoffMs(pollIntervalMs: number): number {
   return Math.max(CACHE_TTL_TRANSIENT_NETWORK_MS, sanitizePollIntervalMs(pollIntervalMs));
 }
 
-function isCacheValid(cache: UsageCache, pollIntervalMs: number): boolean {
+function isCacheValid(cache: UsageCache, pollIntervalMs: number, rateLimitIdentity?: string): boolean {
   if (cache.rateLimited) {
+    if (
+      cache.source === 'anthropic' &&
+      (cache.rateLimitIdentity ?? 'anonymous') !== (rateLimitIdentity ?? 'anonymous')
+    ) {
+      return false;
+    }
     if (cache.rateLimitedUntil != null) {
       return Date.now() < cache.rateLimitedUntil;
     }
@@ -517,6 +528,7 @@ function createRateLimitedCacheEntry(
   pollIntervalMs: number,
   previousCount: number,
   lastSuccessAt?: number,
+  rateLimitIdentity?: string,
 ): UsageCache {
   const timestamp = Date.now();
   const rateLimitedCount = previousCount + 1;
@@ -531,6 +543,7 @@ function createRateLimitedCacheEntry(
     rateLimitedCount,
     rateLimitedUntil: timestamp + getRateLimitedBackoffMs(pollIntervalMs, rateLimitedCount),
     lastSuccessAt,
+    rateLimitIdentity,
   };
 }
 
@@ -1762,13 +1775,21 @@ async function fetchAndCacheUsage<T>(opts: {
   parseFn: (data: T) => RateLimits | null;
   cache: UsageCache | null;
   pollIntervalMs: number;
+  rateLimitIdentity?: string;
 }): Promise<UsageResult> {
-  const { source, fetchFn, parseFn, cache, pollIntervalMs } = opts;
+  const { source, fetchFn, parseFn, cache, pollIntervalMs, rateLimitIdentity } = opts;
   const result = await fetchFn();
 
   if (result.rateLimited) {
     const prevLastSuccess = cache?.lastSuccessAt;
-    const rateLimitedCache = createRateLimitedCacheEntry(source, cache?.data || null, pollIntervalMs, cache?.rateLimitedCount || 0, prevLastSuccess);
+    const rateLimitedCache = createRateLimitedCacheEntry(
+      source,
+      cache?.data || null,
+      pollIntervalMs,
+      cache?.rateLimitedCount || 0,
+      prevLastSuccess,
+      rateLimitIdentity,
+    );
     writeCache({
       data: rateLimitedCache.data,
       error: rateLimitedCache.error,
@@ -1778,6 +1799,7 @@ async function fetchAndCacheUsage<T>(opts: {
       rateLimitedUntil: rateLimitedCache.rateLimitedUntil,
       errorReason: 'rate_limited',
       lastSuccessAt: rateLimitedCache.lastSuccessAt,
+      rateLimitIdentity: rateLimitedCache.rateLimitIdentity,
     });
     if (rateLimitedCache.data) {
       if (prevLastSuccess && Date.now() - prevLastSuccess > MAX_STALE_DATA_MS) {
@@ -1845,19 +1867,30 @@ export async function getUsage(opts?: { clientVersion?: string }): Promise<Usage
   const currentSource: UsageSource =
     isMinimax ? 'minimax' : isKimi ? 'kimi' : isZai && authToken ? 'zai' : 'anthropic';
   const pollIntervalMs = getUsagePollIntervalMs();
+  const rateLimitIdentity = currentSource === 'anthropic'
+    ? buildUserAgent(opts?.clientVersion) ?? 'anonymous'
+    : undefined;
 
   // Migrate legacy single-file cache to provider-specific file (one-shot, best-effort)
   migrateLegacyCache(currentSource);
 
   const initialCache = readCache(currentSource);
-  if (initialCache && isCacheValid(initialCache, pollIntervalMs) && initialCache.source === currentSource) {
+  if (
+    initialCache &&
+    isCacheValid(initialCache, pollIntervalMs, rateLimitIdentity) &&
+    initialCache.source === currentSource
+  ) {
     return getCachedUsageResult(initialCache);
   }
 
   try {
     return await withFileLock(lockPathFor(getCachePath(currentSource)), async () => {
       const cache = readCache(currentSource);
-      if (cache && isCacheValid(cache, pollIntervalMs) && cache.source === currentSource) {
+      if (
+        cache &&
+        isCacheValid(cache, pollIntervalMs, rateLimitIdentity) &&
+        cache.source === currentSource
+      ) {
         return getCachedUsageResult(cache);
       }
 
@@ -1933,6 +1966,7 @@ export async function getUsage(opts?: { clientVersion?: string }): Promise<Usage
           }),
           cache,
           pollIntervalMs,
+          rateLimitIdentity,
         });
       }
 

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -758,9 +758,43 @@ interface FetchResult<T> {
 }
 
 /**
+ * Build the User-Agent for the OAuth usage request.
+ *
+ * The endpoint buckets its rate limit by User-Agent, and a request that does not
+ * name a Claude Code *version* lands in a bucket that allows roughly one request
+ * per hour. Measured against api.anthropic.com with a single OAuth token,
+ * requests seconds apart, recording status and `retry-after` only:
+ *
+ *   User-Agent           | HTTP | retry-after
+ *   ---------------------|------|--------------------------------------------
+ *   (header omitted)     | 429  | 348s
+ *   claude-code          | 429  | 349s / 348s - same absolute deadline
+ *   claude-code/2.1.232  | 403  | none - the endpoint's real answer
+ *   claude-code/9.9.9    | 403  | none - the endpoint's real answer
+ *
+ * Node sends no User-Agent of its own, so this call has been landing in the
+ * throttled bucket and only the first request of each hour ever reached the API.
+ *
+ * The version is never invented. It comes from the Claude Code statusline
+ * payload's `version` field. When we do not have one we send no header at all:
+ * the bare product token was measured to share the throttled bucket, so it would
+ * buy nothing while looking like a fix, and a made-up version would put a false
+ * claim on the wire. The pattern is anchored because the value arrives as JSON
+ * and an unanchored match would let stray characters into an outgoing header.
+ */
+export function buildUserAgent(clientVersion?: string): string | undefined {
+  if (typeof clientVersion !== 'string') return undefined;
+  const version = clientVersion.trim();
+  return /^\d+\.\d+\.\d+[A-Za-z0-9.+-]*$/.test(version)
+    ? `claude-code/${version}`
+    : undefined;
+}
+
+/**
  * Fetch usage from Anthropic API
  */
-function fetchUsageFromApi(accessToken: string): Promise<FetchResult<UsageApiResponse>> {
+function fetchUsageFromApi(accessToken: string, clientVersion?: string): Promise<FetchResult<UsageApiResponse>> {
+  const userAgent = buildUserAgent(clientVersion);
   return new Promise((resolve) => {
     const req = https.request(
       {
@@ -771,6 +805,7 @@ function fetchUsageFromApi(accessToken: string): Promise<FetchResult<UsageApiRes
           'Authorization': `Bearer ${accessToken}`,
           'anthropic-beta': 'oauth-2025-04-20',
           'Content-Type': 'application/json',
+          ...(userAgent ? { 'User-Agent': userAgent } : {}),
         },
         timeout: API_TIMEOUT_MS,
       },
@@ -1783,8 +1818,12 @@ async function fetchAndCacheUsage<T>(opts: {
  *   - 'auth': credentials expired and refresh failed
  *   - 'no_credentials': no OAuth credentials available (expected for API key users)
  *   - 'rate_limited': API returned 429; stale data served if available, with exponential backoff
+ *
+ * @param opts.clientVersion Claude Code version for the usage API User-Agent
+ *   (see buildUserAgent). Optional: callers without a statusline payload omit it
+ *   and the header is left off rather than guessed.
  */
-export async function getUsage(): Promise<UsageResult> {
+export async function getUsage(opts?: { clientVersion?: string }): Promise<UsageResult> {
   const baseUrl = process.env.ANTHROPIC_BASE_URL;
   const authToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const isMinimax = baseUrl != null && isMinimaxHost(baseUrl);
@@ -1887,7 +1926,7 @@ export async function getUsage(): Promise<UsageResult> {
         const rateLimitTier = creds.rateLimitTier;
         return fetchAndCacheUsage({
           source: 'anthropic',
-          fetchFn: () => fetchUsageFromApi(accessToken),
+          fetchFn: () => fetchUsageFromApi(accessToken, opts?.clientVersion),
           parseFn: (data) => parseUsageResponse(data, {
             subscriptionType,
             rateLimitTier,

--- a/src/hud/usage-api.ts
+++ b/src/hud/usage-api.ts
@@ -56,6 +56,12 @@ const TOKEN_REFRESH_URL_PATH = '/v1/oauth/token';
  */
 const DEFAULT_OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
+interface RateLimitBackoff {
+  timestamp: number;
+  rateLimitedCount: number;
+  rateLimitedUntil?: number;
+}
+
 interface UsageCache {
   timestamp: number;
   data: RateLimits | null;
@@ -74,6 +80,8 @@ interface UsageCache {
   lastSuccessAt?: number;
   /** User-Agent identity that received a rate-limit response (Anthropic only) */
   rateLimitIdentity?: string;
+  /** Active Anthropic rate-limit backoffs keyed by User-Agent identity */
+  rateLimitBackoffs?: Record<string, RateLimitBackoff>;
 }
 
 interface OAuthCredentials {
@@ -404,6 +412,8 @@ interface WriteCacheOptions {
   lastSuccessAt?: number;
   /** User-Agent identity associated with an Anthropic rate-limit response */
   rateLimitIdentity?: string;
+  /** Active Anthropic rate-limit backoffs keyed by User-Agent identity */
+  rateLimitBackoffs?: Record<string, RateLimitBackoff>;
 }
 
 /**
@@ -429,6 +439,7 @@ function writeCache(opts: WriteCacheOptions): void {
       rateLimitedUntil: opts.rateLimitedUntil,
       lastSuccessAt: opts.lastSuccessAt,
       rateLimitIdentity: opts.rateLimitIdentity,
+      rateLimitBackoffs: opts.rateLimitBackoffs,
     };
 
     writeFileSync(cachePath, JSON.stringify(cache, null, 2));
@@ -468,14 +479,67 @@ function getTransientNetworkBackoffMs(pollIntervalMs: number): number {
   return Math.max(CACHE_TTL_TRANSIENT_NETWORK_MS, sanitizePollIntervalMs(pollIntervalMs));
 }
 
+function getRateLimitBackoff(
+  cache: UsageCache | null | undefined,
+  rateLimitIdentity?: string,
+): RateLimitBackoff | null {
+  const identity = rateLimitIdentity ?? 'anonymous';
+  const stored = cache?.rateLimitBackoffs?.[identity];
+  if (stored) return stored;
+
+  // Interpret caches written before per-identity backoffs existed as anonymous
+  // entries, preserving their protection without letting them suppress a
+  // versioned request.
+  if (
+    cache?.rateLimited &&
+    (cache.rateLimitIdentity ?? 'anonymous') === identity
+  ) {
+    return {
+      timestamp: cache.timestamp,
+      rateLimitedCount: cache.rateLimitedCount || 1,
+      rateLimitedUntil: cache.rateLimitedUntil,
+    };
+  }
+
+  return null;
+}
+
+function getRateLimitBackoffs(cache: UsageCache | null | undefined): Record<string, RateLimitBackoff> {
+  const backoffs = { ...(cache?.rateLimitBackoffs ?? {}) };
+  if (cache?.rateLimited) {
+    const identity = cache.rateLimitIdentity ?? 'anonymous';
+    backoffs[identity] ??= {
+      timestamp: cache.timestamp,
+      rateLimitedCount: cache.rateLimitedCount || 1,
+      rateLimitedUntil: cache.rateLimitedUntil,
+    };
+  }
+  return backoffs;
+}
+
+function clearRateLimitBackoff(
+  cache: UsageCache | null | undefined,
+  rateLimitIdentity?: string,
+): Record<string, RateLimitBackoff> | undefined {
+  const backoffs = getRateLimitBackoffs(cache);
+  delete backoffs[rateLimitIdentity ?? 'anonymous'];
+  return Object.keys(backoffs).length > 0 ? backoffs : undefined;
+}
+
 function isCacheValid(cache: UsageCache, pollIntervalMs: number, rateLimitIdentity?: string): boolean {
-  if (cache.rateLimited) {
-    if (
-      cache.source === 'anthropic' &&
-      (cache.rateLimitIdentity ?? 'anonymous') !== (rateLimitIdentity ?? 'anonymous')
-    ) {
-      return false;
+  if (cache.source === 'anthropic') {
+    const backoff = getRateLimitBackoff(cache, rateLimitIdentity);
+    if (backoff) {
+      if (backoff.rateLimitedUntil != null) {
+        return Date.now() < backoff.rateLimitedUntil;
+      }
+      return Date.now() - backoff.timestamp < getRateLimitedBackoffMs(
+        pollIntervalMs,
+        backoff.rateLimitedCount,
+      );
     }
+    if (cache.rateLimited) return false;
+  } else if (cache.rateLimited) {
     if (cache.rateLimitedUntil != null) {
       return Date.now() < cache.rateLimitedUntil;
     }
@@ -503,7 +567,14 @@ function hasUsableStaleData(cache: UsageCache | null | undefined): cache is Usag
   return true;
 }
 
-function getCachedUsageResult(cache: UsageCache): UsageResult {
+function getCachedUsageResult(cache: UsageCache, rateLimitIdentity?: string): UsageResult {
+  if (cache.source === 'anthropic' && getRateLimitBackoff(cache, rateLimitIdentity)) {
+    if (!hasUsableStaleData(cache) && cache.data) {
+      return { rateLimits: null, error: 'rate_limited' };
+    }
+    return { rateLimits: cache.data, error: 'rate_limited', stale: cache.data ? true : undefined };
+  }
+
   if (cache.rateLimited) {
     if (!hasUsableStaleData(cache) && cache.data) {
       return { rateLimits: null, error: 'rate_limited' };
@@ -529,9 +600,11 @@ function createRateLimitedCacheEntry(
   previousCount: number,
   lastSuccessAt?: number,
   rateLimitIdentity?: string,
+  previousBackoffs?: Record<string, RateLimitBackoff>,
 ): UsageCache {
   const timestamp = Date.now();
   const rateLimitedCount = previousCount + 1;
+  const identity = rateLimitIdentity ?? 'anonymous';
 
   return {
     timestamp,
@@ -544,6 +617,18 @@ function createRateLimitedCacheEntry(
     rateLimitedUntil: timestamp + getRateLimitedBackoffMs(pollIntervalMs, rateLimitedCount),
     lastSuccessAt,
     rateLimitIdentity,
+    ...(source === 'anthropic'
+      ? {
+        rateLimitBackoffs: {
+          ...(previousBackoffs ?? {}),
+          [identity]: {
+            timestamp,
+            rateLimitedCount,
+            rateLimitedUntil: timestamp + getRateLimitedBackoffMs(pollIntervalMs, rateLimitedCount),
+          },
+        },
+      }
+      : {}),
   };
 }
 
@@ -798,6 +883,7 @@ interface FetchResult<T> {
 export function buildUserAgent(clientVersion?: string): string | undefined {
   if (typeof clientVersion !== 'string') return undefined;
   const version = clientVersion.trim();
+  if (version.length > 128) return undefined;
   return /^\d+\.\d+\.\d+[A-Za-z0-9.+-]*$/.test(version)
     ? `claude-code/${version}`
     : undefined;
@@ -1782,13 +1868,20 @@ async function fetchAndCacheUsage<T>(opts: {
 
   if (result.rateLimited) {
     const prevLastSuccess = cache?.lastSuccessAt;
+    const previousBackoffs = source === 'anthropic' ? getRateLimitBackoffs(cache) : undefined;
+    const previousBackoff = source === 'anthropic'
+      ? getRateLimitBackoff(cache, rateLimitIdentity)
+      : null;
     const rateLimitedCache = createRateLimitedCacheEntry(
       source,
       cache?.data || null,
       pollIntervalMs,
-      cache?.rateLimitedCount || 0,
+      source === 'anthropic'
+        ? previousBackoff?.rateLimitedCount || 0
+        : cache?.rateLimitedCount || 0,
       prevLastSuccess,
       rateLimitIdentity,
+      previousBackoffs,
     );
     writeCache({
       data: rateLimitedCache.data,
@@ -1800,6 +1893,7 @@ async function fetchAndCacheUsage<T>(opts: {
       errorReason: 'rate_limited',
       lastSuccessAt: rateLimitedCache.lastSuccessAt,
       rateLimitIdentity: rateLimitedCache.rateLimitIdentity,
+      rateLimitBackoffs: rateLimitedCache.rateLimitBackoffs,
     });
     if (rateLimitedCache.data) {
       if (prevLastSuccess && Date.now() - prevLastSuccess > MAX_STALE_DATA_MS) {
@@ -1818,6 +1912,7 @@ async function fetchAndCacheUsage<T>(opts: {
       source,
       errorReason: 'network',
       lastSuccessAt: cache?.lastSuccessAt,
+      rateLimitBackoffs: source === 'anthropic' ? getRateLimitBackoffs(cache) : undefined,
     });
     if (fallbackData) {
       return { rateLimits: fallbackData, error: 'network', stale: true };
@@ -1826,7 +1921,15 @@ async function fetchAndCacheUsage<T>(opts: {
   }
 
   const usage = parseFn(result.data);
-  writeCache({ data: usage, error: !usage, source, lastSuccessAt: Date.now() });
+  writeCache({
+    data: usage,
+    error: !usage,
+    source,
+    lastSuccessAt: Date.now(),
+    rateLimitBackoffs: source === 'anthropic'
+      ? clearRateLimitBackoff(cache, rateLimitIdentity)
+      : undefined,
+  });
   return { rateLimits: usage };
 }
 
@@ -1880,7 +1983,7 @@ export async function getUsage(opts?: { clientVersion?: string }): Promise<Usage
     isCacheValid(initialCache, pollIntervalMs, rateLimitIdentity) &&
     initialCache.source === currentSource
   ) {
-    return getCachedUsageResult(initialCache);
+    return getCachedUsageResult(initialCache, rateLimitIdentity);
   }
 
   try {
@@ -1891,7 +1994,7 @@ export async function getUsage(opts?: { clientVersion?: string }): Promise<Usage
         isCacheValid(cache, pollIntervalMs, rateLimitIdentity) &&
         cache.source === currentSource
       ) {
-        return getCachedUsageResult(cache);
+        return getCachedUsageResult(cache, rateLimitIdentity);
       }
 
       // MiniMax path (must precede z.ai and OAuth checks)


### PR DESCRIPTION
## The problem

The HUD polls `api.anthropic.com/api/oauth/usage` for rate-limit data. That endpoint buckets its rate limit by `User-Agent`, and Node sends no `User-Agent` unless you set one. Unidentified clients get roughly one request an hour.

So the first poll of the hour answers and the rest return 429. `getUsage()` falls back to the statusline payload, which carries only the 5h and weekly windows. Anything that exists only in the API response cannot reach the line: `sn:`, `op:`, the per-model weekly buckets from `limits[]`, extra usage, monthly. Nothing looks broken, because the two numbers most people read are the two that survive.

Seven of the ten OMC usage caches on this machine are in that state right now: `errorReason: "rate_limited"`, `rateLimited: true`, consecutive-429 counts of 3 to 8, backoff pinned at its 300s ceiling, `lastSuccessAt: null`. None of the seven has ever completed a usage fetch.

## The fix

Send `User-Agent: claude-code/<version>`, taking the version from the statusline payload's `version` field. `StatuslineStdin` gains the field, `getUsage()` takes an optional `clientVersion`, and `fetchUsageFromApi` sends the header.

`rate-limit-monitor` has no statusline payload of its own and it is the caller that polls in a loop, so it reuses the version the HUD last observed and cached.

Only the Anthropic path changes. `fetchUsageFromApi` is hard-coded to `api.anthropic.com`; the z.ai, MiniMax and Kimi fetchers are untouched, and the new `getUsage` parameter is optional, so every existing call site still compiles and behaves as before.

## What the header claims

It says the request comes from Claude Code at a given version, and it does. Claude Code spawns the statusline program, hands it the payload the version is read from, and the request reads that session's own usage with that session's own OAuth token. The version is never invented: when the payload does not carry one, no header is sent.

A suffixed form such as `claude-code/2.1.232 (oh-my-claudecode)` would name the plugin too. I did not measure it, so I did not ship it. If you prefer that shape it needs its own A/B first, because a variant that lands back in the throttled bucket fails silently.

## Evidence

One OAuth token, requests seconds apart, recording status and `retry-after` only:

| User-Agent | HTTP | retry-after |
| --- | --- | --- |
| *(header omitted)* | 429 | 348s |
| `claude-code` | 429 | 349s, then 348s |
| `claude-code/2.1.232` | 403 | none |
| `claude-code/9.9.9` | 403 | none |

The 403 is that token's own scope error, with a fresh `request_id` each time, so it is a real per-request answer rather than a throttle. The 429 body is `rate_limit_error`.

Two things follow, and both shape the code.

**The version is the part that matters.** A made-up version (`9.9.9`) gets through, so the endpoint keys on the shape rather than the value.

**A version-less product token buys nothing.** Bare `claude-code` and no header at all share one window: their absolute deadlines (`now + retry-after`) landed within two seconds of each other across interleaved requests. So when no version is available this sends no header. A bare token would look like a fix and change nothing, and a fabricated version would put a false claim on the wire.

The version pattern is anchored (`^\d+\.\d+\.\d+[A-Za-z0-9.+-]*$`). The value arrives as JSON, and an unanchored prefix match would let `\r\n` or a stray token into an outgoing header.

One limit, stated plainly: no credential I can read carries the `user:profile` scope, which is what the 403 above is, so I never saw a 200. This PR shows a throttle being lifted. It does not show what the endpoint returns once it is, and it does not prove any particular bucket will render.

## What is not here

Parsing `limits[]` into per-model weekly buckets landed in #3577 for issue #3576. It already handles the absent array, a non-array value, malformed entries, a missing or blank `display_name`, a missing or `NaN` percent, and duplicate display names, and it leaves old-shape responses untouched. I went looking for cases to add and found none, so this PR leaves it alone.

## Tests

`src/__tests__/hud/usage-api-user-agent.test.ts`, 8 tests. The integration cases drive the file-credential path rather than the Keychain one, so they behave the same on macOS and on Linux CI.

Each was checked against the mutation that should make it fail. Counts are measured, not estimated:

| Mutation | Tests that went red |
| --- | --- |
| Drop the `User-Agent` header from the request | 1 |
| Interpolate the version unconditionally | 5 |
| Unanchor the version pattern | 1, the header-injection case |
| Send a bare `claude-code` when no version is known | 2 |
| Send a bare `claude-code` for an unusable version string | 3 |

Nothing had to be relaxed or deleted to make room for the header. No existing test pins the header set: `headers).toEqual` and `Object.keys(...headers)` appear nowhere in test code, and every header assertion in `usage-api.test.ts` reads a single key. The new tests assert the three existing headers are still exactly what they were.

## Gates

macOS arm64, Node 22.23.2. CI runs Node 20, so treat these as indicative and CI as authoritative.

| Gate | Base `e76c9e5d` | With this change |
| --- | --- | --- |
| `npx tsc --noEmit` | rc 0 | rc 0 |
| `npm run lint` | rc 0, 0 errors, 31 warnings | rc 0, 0 errors, 31 warnings |
| `npm run build` | not run | rc 0 |
| `npm run plugin:shipping:verify` | not run | rc 0 |
| `scripts/ci/check-multirepo-paths.mjs` | not run | rc 0 |
| `scripts/ci/check-no-committed-build-artifacts.mjs` | not applicable | rc 0 |
| `npm run test:run` | rc 1, 82 files / 702 tests failed of 13,219 | rc 1, 85 files / 686 tests failed of 13,244 |

`npm run test:run` does not pass at the base commit on macOS either, before this branch exists. The failures are dominated by timeouts under 16-way parallelism, `/proc/<pid>/stat` reads that only exist on Linux, and `/var` against `/private/var` path comparisons. CI runs `ubuntu-latest`.

Eight files failed here and not on base. Run alone against a fresh clone of `e76c9e5d`, three fail there identically, including `npm-package-bin-surface` with the same `runtime import escapes package root` error. The other five pass when run alone on this branch. Four files went the other way, failing on base and not here. None of the twelve imports anything this PR touches.

Full-suite counts are not stable run to run on this machine, so they are weak evidence either way. The scoped run is the one that means something. Twenty-one test files import `hud/usage-api`, `hud/elements/limits` or `features/rate-limit-wait`. Run alone on both trees:

| | Test files | Tests | Result |
| --- | --- | --- | --- |
| Base `e76c9e5d` | 20 | 386 | all pass |
| With this change | 21 | 394 | all pass |

The extra file is the new one and the extra 8 tests are its cases. `hud/types.ts` changes too, and 22 more test files import it, but the change is one new optional field and cannot alter runtime behaviour.
