### PR TITLE
fix(deps): make better-sqlite3 Node 26 capable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   test-windows:
     name: Test (Windows path suite)
     if: github.event_name != 'push' || github.ref_type != 'tag'
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
@@ -78,9 +78,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # better-sqlite3 12.10+ ships Windows prebuilds from Node 22 onward.
-          # The hosted VS 2025 image cannot build this native module from source.
-          node-version: '22'
+          # better-sqlite3 12.10+ no longer ships a Node 20 Windows prebuild.
+          # Pin the runner with the supported VS 2022 toolchain so Node 20 users
+          # keep a tested source-build path instead of hiding the gap with Node 22.
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -121,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2022]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.os == 'windows-latest' && '22' || '20' }}
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -228,7 +229,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -237,7 +238,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.os == 'windows-latest' && '22' || '20' }}
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,31 @@ jobs:
           src/installer/__tests__/claude-md-transaction.test.ts
           src/team/__tests__/cli-detection.windows.integration.test.ts
 
+  better-sqlite3-node26:
+    name: better-sqlite3 Node 26 (${{ matrix.os }})
+    if: github.event_name != 'push' || github.ref_type != 'tag'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-2022]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '26'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Smoke-test native SQLite on Node 26
+        run: node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); db.prepare('select 1 as ok').get(); db.close();"
+
   test-precompact-restore:
     name: PreCompact restore (${{ matrix.os }})
     if: github.event_name != 'push' || github.ref_type != 'tag'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # better-sqlite3 12.10+ ships Windows prebuilds from Node 22 onward.
+          # The hosted VS 2025 image cannot build this native module from source.
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -128,7 +130,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.os == 'windows-latest' && '22' || '20' }}
           cache: 'npm'
 
       - name: Install dependencies
@@ -235,7 +237,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.os == 'windows-latest' && '22' || '20' }}
           cache: 'npm'
 
       - name: Install dependencies

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "27afffd964a101b186360b29255e6a1570f1a776",
-    "sourceSha256": "ec1a11cfd4de131d4416cb987025dc4ff0a2bcdae7f9b9e9117e6a05648cb172",
+    "head": "5880c3d4a9fc6ff37dac81ec789445f56ec9b9a9",
+    "sourceSha256": "66d51a74027f60af0e3614fb44285c22a05fbb55b53913aaa6e935f3baf394bc",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "27afffd964a101b186360b29255e6a1570f1a776",
-  "sourceSha256": "ec1a11cfd4de131d4416cb987025dc4ff0a2bcdae7f9b9e9117e6a05648cb172",
+  "head": "5880c3d4a9fc6ff37dac81ec789445f56ec9b9a9",
+  "sourceSha256": "66d51a74027f60af0e3614fb44285c22a05fbb55b53913aaa6e935f3baf394bc",
   "counts": {
     "public": {
       "skills": 32,
@@ -76089,5 +76089,5 @@
     }
   },
   "inventorySha256": "8a3bdb8b5fdc3f63c386a31b44a1ed5085ec24aab4e022cb2fef0c4e692cd502",
-  "manifestSha256": "d1971ac7a98a6034767e9b224991c4dc6fb40999b70d94787ed3b768dd4ea4ed"
+  "manifestSha256": "297663948f7a9fe17c163f800d45019c6359e8cc39527ce5a2e911fbff537cf3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "dcb6b57efc2b5f09e26edbc46669a29d24c4909f",
-    "sourceSha256": "c10eee2b9631d395ea005b5cbeb410479dd977bd00dedf7792293cf4a179ef79",
+    "head": "33fb4d9441b1fb7a620ca8d6fa1f7f94540822b0",
+    "sourceSha256": "27fd77817aeb62a7a053e46fa48e37eb85d7cdf0a2af0870f7287c0ce5e0765f",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "dcb6b57efc2b5f09e26edbc46669a29d24c4909f",
-  "sourceSha256": "c10eee2b9631d395ea005b5cbeb410479dd977bd00dedf7792293cf4a179ef79",
+  "head": "33fb4d9441b1fb7a620ca8d6fa1f7f94540822b0",
+  "sourceSha256": "27fd77817aeb62a7a053e46fa48e37eb85d7cdf0a2af0870f7287c0ce5e0765f",
   "counts": {
     "public": {
       "skills": 32,
@@ -25,11 +25,11 @@
     "internal": {
       "hookFiles": 295,
       "featureFiles": 68,
-      "toolFiles": 59,
+      "toolFiles": 60,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1307,
-      "total": 1328
+      "srcFiles": 1308,
+      "total": 1329
     },
     "generated": {
       "distFiles": 4955,
@@ -76350,12 +76350,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6831,
-      "edgeCount": 7137,
-      "importEdgeCount": 5853,
+      "nodeCount": 6832,
+      "edgeCount": 7182,
+      "importEdgeCount": 5898,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "d96a7f74a44ab3169d060859801cbfb3d06bd72e29cc7dca3bd8b9cdb6aef4e4",
-  "manifestSha256": "bde46af7d19cca2665feacaa75251b10109834b772187415a201a0880da6adc3"
+  "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
+  "manifestSha256": "2ce1b253635639171a6149ae5a3971dce2d401425614224a7b843ac6bf00f87c"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "5880c3d4a9fc6ff37dac81ec789445f56ec9b9a9",
-    "sourceSha256": "66d51a74027f60af0e3614fb44285c22a05fbb55b53913aaa6e935f3baf394bc",
+    "head": "a3db489ac8fcd2aa68404f7bdfa02bcfb3776847",
+    "sourceSha256": "521afafc3343bf777f846c0928e5d40570c8cd845fdc23cdc9d0b3da129af269",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "5880c3d4a9fc6ff37dac81ec789445f56ec9b9a9",
-  "sourceSha256": "66d51a74027f60af0e3614fb44285c22a05fbb55b53913aaa6e935f3baf394bc",
+  "head": "a3db489ac8fcd2aa68404f7bdfa02bcfb3776847",
+  "sourceSha256": "521afafc3343bf777f846c0928e5d40570c8cd845fdc23cdc9d0b3da129af269",
   "counts": {
     "public": {
       "skills": 32,
@@ -26,10 +26,10 @@
       "hookFiles": 295,
       "featureFiles": 68,
       "toolFiles": 59,
-      "libFiles": 36,
+      "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1306,
-      "total": 1327
+      "srcFiles": 1307,
+      "total": 1328
     },
     "generated": {
       "distFiles": 4955,
@@ -579,6 +579,7 @@
       "src/lib/__tests__/worktree-cleanup-safety.test.ts",
       "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
       "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts",
+      "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
       "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
       "src/lib/__tests__/worktree-paths.test.ts",
       "src/lib/atomic-write.ts",
@@ -38049,6 +38050,11 @@
         "path": "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts"
@@ -64066,6 +64072,31 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -76082,12 +76113,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6830,
-      "edgeCount": 7131,
-      "importEdgeCount": 5847,
+      "nodeCount": 6831,
+      "edgeCount": 7136,
+      "importEdgeCount": 5852,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "8a3bdb8b5fdc3f63c386a31b44a1ed5085ec24aab4e022cb2fef0c4e692cd502",
-  "manifestSha256": "297663948f7a9fe17c163f800d45019c6359e8cc39527ce5a2e911fbff537cf3"
+  "inventorySha256": "d96a7f74a44ab3169d060859801cbfb3d06bd72e29cc7dca3bd8b9cdb6aef4e4",
+  "manifestSha256": "b9f00095d830e627167b45c8d0e0fc0fa9f263dfdf5fd8ed1f449ca94f2f7c68"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "98bf032fd4b38b275dae9d2fce0702e6cdd2d25c",
-    "sourceSha256": "caa827d77b1886166c2133db77dd8067711f1fc4b95fdcd69156f90fba756e53",
+    "head": "27afffd964a101b186360b29255e6a1570f1a776",
+    "sourceSha256": "ec1a11cfd4de131d4416cb987025dc4ff0a2bcdae7f9b9e9117e6a05648cb172",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "98bf032fd4b38b275dae9d2fce0702e6cdd2d25c",
-  "sourceSha256": "caa827d77b1886166c2133db77dd8067711f1fc4b95fdcd69156f90fba756e53",
+  "head": "27afffd964a101b186360b29255e6a1570f1a776",
+  "sourceSha256": "ec1a11cfd4de131d4416cb987025dc4ff0a2bcdae7f9b9e9117e6a05648cb172",
   "counts": {
     "public": {
       "skills": 32,
@@ -76089,5 +76089,5 @@
     }
   },
   "inventorySha256": "8a3bdb8b5fdc3f63c386a31b44a1ed5085ec24aab4e022cb2fef0c4e692cd502",
-  "manifestSha256": "1eac8e43f2e86014bf9d654380a0de1248b67c0a8088692b331cb34d6116c722"
+  "manifestSha256": "d1971ac7a98a6034767e9b224991c4dc6fb40999b70d94787ed3b768dd4ea4ed"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "985f22945a9773fa7d2d4bb21c32262ed75dbc1d",
-    "sourceSha256": "62fcadf8d68216d6d4ffbe94ff6964101bfeb433af0771e0ba2bd6d13bb68c0c",
+    "head": "dcb6b57efc2b5f09e26edbc46669a29d24c4909f",
+    "sourceSha256": "c10eee2b9631d395ea005b5cbeb410479dd977bd00dedf7792293cf4a179ef79",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "985f22945a9773fa7d2d4bb21c32262ed75dbc1d",
-  "sourceSha256": "62fcadf8d68216d6d4ffbe94ff6964101bfeb433af0771e0ba2bd6d13bb68c0c",
+  "head": "dcb6b57efc2b5f09e26edbc46669a29d24c4909f",
+  "sourceSha256": "c10eee2b9631d395ea005b5cbeb410479dd977bd00dedf7792293cf4a179ef79",
   "counts": {
     "public": {
       "skills": 32,
@@ -75938,6 +75938,11 @@
       },
       {
         "from": "tests/lint/better-sqlite3-lockfloor.test.ts",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/better-sqlite3-lockfloor.test.ts",
         "to": "external:vitest",
         "kind": "imports"
       },
@@ -76114,11 +76119,11 @@
     ],
     "stats": {
       "nodeCount": 6831,
-      "edgeCount": 7136,
-      "importEdgeCount": 5852,
+      "edgeCount": 7137,
+      "importEdgeCount": 5853,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "d96a7f74a44ab3169d060859801cbfb3d06bd72e29cc7dca3bd8b9cdb6aef4e4",
-  "manifestSha256": "a47f2151420a98e7e68fa02da2843b3c47572ee05b785ea25fde0b5157af458e"
+  "manifestSha256": "bde46af7d19cca2665feacaa75251b10109834b772187415a201a0880da6adc3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "a3db489ac8fcd2aa68404f7bdfa02bcfb3776847",
-    "sourceSha256": "521afafc3343bf777f846c0928e5d40570c8cd845fdc23cdc9d0b3da129af269",
+    "head": "985f22945a9773fa7d2d4bb21c32262ed75dbc1d",
+    "sourceSha256": "62fcadf8d68216d6d4ffbe94ff6964101bfeb433af0771e0ba2bd6d13bb68c0c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "a3db489ac8fcd2aa68404f7bdfa02bcfb3776847",
-  "sourceSha256": "521afafc3343bf777f846c0928e5d40570c8cd845fdc23cdc9d0b3da129af269",
+  "head": "985f22945a9773fa7d2d4bb21c32262ed75dbc1d",
+  "sourceSha256": "62fcadf8d68216d6d4ffbe94ff6964101bfeb433af0771e0ba2bd6d13bb68c0c",
   "counts": {
     "public": {
       "skills": 32,
@@ -76120,5 +76120,5 @@
     }
   },
   "inventorySha256": "d96a7f74a44ab3169d060859801cbfb3d06bd72e29cc7dca3bd8b9cdb6aef4e4",
-  "manifestSha256": "b9f00095d830e627167b45c8d0e0fc0fa9f263dfdf5fd8ed1f449ca94f2f7c68"
+  "manifestSha256": "a47f2151420a98e7e68fa02da2843b3c47572ee05b785ea25fde0b5157af458e"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "06fc4a14a3ae62888c1b247584eee744ba435ebd",
-    "sourceSha256": "2ee35f9fcc21e3a720bbe8d3ac73607542b56ba64f8aab7b1bc861cd3476f70b",
+    "head": "98bf032fd4b38b275dae9d2fce0702e6cdd2d25c",
+    "sourceSha256": "caa827d77b1886166c2133db77dd8067711f1fc4b95fdcd69156f90fba756e53",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "06fc4a14a3ae62888c1b247584eee744ba435ebd",
-  "sourceSha256": "2ee35f9fcc21e3a720bbe8d3ac73607542b56ba64f8aab7b1bc861cd3476f70b",
+  "head": "98bf032fd4b38b275dae9d2fce0702e6cdd2d25c",
+  "sourceSha256": "caa827d77b1886166c2133db77dd8067711f1fc4b95fdcd69156f90fba756e53",
   "counts": {
     "public": {
       "skills": 32,
@@ -40349,6 +40349,11 @@
         "path": "tests/integration/workflow-profile-stop-transition.test.ts"
       },
       {
+        "id": "tests/lint/better-sqlite3-lockfloor.test.ts",
+        "kind": "other",
+        "path": "tests/lint/better-sqlite3-lockfloor.test.ts"
+      },
+      {
         "id": "tests/lint/cancel-signal-fixture-ttl.test.ts",
         "kind": "other",
         "path": "tests/lint/cancel-signal-fixture-ttl.test.ts"
@@ -75891,6 +75896,21 @@
         "kind": "imports"
       },
       {
+        "from": "tests/lint/better-sqlite3-lockfloor.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/better-sqlite3-lockfloor.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/better-sqlite3-lockfloor.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/lint/cancel-signal-fixture-ttl.test.ts",
         "to": "external:node:fs",
         "kind": "imports"
@@ -76062,12 +76082,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6829,
-      "edgeCount": 7128,
-      "importEdgeCount": 5844,
+      "nodeCount": 6830,
+      "edgeCount": 7131,
+      "importEdgeCount": 5847,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "126a502711b1cf018cbe88c4a8a08d8b4b6b876e8cea1c890ce1f8563417e9f7",
-  "manifestSha256": "227dca528414e8a30a9afa31fbf6e7f3789354f1ba0db85cfb9654afe2e6eece"
+  "inventorySha256": "8a3bdb8b5fdc3f63c386a31b44a1ed5085ec24aab4e022cb2fef0c4e692cd502",
+  "manifestSha256": "1eac8e43f2e86014bf9d654380a0de1248b67c0a8088692b331cb34d6116c722"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/better-sqlite3": "^7.6.13",
         "ajv": "^8.17.1",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.10.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "jsonc-parser": "^3.3.1",
@@ -2235,9 +2235,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2245,7 +2245,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "vitest": "^4.0.17"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "vitest": "^4.0.17"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/better-sqlite3": "^7.6.13",
     "ajv": "^8.17.1",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.10.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "jsonc-parser": "^3.3.1",

--- a/tests/lint/better-sqlite3-lockfloor.test.ts
+++ b/tests/lint/better-sqlite3-lockfloor.test.ts
@@ -75,6 +75,14 @@ const gte = (version: string, minimum: string): boolean => {
   return vPatch >= mPatch;
 };
 
+/** True when a version satisfies the caret range shape used by this dependency. */
+const satisfiesDeclaredRange = (version: string, range: string): boolean => {
+  const floor = floorOf(range);
+  const [versionMajor] = version.split(".").map(Number);
+  const [floorMajor] = floor.split(".").map(Number);
+  return versionMajor === floorMajor && gte(version, floor);
+};
+
 /** Node majors better-sqlite3 upstream supports within the current semver major (odd majors are upstream-supported non-LTS lines, e.g. 23.x). */
 const SUPPORTED_NODE_MAJORS = [20, 22, 23, 24, 25, 26] as const;
 
@@ -90,8 +98,13 @@ describe("better-sqlite3 lockfile contract (issue #3872)", () => {
     const { deps } = readManifest();
     const locked = readLocked();
     expect(gte(locked.version, NODE_26_CAPABLE_FLOOR)).toBe(true);
-    // Lock resolution must stay inside the declared range shape (same major).
-    expect(locked.version.startsWith(`${floorOf(deps["better-sqlite3"]).split(".")[0]}.`)).toBe(true);
+    // Lock resolution must satisfy the complete declared caret range.
+    expect(satisfiesDeclaredRange(locked.version, deps["better-sqlite3"])).toBe(true);
+  });
+
+  it("rejects a locked version below the declared caret floor", () => {
+    expect(satisfiesDeclaredRange("12.11.1", "^12.12.0")).toBe(false);
+    expect(satisfiesDeclaredRange("13.0.0", "^12.10.0")).toBe(false);
   });
 
   it("locked engines cover every upstream-supported Node major", () => {

--- a/tests/lint/better-sqlite3-lockfloor.test.ts
+++ b/tests/lint/better-sqlite3-lockfloor.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Lockfile contract for better-sqlite3 Node compatibility (issue #3872).
+ *
+ * better-sqlite3 12.6.2 (the previously locked resolution) ships no prebuilt
+ * binary for Node 26 (module ABI 147) and its source fails to compile there
+ * (`v8::PropertyCallbackInfo<v8::Value>` has no member named `This`). Because
+ * the plugin install path installs from the repo tree, the committed
+ * package-lock.json is what plugin users get: a stale pin silently disables
+ * the SQLite-backed job state and prompt persistence on Node 26.
+ *
+ * First Node-26-capable release is 12.10.0 (engines add `26.x`; prebuilds
+ * include node-v147). This contract fails when either surface regresses:
+ *
+ * 1. package.json floor drops below the Node-26-capable minimum
+ *    (fresh lockfile regeneration could re-resolve an incompatible version).
+ * 2. The committed lockfile resolves better-sqlite3 outside the declared
+ *    package.json range, or below the Node-26-capable minimum.
+ * 3. The locked version does not declare support for the Node major this
+ *    check runs on (guards CI matrices against silent engine exclusions).
+ *
+ * Prebuild availability itself is registry-side and deliberately not fetched
+ * here; the engines assertion is the deterministic local proxy — WiseLibs
+ * gates engines and prebuild targets on the same Node-major set.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, it, expect } from "vitest";
+
+const REPO_ROOT = join(import.meta.dirname, "../..");
+
+/** First better-sqlite3 release whose engines include Node 26 and that ships node-v147 prebuilds. */
+const NODE_26_CAPABLE_FLOOR = "12.10.0";
+
+const readJson = (relativePath: string): Record<string, unknown> =>
+  JSON.parse(readFileSync(join(REPO_ROOT, relativePath), "utf8")) as Record<string, unknown>;
+
+const readManifest = (): { deps: Record<string, string>; engines: string } => {
+  const pkg = readJson("package.json") as {
+    dependencies?: Record<string, string>;
+    engines?: Record<string, string>;
+  };
+  return {
+    deps: pkg.dependencies ?? {},
+    engines: pkg.engines?.node ?? "",
+  };
+};
+
+const readLocked = (): { version: string; engines: string } => {
+  const lock = readJson("package-lock.json") as {
+    packages?: Record<string, { version?: string; engines?: Record<string, string> }>;
+  };
+  const entry = lock.packages?.["node_modules/better-sqlite3"];
+  if (!entry?.version) {
+    throw new Error("node_modules/better-sqlite3 missing from package-lock.json packages map");
+  }
+  return { version: entry.version, engines: entry.engines?.node ?? "" };
+};
+
+/** `>=X.Y.Z` lower bound of a caret/caret-equivalent range, e.g. `^12.10.0` -> `12.10.0`. */
+const floorOf = (range: string): string => {
+  const match = /^\^?(\d+)\.(\d+)\.(\d+)/.exec(range);
+  if (!match) {
+    throw new Error(`Unsupported better-sqlite3 range shape: ${range}`);
+  }
+  return match.slice(1).join(".");
+};
+
+/** True when `version` is semver-greater than or equal to `minimum` (major.minor.patch only). */
+const gte = (version: string, minimum: string): boolean => {
+  const [vMaj, vMin, vPatch] = version.split(".").map(Number);
+  const [mMaj, mMin, mPatch] = minimum.split(".").map(Number);
+  if (vMaj !== mMaj) return vMaj > mMaj;
+  if (vMin !== mMin) return vMin > mMin;
+  return vPatch >= mPatch;
+};
+
+/** Node majors better-sqlite3 upstream supports within the current semver major (odd majors are upstream-supported non-LTS lines, e.g. 23.x). */
+const SUPPORTED_NODE_MAJORS = [20, 22, 23, 24, 25, 26] as const;
+
+describe("better-sqlite3 lockfile contract (issue #3872)", () => {
+  it("declares a Node-26-capable floor in package.json", () => {
+    const { deps } = readManifest();
+    const range = deps["better-sqlite3"];
+    if (!range) throw new Error("better-sqlite3 missing from package.json dependencies");
+    expect(gte(floorOf(range), NODE_26_CAPABLE_FLOOR)).toBe(true);
+  });
+
+  it("resolves a Node-26-capable version in the committed lockfile", () => {
+    const { deps } = readManifest();
+    const locked = readLocked();
+    expect(gte(locked.version, NODE_26_CAPABLE_FLOOR)).toBe(true);
+    // Lock resolution must stay inside the declared range shape (same major).
+    expect(locked.version.startsWith(`${floorOf(deps["better-sqlite3"]).split(".")[0]}.`)).toBe(true);
+  });
+
+  it("locked engines cover every upstream-supported Node major", () => {
+    const locked = readLocked();
+    for (const major of SUPPORTED_NODE_MAJORS) {
+      expect(locked.engines).toContain(`${major}.x`);
+    }
+  });
+
+  it("locked engines cover the Node major running this check", () => {
+    const locked = readLocked();
+    const major = process.versions.node.split(".")[0];
+    expect(locked.engines).toContain(`${major}.x`);
+  });
+});

--- a/tests/lint/better-sqlite3-lockfloor.test.ts
+++ b/tests/lint/better-sqlite3-lockfloor.test.ts
@@ -24,10 +24,11 @@
  */
 
 import { readFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { describe, it, expect } from "vitest";
 
-const REPO_ROOT = join(import.meta.dirname, "../..");
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
 /** First better-sqlite3 release whose engines include Node 26 and that ships node-v147 prebuilds. */
 const NODE_26_CAPABLE_FLOOR = "12.10.0";
@@ -118,5 +119,9 @@ describe("better-sqlite3 lockfile contract (issue #3872)", () => {
     const locked = readLocked();
     const major = process.versions.node.split(".")[0];
     expect(locked.engines).toContain(`${major}.x`);
+  });
+
+  it("manifest and lockfile expose the same supported Node majors", () => {
+    expect(readManifest().engines).toBe(readLocked().engines);
   });
 });


### PR DESCRIPTION
## Summary
- raise the better-sqlite3 dependency floor and committed lock resolution to a Node 26-capable release
- add a regression contract covering the manifest floor, lockfile resolution, supported Node majors, and the running Node major
- refresh generated inventory metadata

## Validation
- `npm exec -- vitest run tests/lint/better-sqlite3-lockfloor.test.ts`
- `npm ci --ignore-scripts --dry-run --no-audit --no-fund`
- `git diff --check`

Closes #3872

Recovery note: preserved dedicated worktree and branch were reused at exact current `origin/dev` base including merged PR #3874 (`98bf032fd4b38b275dae9d2fce0702e6cdd2d25c`). Existing unrelated dirty generated artifacts remain untouched and are intentionally excluded from this PR.