### PR TITLE
fix(setup): remove retired skill drift

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -70,7 +70,7 @@ names no longer resolve. Use the replacement in the table below.
 | `ccg`                  | `/oh-my-claudecode:ask` + `/team`        | Run `/ask codex` and `/ask antigravity`, then synthesize      |
 | `omc-teams`            | `/oh-my-claudecode:team` or `omc team`   |                                                               |
 | `setup`                | `/oh-my-claudecode:omc-setup`            |                                                               |
-| `mcp-setup`            | `/oh-my-claudecode:omc-setup`            |                                                               |
+| `mcp-setup`            | Claude Code native MCP configuration     | Use `claude mcp add <name> ...` or the path selected by `CLAUDE_MCP_CONFIG_PATH`. |
 | `omc-reference`        | `/oh-my-claudecode:wiki`                 | Model-routing reference moved into the wiki skill             |
 | `learner`              | `/oh-my-claudecode:remember`             |                                                               |
 | `writer-memory`        | `/oh-my-claudecode:remember`             |                                                               |

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -40387,6 +40387,11 @@
         "path": "tests/lint/inventory-graph-drift.test.ts"
       },
       {
+        "id": "tests/lint/setup-phases-drift.test.ts",
+        "kind": "other",
+        "path": "tests/lint/setup-phases-drift.test.ts"
+      },
+      {
         "id": "tests/lint/skill-parallel-caveats.test.ts",
         "kind": "other",
         "path": "tests/lint/skill-parallel-caveats.test.ts"
@@ -76254,6 +76259,31 @@
         "kind": "imports"
       },
       {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/lint/skill-parallel-caveats.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -76355,6 +76385,7 @@
       }
     ],
     "stats": {
+<<<<<<< HEAD
       "nodeCount": 6832,
       "edgeCount": 7183,
       "importEdgeCount": 5900,
@@ -76363,4 +76394,14 @@
   },
   "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
   "manifestSha256": "c807502026fb6be08424b3d761ab12ab8b71c3fdf712a499f3b6cb6dae4d8b5e"
+=======
+      "nodeCount": 6833,
+      "edgeCount": 7189,
+      "importEdgeCount": 5905,
+      "registerEdgeCount": 53
+    }
+  },
+  "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
+  "manifestSha256": "bb0ecdf94690d3ed227750c40b154be4edff9434c22710dd91dce75e1c04f716"
+>>>>>>> e490136a (fix(setup): remove retired workflow guidance)
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -76403,9 +76403,13 @@
   },
   "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
 <<<<<<< HEAD
+<<<<<<< HEAD
   "manifestSha256": "bb0ecdf94690d3ed227750c40b154be4edff9434c22710dd91dce75e1c04f716"
 >>>>>>> e490136a (fix(setup): remove retired workflow guidance)
 =======
   "manifestSha256": "a79bfcf57ab9fb686f524e3853cf31056b50e124308f2e64e783131dde0262e2"
 >>>>>>> 2b532f65 (fix(setup): align backslash config paths)
+=======
+  "manifestSha256": "3bd70ebdae1fae0b53066f75fa52ba7d0139cc70b800c64e7b5189b4ba55d1d9"
+>>>>>>> d86defee (chore(inventory): refresh setup patch provenance)
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -76402,6 +76402,10 @@
     }
   },
   "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
+<<<<<<< HEAD
   "manifestSha256": "bb0ecdf94690d3ed227750c40b154be4edff9434c22710dd91dce75e1c04f716"
 >>>>>>> e490136a (fix(setup): remove retired workflow guidance)
+=======
+  "manifestSha256": "a79bfcf57ab9fb686f524e3853cf31056b50e124308f2e64e783131dde0262e2"
+>>>>>>> 2b532f65 (fix(setup): align backslash config paths)
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2972c31047acec5181a16d7824879231de479621",
-    "sourceSha256": "056d1324b951cba3d6aca551236bc78e464503cdd03e6063c9c7af4924a95cab",
+    "head": "4d24cf3d9b8e65e9a8aec0925f3e6dac5b55317f",
+    "sourceSha256": "86faf90fb1c4f3ade00ead74d1ac038db67fafb0b69915bbf21b116e1758dd18",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2972c31047acec5181a16d7824879231de479621",
-  "sourceSha256": "056d1324b951cba3d6aca551236bc78e464503cdd03e6063c9c7af4924a95cab",
+  "head": "4d24cf3d9b8e65e9a8aec0925f3e6dac5b55317f",
+  "sourceSha256": "86faf90fb1c4f3ade00ead74d1ac038db67fafb0b69915bbf21b116e1758dd18",
   "counts": {
     "public": {
       "skills": 32,
@@ -76385,31 +76385,12 @@
       }
     ],
     "stats": {
-<<<<<<< HEAD
-      "nodeCount": 6832,
-      "edgeCount": 7183,
-      "importEdgeCount": 5900,
-      "registerEdgeCount": 53
-    }
-  },
-  "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "c807502026fb6be08424b3d761ab12ab8b71c3fdf712a499f3b6cb6dae4d8b5e"
-=======
       "nodeCount": 6833,
-      "edgeCount": 7189,
+      "edgeCount": 7188,
       "importEdgeCount": 5905,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
-<<<<<<< HEAD
-<<<<<<< HEAD
-  "manifestSha256": "bb0ecdf94690d3ed227750c40b154be4edff9434c22710dd91dce75e1c04f716"
->>>>>>> e490136a (fix(setup): remove retired workflow guidance)
-=======
-  "manifestSha256": "a79bfcf57ab9fb686f524e3853cf31056b50e124308f2e64e783131dde0262e2"
->>>>>>> 2b532f65 (fix(setup): align backslash config paths)
-=======
-  "manifestSha256": "3bd70ebdae1fae0b53066f75fa52ba7d0139cc70b800c64e7b5189b4ba55d1d9"
->>>>>>> d86defee (chore(inventory): refresh setup patch provenance)
+  "manifestSha256": "9b7c5a5fe48de3aca786152e4ee98ff6044f3a7902722dd268f3262bdd96b694"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "4d24cf3d9b8e65e9a8aec0925f3e6dac5b55317f",
-    "sourceSha256": "86faf90fb1c4f3ade00ead74d1ac038db67fafb0b69915bbf21b116e1758dd18",
+    "head": "2f4b1ec9ed0bc1233d6f359f229518a9bbfe8e4e",
+    "sourceSha256": "a92d33ca8d0d44e776e886fb07a2af47a6e558efd940e61e44c999840f6c6fb4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "4d24cf3d9b8e65e9a8aec0925f3e6dac5b55317f",
-  "sourceSha256": "86faf90fb1c4f3ade00ead74d1ac038db67fafb0b69915bbf21b116e1758dd18",
+  "head": "2f4b1ec9ed0bc1233d6f359f229518a9bbfe8e4e",
+  "sourceSha256": "a92d33ca8d0d44e776e886fb07a2af47a6e558efd940e61e44c999840f6c6fb4",
   "counts": {
     "public": {
       "skills": 32,
@@ -76392,5 +76392,5 @@
     }
   },
   "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
-  "manifestSha256": "9b7c5a5fe48de3aca786152e4ee98ff6044f3a7902722dd268f3262bdd96b694"
+  "manifestSha256": "a814f4b00a41a0ac1eb2c7ff4cd3c7fa1f629efd0a189fe81de588d71df03aef"
 }

--- a/scripts/lib/config-dir.sh
+++ b/scripts/lib/config-dir.sh
@@ -11,6 +11,11 @@ resolve_claude_config_dir() {
       configured="${configured#\~/}"
       printf '%s/%s\n' "$HOME" "$configured"
       ;;
+    \~\\*)
+      configured="${configured#\~}"
+      configured="${configured#\\}"
+      printf '%s/%s\n' "$HOME" "$configured"
+      ;;
     *)
       printf '%s\n' "$configured"
       ;;

--- a/scripts/lib/config-dir.sh
+++ b/scripts/lib/config-dir.sh
@@ -2,7 +2,11 @@
 
 resolve_claude_config_dir() {
   configured="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-  configured="${configured%/}"
+  configured="${configured#${configured%%[![:space:]]*}}"
+  configured="${configured%${configured##*[![:space:]]}}"
+  if [ "$configured" != "/" ]; then
+    configured="${configured%/}"
+  fi
   case "$configured" in
     \~)
       printf '%s\n' "$HOME"

--- a/scripts/setup-progress.sh
+++ b/scripts/setup-progress.sh
@@ -61,8 +61,16 @@ cmd_resume() {
     return 0
   fi
 
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required to resume setup safely. Existing setup state was not modified." >&2
+    return 1
+  fi
+
   # Check if state is stale (older than 24 hours)
-  TIMESTAMP_RAW=$(jq -r '.timestamp // empty' "$STATE_FILE" 2>/dev/null)
+  if ! TIMESTAMP_RAW=$(jq -r '.timestamp // empty' "$STATE_FILE" 2>/dev/null); then
+    echo "ERROR: Setup state is invalid JSON. Existing setup state was not modified." >&2
+    return 1
+  fi
   if [ -n "$TIMESTAMP_RAW" ]; then
     TIMESTAMP_EPOCH=$(iso_to_epoch "$TIMESTAMP_RAW")
     NOW_EPOCH=$(date +%s)
@@ -78,9 +86,12 @@ cmd_resume() {
     return 0
   fi
 
-  LAST_STEP=$(jq -r ".lastCompletedStep // 0" "$STATE_FILE" 2>/dev/null || echo "0")
-  TIMESTAMP=$(jq -r .timestamp "$STATE_FILE" 2>/dev/null || echo "unknown")
-  CONFIG_TYPE=$(jq -r '.configType // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+  if ! LAST_STEP=$(jq -r ".lastCompletedStep // 0" "$STATE_FILE" 2>/dev/null) \
+    || ! TIMESTAMP=$(jq -r .timestamp "$STATE_FILE" 2>/dev/null) \
+    || ! CONFIG_TYPE=$(jq -r '.configType // "unknown"' "$STATE_FILE" 2>/dev/null); then
+    echo "ERROR: Setup state is invalid JSON. Existing setup state was not modified." >&2
+    return 1
+  fi
   echo "Found previous setup session (Step $LAST_STEP completed at $TIMESTAMP, configType=$CONFIG_TYPE)"
   echo "$LAST_STEP"
 }

--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -128,7 +128,7 @@ ls -la "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/skills/ 2>/dev/null
 `architect.md`, `document-specialist.md`, `explore.md`, `executor.md`, `debugger.md`, `planner.md`, `analyst.md`, `critic.md`, `verifier.md`, `test-engineer.md`, `designer.md`, `writer.md`, `qa-tester.md`, `scientist.md`, `security-reviewer.md`, `code-reviewer.md`, `git-master.md`, `code-simplifier.md`
 
 **Known plugin skill names** (check skills/ for these):
-`ai-slop-cleaner`, `ask`, `autopilot`, `cancel`, `configure-notifications`, `deep-interview`, `deepinit`, `external-context`, `hud`, `skillify`, `learner`, `mcp-setup`, `omc-doctor`, `omc-setup`, `omc-teams`, `plan`, `project-session-manager`, `ralph`, `ralplan`, `release`, `sciomc`, `setup`, `skill`, `team`, `visual-verdict`, `writer-memory`
+`ai-slop-cleaner`, `ask`, `autopilot`, `cancel`, `configure-notifications`, `deep-interview`, `deepinit`, `external-context`, `hud`, `omc-doctor`, `omc-setup`, `plan`, `project-session-manager`, `ralph`, `ralplan`, `release`, `skill`, `team`, `visual-verdict`, `wiki`
 
 **Known plugin command names** (check commands/ for these):
 `deepsearch.md`

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -91,7 +91,7 @@ Do not independently scan plugin cache directories or select a plugin root in th
 bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" <local|global> [overwrite|preserve]
 ```
 
-The script is the sole cache resolver. It accepts only complete plugin roots (canonical `docs/CLAUDE.md`, coordinator artifact, and `omc-reference` skill), chooses a strict full-SemVer cache version, verifies the compiled-source handshake, and fails closed on coordinator protocol or status disagreement. Do not download configuration or mutate `CLAUDE.md` outside that coordinator.
+The script is the sole cache resolver. It accepts only complete plugin roots (canonical `docs/CLAUDE.md`, coordinator artifact, and `wiki` skill), chooses a strict full-SemVer cache version, verifies the compiled-source handshake, and fails closed on coordinator protocol or status disagreement. Do not download configuration or mutate `CLAUDE.md` outside that coordinator.
 
 ## Pre-Setup Check: Already Configured?
 
@@ -108,8 +108,15 @@ esac
 CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
-  SETUP_COMPLETED=$(jq -r '.setupCompleted // empty' "$CONFIG_FILE" 2>/dev/null)
-  SETUP_VERSION=$(jq -r '.setupVersion // empty' "$CONFIG_FILE" 2>/dev/null)
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required to inspect existing OMC setup state. Existing config was not modified."
+    exit 1
+  fi
+  if ! SETUP_COMPLETED=$(jq -r '.setupCompleted // empty' "$CONFIG_FILE" 2>/dev/null) \
+    || ! SETUP_VERSION=$(jq -r '.setupVersion // empty' "$CONFIG_FILE" 2>/dev/null); then
+    echo "ERROR: Existing OMC config is invalid JSON. Existing config was not modified."
+    exit 1
+  fi
 
   if [ -n "$SETUP_COMPLETED" ] && [ "$SETUP_COMPLETED" != "null" ]; then
     echo "OMC setup was already completed on: $SETUP_COMPLETED"

--- a/skills/omc-setup/SKILL.md
+++ b/skills/omc-setup/SKILL.md
@@ -49,7 +49,7 @@ MODES:
     - Configures CLAUDE.md (local or global)
     - Sets up HUD statusline
     - Checks for updates
-    - Offers MCP server configuration
+    - Clears retired setup values (5.0.0 removed defaultExecutionMode) and points MCP registration at Claude Code's native config
     - Configures team mode defaults (agent count, type, model)
     - If already configured, offers quick update option
 
@@ -99,7 +99,13 @@ The script is the sole cache resolver. It accepts only complete plugin roots (ca
 
 ```bash
 # Check if setup was already completed
-CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 
 if [ -f "$CONFIG_FILE" ]; then
   SETUP_COMPLETED=$(jq -r '.setupCompleted // empty' "$CONFIG_FILE" 2>/dev/null)
@@ -122,15 +128,16 @@ Use AskUserQuestion to prompt:
 **Question:** "OMC is already configured. What would you like to do?"
 
 **Options:**
-1. **Update CLAUDE.md only** - Install the active plugin's canonical CLAUDE.md without re-running full setup
+1. **Update CLAUDE.md and clear retired setup values** - Install the active plugin's canonical CLAUDE.md and run Phase 2 Step 2.4 without re-running the full setup
 2. **Run full setup again** - Go through the complete setup wizard
 3. **Cancel** - Exit without changes
 
-**If user chooses "Update CLAUDE.md only":**
+**If user chooses "Update CLAUDE.md and clear retired setup values":**
 - Detect if local (.claude/CLAUDE.md) or global (~/.claude/CLAUDE.md) config exists
 - If local exists, run: `bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" local`
 - If only global exists, run: `bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-claude-md.sh" global`
-- Skip all other steps
+- Run Phase 2 Step 2.4 to clear the retired `defaultExecutionMode` key
+- Skip all other steps after the cleanup
 - Report success and exit
 
 **If user chooses "Run full setup again":**
@@ -189,7 +196,9 @@ Execute phases sequentially. For each phase, read the corresponding file and fol
 
 After installing oh-my-claudecode updates (via npm or plugin update):
 
-**Automatic**: Just run `/oh-my-claudecode:omc-setup` - it will detect you've already configured and offer a quick "Update CLAUDE.md only" option that skips the full wizard.
+**Automatic**: Just run `/oh-my-claudecode:omc-setup` - it will detect you've already configured and offer a quick "Update CLAUDE.md and clear retired setup values" option that skips the rest of the wizard.
+
+The quick update path must still perform Phase 2 Step 2.4 so upgrades remove the retired `defaultExecutionMode` value; it must not write any replacement execution-mode setting.
 
 **Manual options**:
 - `/oh-my-claudecode:omc-setup --local` to update project config only

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -68,7 +68,7 @@ Notify user if a newer version is available:
 node -e "
 const p=require('path'),f=require('fs'),h=require('os').homedir();
 const raw=process.env.CLAUDE_CONFIG_DIR?.trim();
-const d=raw==null||raw===''? p.join(h,'.claude'):raw==='~'?h:raw.startsWith('~/')||raw.startsWith('~\\')?p.join(h,raw.slice(2)):raw;
+const d=raw==null||raw===''? p.join(h,'.claude'):raw==='~'?h:raw.startsWith('~/')||raw.startsWith('~\\\\')?p.join(h,raw.slice(2)):raw;
 let v='';
 // Try cache directory first
 const b=p.join(d,'plugins','cache','omc','oh-my-claudecode');

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -7,7 +7,14 @@
 Capture the original progress marker once when Phase 2 starts. A resumed run that enters at Step 2.4 must not repeat the completed Steps 2.5/2.6 prompts or overwrite a higher progress marker:
 
 ```bash
-RESUME_LAST_COMPLETED_STEP=$(jq -r '.lastCompletedStep // 0' ".omc/state/setup-state.json" 2>/dev/null || echo "0")
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required to resume setup safely. Existing setup state was not modified."
+  exit 1
+fi
+if ! RESUME_LAST_COMPLETED_STEP=$(jq -r '.lastCompletedStep // 0' ".omc/state/setup-state.json" 2>/dev/null); then
+  echo "ERROR: Setup state is invalid JSON. Existing setup state was not modified."
+  exit 1
+fi
 if [ "$RESUME_LAST_COMPLETED_STEP" -ge 4 ] 2>/dev/null; then
   RESUMED_PHASE_TWO_BOUNDARY="true"
 else
@@ -252,10 +259,12 @@ fi
 # USER_CHOICE is "builtin", "beads", or "beads-rust" based on user selection
 TEMP_FILE=$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")
 trap 'rm -f "$TEMP_FILE"' EXIT
-if printf '%s\n' "$EXISTING" | jq --arg tool "USER_CHOICE" '. + {taskTool: $tool, taskToolConfig: {injectInstructions: true, useMcp: false}}' > "$TEMP_FILE"; then
-  mv "$TEMP_FILE" "$CONFIG_FILE"
+if printf '%s\n' "$EXISTING" | jq --arg tool "USER_CHOICE" '. + {taskTool: $tool, taskToolConfig: {injectInstructions: true, useMcp: false}}' > "$TEMP_FILE" \
+  && mv "$TEMP_FILE" "$CONFIG_FILE"; then
+  :
 else
   echo "ERROR: Failed to update $CONFIG_FILE. Existing config was not modified."
+  rm -f "$TEMP_FILE"
   exit 1
 fi
 trap - EXIT

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -1,6 +1,19 @@
 # Phase 2: Environment Configuration
 
-**Skip condition**: If resuming and `lastCompletedStep >= 4`, skip this entire phase.
+**Skip condition**: If resuming and `lastCompletedStep >= 4`, skip Steps 2.0–2.3 and begin at Step 2.4 so retired setup values are always cleared before the phase exits.
+
+## Resume Boundary
+
+Capture the original progress marker once when Phase 2 starts. A resumed run that enters at Step 2.4 must not repeat the completed Steps 2.5/2.6 prompts or overwrite a higher progress marker:
+
+```bash
+RESUME_LAST_COMPLETED_STEP=$(jq -r '.lastCompletedStep // 0' ".omc/state/setup-state.json" 2>/dev/null || echo "0")
+if [ "$RESUME_LAST_COMPLETED_STEP" -ge 4 ] 2>/dev/null; then
+  RESUMED_PHASE_TWO_BOUNDARY="true"
+else
+  RESUMED_PHASE_TWO_BOUNDARY="false"
+fi
+```
 
 ## Step 2.0: Check Ralph Ruby Dependency
 
@@ -54,7 +67,8 @@ Notify user if a newer version is available:
 # Detect installed version (cross-platform)
 node -e "
 const p=require('path'),f=require('fs'),h=require('os').homedir();
-const d=process.env.CLAUDE_CONFIG_DIR||p.join(h,'.claude');
+const raw=process.env.CLAUDE_CONFIG_DIR?.trim();
+const d=raw==null||raw===''? p.join(h,'.claude'):raw==='~'?h:raw.startsWith('~/')||raw.startsWith('~\\')?p.join(h,raw.slice(2)):raw;
 let v='';
 // Try cache directory first
 const b=p.join(d,'plugins','cache','omc','oh-my-claudecode');
@@ -84,6 +98,42 @@ elif [ -n "$LATEST_VERSION" ]; then
   echo "Latest version available: v$LATEST_VERSION"
 fi
 ```
+
+## Step 2.4: Clear Retired Setup Values
+
+The `ultrawork` workflow was removed in 5.0.0 and the `defaultExecutionMode` config key is no longer read by any runtime surface. Upgrades from 4.x may still carry a dead persisted value in `.omc-config.json`. Clear it so the config matches the current contract:
+
+```bash
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
+
+if [ -f "$CONFIG_FILE" ] && grep -q '"defaultExecutionMode"' "$CONFIG_FILE" 2>/dev/null; then
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "WARNING: jq is required to clear the retired defaultExecutionMode key from $CONFIG_FILE."
+    echo "The stale value is harmless (no runtime reads it), but install jq and rerun setup to clean it."
+  else
+    TEMP_FILE=$(mktemp "${CONFIG_FILE}.tmp.XXXXXX")
+    trap 'rm -f "$TEMP_FILE"' EXIT
+    if jq 'del(.defaultExecutionMode)' "$CONFIG_FILE" > "$TEMP_FILE" \
+      && mv "$TEMP_FILE" "$CONFIG_FILE"; then
+      echo "Cleared retired defaultExecutionMode key (ultrawork was removed in 5.0.0)"
+    else
+      echo "WARNING: Failed to clear retired defaultExecutionMode. Existing config was not modified."
+      rm -f "$TEMP_FILE"
+    fi
+    trap - EXIT
+  fi
+fi
+```
+
+**Note:** Never write a new `defaultExecutionMode` value. Generic keywords no longer route through a configured execution mode; invoke `/oh-my-claudecode:execute` or `/oh-my-claudecode:team` directly instead.
+
+**Resume-only boundary:** If `RESUMED_PHASE_TWO_BOUNDARY` is `true`, stop Phase 2 after this cleanup. Do not execute Steps 2.5 or 2.6, do not prompt for task-tool or team settings again, and do not save a new progress value. Return to the setup orchestrator with the original `RESUME_LAST_COMPLETED_STEP` unchanged.
 
 ## Step 2.5: Install OMC CLI Tool
 
@@ -178,7 +228,13 @@ If beads or beads-rust is detected, use AskUserQuestion:
 Store the preference:
 
 ```bash
-CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -212,5 +268,9 @@ echo "Task tool set to: USER_CHOICE"
 
 ```bash
 CONFIG_TYPE=$(jq -r '.configType // "unknown"' ".omc/state/setup-state.json" 2>/dev/null || echo "unknown")
-bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" save 4 "$CONFIG_TYPE"
+if [ "${RESUMED_PHASE_TWO_BOUNDARY:-false}" != "true" ]; then
+  bash "${OMC_SETUP_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/setup-progress.sh" save 4 "$CONFIG_TYPE"
+else
+  echo "Resumed Phase 2: preserving lastCompletedStep=$RESUME_LAST_COMPLETED_STEP"
+fi
 ```

--- a/skills/omc-setup/phases/03-integrations.md
+++ b/skills/omc-setup/phases/03-integrations.md
@@ -87,10 +87,12 @@ fi
 if [ -f "$SETTINGS_FILE" ]; then
   TEMP_FILE=$(mktemp "${SETTINGS_FILE}.tmp.XXXXXX")
   trap 'rm -f "$TEMP_FILE"' EXIT
-  if jq '.env = (.env // {} | . + {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"})' "$SETTINGS_FILE" > "$TEMP_FILE"; then
-    mv "$TEMP_FILE" "$SETTINGS_FILE"
+  if jq '.env = (.env // {} | . + {"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"})' "$SETTINGS_FILE" > "$TEMP_FILE" \
+    && mv "$TEMP_FILE" "$SETTINGS_FILE"; then
+    :
   else
     echo "ERROR: Failed to update $SETTINGS_FILE. Existing settings were not modified."
+    rm -f "$TEMP_FILE"
     exit 1
   fi
   trap - EXIT
@@ -142,10 +144,12 @@ fi
 # Skip this if user chose "Auto" (that's the default)
 TEMP_FILE=$(mktemp "${SETTINGS_FILE}.tmp.XXXXXX")
 trap 'rm -f "$TEMP_FILE"' EXIT
-if jq --arg mode "TEAMMATE_MODE" '. + {teammateMode: $mode}' "$SETTINGS_FILE" > "$TEMP_FILE"; then
-  mv "$TEMP_FILE" "$SETTINGS_FILE"
+if jq --arg mode "TEAMMATE_MODE" '. + {teammateMode: $mode}' "$SETTINGS_FILE" > "$TEMP_FILE" \
+  && mv "$TEMP_FILE" "$SETTINGS_FILE"; then
+  :
 else
   echo "ERROR: Failed to update $SETTINGS_FILE. Existing settings were not modified."
+  rm -f "$TEMP_FILE"
   exit 1
 fi
 trap - EXIT
@@ -201,10 +205,12 @@ trap 'rm -f "$TEMP_FILE"' EXIT
 if printf '%s\n' "$EXISTING" | jq \
   --argjson maxAgents MAX_AGENTS \
   --arg agentType "AGENT_TYPE" \
-  '. + {team: {ops: {maxAgents: $maxAgents, defaultAgentType: $agentType, monitorIntervalMs: 30000, shutdownTimeoutMs: 15000}}}' > "$TEMP_FILE"; then
-  mv "$TEMP_FILE" "$CONFIG_FILE"
+  '. + {team: {ops: {maxAgents: $maxAgents, defaultAgentType: $agentType, monitorIntervalMs: 30000, shutdownTimeoutMs: 15000}}}' > "$TEMP_FILE" \
+  && mv "$TEMP_FILE" "$CONFIG_FILE"; then
+  :
 else
   echo "ERROR: Failed to update $CONFIG_FILE. Existing config was not modified."
+  rm -f "$TEMP_FILE"
   exit 1
 fi
 trap - EXIT

--- a/skills/omc-setup/phases/03-integrations.md
+++ b/skills/omc-setup/phases/03-integrations.md
@@ -5,21 +5,26 @@
 ## Step 3.1: Verify Plugin Installation
 
 ```bash
-grep -q "oh-my-claudecode" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json" && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+grep -q "oh-my-claudecode" "$CONFIG_DIR/settings.json" && echo "Plugin verified" || echo "Plugin NOT found - run: claude /install-plugin oh-my-claudecode"
 ```
 
-## Step 3.2: Offer MCP Server Configuration
+## Step 3.2: MCP Server Configuration (Pointer Only)
 
-MCP servers extend Claude Code with additional tools (web search, GitHub, etc.).
+MCP servers extend Claude Code with additional tools (web search, GitHub, etc.). OMC no longer ships an MCP setup skill; servers are registered through Claude Code's native MCP surfaces.
 
-Use AskUserQuestion: "Would you like to configure MCP servers for enhanced capabilities? (Context7, Exa search, GitHub, etc.)"
+If the user asks about MCP servers, point them at the native registration path:
 
-If yes, invoke the mcp-setup skill:
-```
-/oh-my-claudecode:mcp-setup
-```
+- Claude Code: `claude mcp add <name> ...` (see `claude mcp --help`), or the native MCP config selected by `CLAUDE_MCP_CONFIG_PATH` (by default, the sibling `.claude.json` next to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`)
+- OMC keeps its own bundled MCP server (`bridge/mcp-server.cjs`) registered via `.mcp.json`; it requires no user action
+- Company-context guidance, if used, is documented in `docs/company-context-interface.md`
 
-If no, skip to next step.
+Do **not** try to invoke an MCP setup skill — `mcp-setup` was removed in 5.0.0 and has no replacement skill; the native surfaces above are the whole story.
 
 ## Step 3.3: Configure Agent Teams (Optional)
 
@@ -44,7 +49,13 @@ Use AskUserQuestion:
 First, read the current settings.json:
 
 ```bash
-SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+SETTINGS_FILE="$CONFIG_DIR/settings.json"
 
 if [ -f "$SETTINGS_FILE" ]; then
   echo "Current settings.json found"
@@ -59,7 +70,13 @@ Then use the Read tool to read `${CLAUDE_CONFIG_DIR:-~/.claude}/settings.json` (
 Use jq to safely merge without overwriting existing settings:
 
 ```bash
-SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+SETTINGS_FILE="$CONFIG_DIR/settings.json"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required to update $SETTINGS_FILE safely."
@@ -107,7 +124,13 @@ Use AskUserQuestion:
 If user chooses anything other than "Auto", add `teammateMode` to settings.json:
 
 ```bash
-SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+SETTINGS_FILE="$CONFIG_DIR/settings.json"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required to update $SETTINGS_FILE safely."
@@ -148,10 +171,16 @@ Use AskUserQuestion with multiple questions:
 3. **gemini** - Use Gemini CLI workers by default when installed (enterprise/API-key tier)
 4. **antigravity** - Use Antigravity CLI (`agy`) workers by default when installed; Google's successor to the Gemini CLI (install per the [official instructions](https://antigravity.google))
 
-Store the team configuration in `~/.claude/.omc-config.json`:
+Store the team configuration in the active Claude config directory's `.omc-config.json`:
 
 ```bash
-CONFIG_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-config.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+CONFIG_FILE="$CONFIG_DIR/.omc-config.json"
 mkdir -p "$(dirname "$CONFIG_FILE")"
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -193,7 +222,13 @@ echo "  Model: teammates inherit your session model"
 After all modifications, verify settings.json is valid JSON and contains the expected keys:
 
 ```bash
-SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+SETTINGS_FILE="$CONFIG_DIR/settings.json"
 
 if jq empty "$SETTINGS_FILE" 2>/dev/null; then
   echo "settings.json: valid JSON"

--- a/skills/omc-setup/phases/04-welcome.md
+++ b/skills/omc-setup/phases/04-welcome.md
@@ -86,8 +86,8 @@ Use the replacement instead — see the migration table in docs/MIGRATION.md
 ```
 OMC Setup Complete! (Upgraded from 2.x)
 
-GOOD NEWS: Your existing commands still work!
-- /ralph, /omc-plan, etc. still function
+IMPORTANT: Some legacy 2.x and 3.x commands were retired in 5.0.0 and are
+not aliased. Use the replacement workflows listed in the migration table.
 
 WHAT'S NEW in 3.0:
 You no longer NEED those commands. Everything is automatic now:
@@ -118,7 +118,7 @@ OMC CLI HELPERS (if installed):
 - omc team status - Inspect a running team job
 - Session summaries are written to `.omc/sessions/*.json`
 
-Your workflow won't break - it just got easier!
+Your configuration is preserved; retired commands are not recreated.
 ```
 
 ## Optional Rule Templates

--- a/skills/omc-setup/phases/04-welcome.md
+++ b/skills/omc-setup/phases/04-welcome.md
@@ -5,7 +5,13 @@
 Check if user has existing 2.x configuration:
 
 ```bash
-ls "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/commands/ralph-loop.md 2>/dev/null
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
+ls "$CONFIG_DIR/commands/ralph-loop.md" 2>/dev/null
 ```
 
 If found, this is an upgrade from 2.x. Set `IS_UPGRADE=true`.
@@ -21,28 +27,36 @@ You don't need to learn any commands. I now have intelligent behaviors that acti
 
 WHAT HAPPENS AUTOMATICALLY:
 - Complex tasks -> I parallelize and delegate to specialists
-- "plan this" -> I start a planning interview
-- "don't stop until done" -> I persist until verified complete
-- "stop" or "cancel" -> I intelligently stop current operation
 
 MAGIC KEYWORDS (optional power-user shortcuts):
 Just include these words naturally in your request:
 
 | Keyword | Effect | Example |
 |---------|--------|---------|
+| autopilot | Autonomous execution | "autopilot build me a todo app" |
 | ralph | Persistence mode | "ralph: fix the auth bug" |
-| ralplan | Iterative planning | "ralplan this feature" |
-| plan | Planning interview | "plan the new endpoints" |
-| team | Coordinated agents | "/team 3:executor fix errors" |
+| ralplan | Iterative consensus planning | "ralplan this feature" |
+| deep interview | Requirements interview | "deep interview me before coding" |
+| deslop / anti-slop | Cleanup review | "deslop this module" |
+| deep-analyze | Analysis mode | "deep-analyze the flaky test" |
+| tdd | TDD mode | "tdd the parser" |
+| deepsearch | Codebase search | "deepsearch where config is loaded" |
+| ultrathink | Deep reasoning | "ultrathink this design" |
+| cancelomc | Stop active OMC modes | "cancelomc" |
+
+CANONICAL WORKFLOWS (Tier-0):
+omc-plan -> execute -> omc-review -> verify, invoked as /oh-my-claudecode:omc-plan and /oh-my-claudecode:omc-review.
+/deep-interview and /ralplan are independent planning workflows.
+/research and /team are internal lanes; /autopilot, /autoresearch, /ralph, /ultragoal stay directly invocable.
 
 TEAMS:
 Spawn coordinated agents with shared task lists and real-time messaging:
 - /oh-my-claudecode:team 3:executor "fix all TypeScript errors"
 - /oh-my-claudecode:team 5:debugger "fix build errors in src/"
-Teams use Claude Code's implicit agent team (spawn teammates directly with distinct `name` values; no TeamCreate/TeamDelete in Claude Code 2.1.178+).
+Teams use Claude Code's implicit agent team (spawn teammates directly with distinct `name` values; no TeamCreate/TeamDelete in Claude Code 2.1.178+). Team orchestration is explicit via /team — there is no bare "team" keyword.
 
 MCP SERVERS:
-Run /oh-my-claudecode:mcp-setup to add tools like web search, GitHub, etc.
+Register extra MCP servers (web search, GitHub, etc.) through Claude Code's native MCP config (`claude mcp add ...` or the path selected by `CLAUDE_MCP_CONFIG_PATH`; by default, the sibling `.claude.json` next to `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`). OMC's bundled MCP server is already registered via the plugin's .mcp.json.
 
 HUD STATUSLINE:
 The status bar now shows OMC state. Restart Claude Code to see it.
@@ -56,6 +70,17 @@ OMC CLI HELPERS (if installed):
 That's it! Just use Claude Code normally.
 ```
 
+### Retired in 5.0.0 (all users)
+
+The following commands and keywords were removed in 5.0.0 and are not aliased:
+/ultrawork, /ultraqa, /ultrapilot, /swarm, /pipeline, /merge-readiness,
+/deep-dive, /sciomc, /ccg, /omc-teams, /setup, /mcp-setup, /omc-reference,
+/learner, /writer-memory, /local-build-reminder.
+Use the replacement instead — see the migration table in docs/MIGRATION.md
+(commonly /execute for ultrawork, /verify for ultraqa, /team for omc-teams,
+/omc-setup for setup, and Claude Code's native MCP config for mcp-setup;
+/wiki for omc-reference).
+
 ### For Users Upgrading from 2.x (IS_UPGRADE is true):
 
 ```
@@ -66,17 +91,18 @@ GOOD NEWS: Your existing commands still work!
 
 WHAT'S NEW in 3.0:
 You no longer NEED those commands. Everything is automatic now:
-- Just say "don't stop until done" instead of /ralph
-- Just say "plan this" instead of /omc-plan
-- Just say "stop" instead of /cancel
+- Just say "autopilot build me ..." instead of /autopilot
+- Just say "ralph: <task>" instead of /ralph
+- Just say "cancelomc" instead of /cancel
 
 MAGIC KEYWORDS (power-user shortcuts):
 | Keyword | Same as old... | Example |
 |---------|----------------|---------|
+| autopilot | /autopilot | "autopilot build me a todo app" |
 | ralph | /ralph | "ralph: fix the bug" |
 | ralplan | /ralplan | "ralplan this feature" |
-| omc-plan | /omc-plan | "plan the endpoints" |
-| team | (new!) | "/team 3:executor fix errors" |
+| deep interview | /deep-interview | "deep interview me before coding" |
+| cancelomc | /cancel | "cancelomc" |
 
 TEAMS (NEW!):
 Spawn coordinated agents with shared task lists and real-time messaging:
@@ -171,10 +197,16 @@ Get the current OMC version and mark setup complete:
 ```bash
 # Get current OMC version from CLAUDE.md
 OMC_VERSION=""
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+case "$CONFIG_DIR" in
+  "~") CONFIG_DIR="$HOME" ;;
+  "~/"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~/}" ;;
+  "~\\"*) CONFIG_DIR="$HOME/${CONFIG_DIR#\~\\}" ;;
+esac
 if [ -f ".claude/CLAUDE.md" ]; then
   OMC_VERSION=$(grep -m1 'OMC:VERSION:' .claude/CLAUDE.md 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
-elif [ -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" ]; then
-  OMC_VERSION=$(grep -m1 'OMC:VERSION:' "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
+elif [ -f "$CONFIG_DIR/CLAUDE.md" ]; then
+  OMC_VERSION=$(grep -m1 'OMC:VERSION:' "$CONFIG_DIR/CLAUDE.md" 2>/dev/null | sed -E 's/.*OMC:VERSION:([^ ]+).*/\1/' || true)
 fi
 if [ -z "$OMC_VERSION" ]; then
   OMC_VERSION=$(omc --version 2>/dev/null | head -1 || true)

--- a/src/__tests__/config-dir.test.ts
+++ b/src/__tests__/config-dir.test.ts
@@ -125,6 +125,21 @@ describe('getClaudeConfigDir', () => {
     expect(output.trim()).toBe(join(homeDir, '.claude-alt'));
   });
 
+  it('shared shell helper expands a backslash-tilde-prefixed CLAUDE_CONFIG_DIR', () => {
+    const homeDir = mkdtempSync(join(tmpdir(), 'omc-uninstall-home-'));
+    const output = execFileSync('bash', ['-lc', `. "${join(process.cwd(), 'scripts', 'lib', 'config-dir.sh')}"; resolve_claude_config_dir`], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        CLAUDE_CONFIG_DIR: '~\\.claude-alt',
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(output.trim()).toBe(join(homeDir, '.claude-alt'));
+  });
+
   it('keeps the CJS helper aligned with the TypeScript helper', () => {
     process.env.CLAUDE_CONFIG_DIR = '~/.claude-alt';
     const cjsPath = join(process.cwd(), 'scripts', 'lib', 'config-dir.cjs');

--- a/src/__tests__/doctor-conflicts.test.ts
+++ b/src/__tests__/doctor-conflicts.test.ts
@@ -959,6 +959,15 @@ describe('doctor-conflicts: config known fields (issue #1499)', () => {
     expect(checkConfigIssues().unknownFields).toEqual(['totallyMadeUpKey', 'anotherUnknown']);
     expect(runConflictCheck().hasConflicts).toBe(true);
   });
+
+  it('flags the retired defaultExecutionMode key as unknown (5.0.0 removed its last writer/reader)', () => {
+    writeFileSync(join(TEST_CLAUDE_DIR, '.omc-config.json'), JSON.stringify({
+      silentAutoUpdate: false,
+      defaultExecutionMode: 'ultrawork',
+    }, null, 2));
+
+    expect(checkConfigIssues().unknownFields).toEqual(['defaultExecutionMode']);
+  });
 });
 
 describe('doctor-conflicts: workspace marker check (Wave F.2)', () => {

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -549,7 +549,9 @@ export function checkConfigIssues(): ConflictReport['configIssues'] {
       'configVersion',
       'taskTool',
       'taskToolConfig',
-      'defaultExecutionMode',
+      // 'defaultExecutionMode' intentionally NOT known: ultrawork and the
+      // generic execution-mode routing were removed in 5.0.0 and no runtime
+      // reads this key. A persisted value is stale and should surface here.
       'bashHistory',
       'agentTiers',
       'setupCompleted',

--- a/src/cli/commands/doctor-conflicts.ts
+++ b/src/cli/commands/doctor-conflicts.ts
@@ -346,7 +346,7 @@ export function checkEnvFlags(): ConflictReport['envFlags'] {
   return { disableOmc, skipHooks };
 }
 
-const SETUP_FALLBACK_SKILL_NAMES = new Set(['omc-reference']);
+const SETUP_FALLBACK_SKILL_NAMES = new Set(['omc-reference', 'wiki']);
 
 function parseSemverLikeVersion(version: string): number[] | null {
   if (!/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(version)) {
@@ -461,9 +461,10 @@ function isSupportedSetupFallbackSkill(legacySkillsDir: string, entry: string, b
   }
 
   // scripts/setup-claude-md.sh intentionally syncs the raw bundled
-  // skills/omc-reference/SKILL.md file into ~/.claude/skills/omc-reference/SKILL.md
+  // skills/wiki/SKILL.md file into ~/.claude/skills/wiki/SKILL.md. Keep the
+  // retired omc-reference fallback for already-installed 4.x upgrades.
   // as a Claude CLI fallback. Suppress only that exact, unmodified sync so real
-  // legacy collisions and user-edited omc-reference copies still surface.
+  // legacy collisions and user-edited fallback copies still surface.
   if (entry.toLowerCase() !== baseName) {
     return false;
   }

--- a/tests/lint/setup-phases-drift.test.ts
+++ b/tests/lint/setup-phases-drift.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Setup-phase drift enforcement (issue #3871).
+ *
+ * The shipped `skills/omc-setup/phases/*` instructions previously told the
+ * setup agent to invoke skills removed in 5.0.0 (`mcp-setup`) and to persist
+ * `defaultExecutionMode: "ultrawork"`. That happened because the workflow
+ * registry moved under #3698 consolidation while the setup phase files were
+ * not updated with it.
+ *
+ * This test locks the setup phases to the shipped surface so they cannot
+ * drift again:
+ *  - every `/oh-my-claudecode:<skill>` reference in the setup phases must
+ *    resolve to a skill the plugin actually ships (`.claude-plugin/plugin.json`)
+ *  - no setup phase may reference a name retired in 5.0.0 (the canonical
+ *    retired list in docs/CLAUDE.md, kept byte-identical to CLAUDE.md)
+ *  - no setup phase may instruct writing a retired config value
+ *    (`defaultExecutionMode`), and the config keys the phases touch must be
+ *    current contract keys (doctor's knownFields minus the retired one)
+ *
+ * Rollback boundary: delete tests/lint/setup-phases-drift.test.ts — no
+ * runtime change.
+ */
+
+import { execFileSync } from "child_process";
+import { readFileSync, existsSync, mkdtempSync, rmSync, writeFileSync, chmodSync, readdirSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { describe, it, expect } from "vitest";
+
+const REPO_ROOT = join(import.meta.dirname, "../..");
+const PHASES_DIR = join(REPO_ROOT, "skills", "omc-setup", "phases");
+const PHASE_FILES = [
+  "01-install-claude-md.md",
+  "02-configure.md",
+  "03-integrations.md",
+  "04-welcome.md",
+] as const;
+
+function readPhase(file: string): string {
+  const path = join(PHASES_DIR, file);
+  expect(existsSync(path), `missing setup phase ${file}`).toBe(true);
+  return readFileSync(path, "utf-8");
+}
+
+/** Skills the plugin actually ships, from the shipped manifest. */
+function shippedSkills(): Set<string> {
+  const pluginJson = JSON.parse(
+    readFileSync(join(REPO_ROOT, ".claude-plugin", "plugin.json"), "utf-8"),
+  ) as { skills?: string[] };
+  const entries = pluginJson.skills ?? [];
+  expect(entries.length, "plugin.json must list skills").toBeGreaterThan(0);
+  const names = new Set<string>();
+  for (const dirRef of entries) {
+    const directory = dirRef.replace(/^\.\//, "").replace(/\/$/, "");
+    const directoryName = directory.split("/")[1];
+    if (directoryName) names.add(directoryName);
+    const skillPath = join(REPO_ROOT, directory, "SKILL.md");
+    if (existsSync(skillPath)) {
+      const match = readFileSync(skillPath, "utf-8").match(/^name:\s*([^\n]+)$/m);
+      if (match?.[1]) names.add(match[1].trim());
+    }
+  }
+  return names;
+}
+
+/**
+ * Names retired in 5.0.0, parsed from the canonical retired sentence in
+ * docs/CLAUDE.md (kept identical to the shipped CLAUDE.md by the fable
+ * routing doc contract test, so this cannot drift from shipped docs).
+ */
+function retiredNames(): Set<string> {
+  const doc = readFileSync(join(REPO_ROOT, "docs", "CLAUDE.md"), "utf-8");
+  const match = doc.match(/\*\*Retired in 5\.0\.0 \(removed, not aliased\):\*\* ([^.]+)\./);
+  expect(match, "docs/CLAUDE.md must keep the canonical 5.0.0 retired list").not.toBeNull();
+  return new Set(
+    match![1]
+      .split(",")
+      .map((name) => name.trim().replace(/`/g, ""))
+      .filter(Boolean),
+  );
+}
+
+describe("setup phases drift enforcement (issue #3871)", () => {
+  const skills = shippedSkills();
+  const retired = retiredNames();
+
+  it("knows the shipped and retired sets are non-trivial and disjoint", () => {
+    expect(retired.size).toBeGreaterThanOrEqual(15);
+    expect(retired.has("mcp-setup")).toBe(true);
+    expect(retired.has("ultrawork")).toBe(true);
+    expect(skills.has("mcp-setup")).toBe(false);
+    expect(skills.has("ultrawork")).toBe(false);
+    expect(skills.has("omc-setup")).toBe(true);
+    for (const name of retired) {
+      expect(skills.has(name), `retired ${name} must not be shipped`).toBe(false);
+    }
+  });
+
+  it("every referenced /oh-my-claudecode:<skill> exists in the shipped plugin", () => {
+    for (const file of PHASE_FILES) {
+      const content = readPhase(file);
+      const referenced = [...content.matchAll(/\/oh-my-claudecode:([a-z0-9-]+)/g)].map(
+        (m) => m[1],
+      );
+      for (const name of referenced) {
+        expect(
+          skills.has(name),
+          `${file} references /oh-my-claudecode:${name}, but the plugin does not ship a skill with that name`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("no setup phase references a 5.0.0-retired skill name as an invocation target", () => {
+    for (const file of PHASE_FILES) {
+      const content = readPhase(file);
+      // An invocation-shaped reference is any of:
+      //   /oh-my-claudecode:<name>   <name>: <task>   "invoke the <name> skill"
+      // Plain-prose retirement notices (a dedicated block listing removed
+      // names, or a "removed in 5.0.0" sentence) are allowed — users and the
+      // setup agent must still be told what no longer exists.
+      const stripped = content
+        .replace(/RETIRED IN 5\.0\.0[\s\S]*?(?=\n[A-Z#]|\n```|$)/g, "")
+        .replace(/[^.\n]*removed in 5\.0\.0[^.\n]*\.?/gi, "");
+      for (const name of retired) {
+        const invocationPatterns = [
+          new RegExp(`/oh-my-claudecode:${name}\\b`),
+          new RegExp(`^#{1,6}.*\\b${name}\\b.*(step|skill|invoke)`, "im"),
+          new RegExp(`invoke (?:the )?.{0,20}\\b${name}\\b (?:skill|workflow)`, "i"),
+        ];
+        for (const pattern of invocationPatterns) {
+          expect(
+            pattern.test(stripped),
+            `${file} treats retired '${name}' as an invocable target`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+
+  it("never instructs writing the retired defaultExecutionMode config value", () => {
+    for (const file of PHASE_FILES) {
+      const content = readPhase(file);
+      // Deletion instructions are fine (Step 2.4 clears a stale value);
+      // writes/sets are not.
+      const writePatterns = [
+        /jq[^|]*--arg\s+mode[^|]*defaultExecutionMode/,
+        /defaultExecutionMode:\s*["']?\$\{?USER_CHOICE/,
+        /\. \{defaultExecutionMode/,
+      ];
+      for (const pattern of writePatterns) {
+        expect(
+          pattern.test(content),
+          `${file} instructs writing defaultExecutionMode (removed in 5.0.0)`,
+        ).toBe(false);
+      }
+      // If the key appears at all, it must only be in a del/clear context.
+      for (const line of content.split("\n")) {
+        if (line.includes("defaultExecutionMode") && /[a-z]{2,}\s*["']?defaultExecutionMode/.test(line)) {
+          const isClearing = /del\(|del\s|Clear|clear|retired|Retired|grep -q/.test(line);
+          expect(
+            isClearing,
+            `${file} mentions defaultExecutionMode outside a clearing context: ${line.trim()}`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("executes cleanup for tilde paths and preserves the original on jq or mv failure", () => {
+    const phase = readPhase("02-configure.md");
+    const snippet = phase.match(/## Step 2\.4:[\s\S]*?```bash\n([\s\S]*?)\n```/)?.[1];
+    expect(snippet, "Step 2.4 must keep an executable cleanup snippet").toBeTruthy();
+    const root = mkdtempSync(join(tmpdir(), "setup-drift-cleanup-"));
+    const original = JSON.stringify({ silentAutoUpdate: false, defaultExecutionMode: "ultrawork" }, null, 2) + "\n";
+    try {
+      const config = join(root, ".omc-config.json");
+      writeFileSync(config, original);
+      execFileSync("bash", ["-c", snippet!], { env: { ...process.env, CLAUDE_CONFIG_DIR: root } });
+      const cleaned = JSON.parse(readFileSync(config, "utf8")) as Record<string, unknown>;
+      expect(cleaned).toEqual({ silentAutoUpdate: false });
+
+      const tildeConfigDir = join(root, "nested");
+      const tildeConfig = join(tildeConfigDir, ".omc-config.json");
+      mkdirSync(tildeConfigDir, { recursive: true });
+      writeFileSync(tildeConfig, original);
+      execFileSync("bash", ["-c", snippet!], {
+        env: { ...process.env, HOME: root, CLAUDE_CONFIG_DIR: "~/nested" },
+      });
+      expect(JSON.parse(readFileSync(tildeConfig, "utf8"))).toEqual({ silentAutoUpdate: false });
+      writeFileSync(tildeConfig, original);
+      execFileSync("bash", ["-c", snippet!], {
+        env: { ...process.env, HOME: root, CLAUDE_CONFIG_DIR: "~\\nested" },
+      });
+      expect(JSON.parse(readFileSync(tildeConfig, "utf8"))).toEqual({ silentAutoUpdate: false });
+
+      const malformed = "{ \"defaultExecutionMode\":";
+      writeFileSync(config, malformed);
+      execFileSync("bash", ["-c", snippet!], {
+        env: { ...process.env, CLAUDE_CONFIG_DIR: root },
+        stdio: "ignore",
+      });
+      expect(readFileSync(config, "utf8")).toBe(malformed);
+
+      writeFileSync(config, original);
+      const fakeBin = join(root, "bin");
+      const fakeMv = join(fakeBin, "mv");
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(fakeMv, "#!/bin/sh\nexit 1\n");
+      chmodSync(fakeMv, 0o755);
+      execFileSync("bash", ["-c", snippet!], {
+        env: { ...process.env, CLAUDE_CONFIG_DIR: root, PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+        stdio: "ignore",
+      });
+      expect(readFileSync(config, "utf8")).toBe(original);
+      expect(readdirSync(root).filter((entry) => entry.includes(".tmp.")).length).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("executes the resume boundary without changing the original progress marker", () => {
+    const phase = readPhase("02-configure.md");
+    const snippet = phase.match(/## Resume Boundary[\s\S]*?```bash\n([\s\S]*?)\n```/)?.[1];
+    expect(snippet, "Phase 2 must keep an executable resume-boundary snippet").toBeTruthy();
+    const root = mkdtempSync(join(tmpdir(), "setup-drift-resume-"));
+    try {
+      mkdirSync(join(root, ".omc", "state"), { recursive: true });
+      writeFileSync(join(root, ".omc", "state", "setup-state.json"), JSON.stringify({ lastCompletedStep: 7 }));
+      const resumed = execFileSync("bash", ["-c", `${snippet}\nprintf '%s:%s\\n' "$RESUMED_PHASE_TWO_BOUNDARY" "$RESUME_LAST_COMPLETED_STEP"`], { cwd: root });
+      expect(resumed.toString()).toContain("true:7");
+
+      writeFileSync(join(root, ".omc", "state", "setup-state.json"), JSON.stringify({ lastCompletedStep: 2 }));
+      const fresh = execFileSync("bash", ["-c", `${snippet}\nprintf '%s:%s\\n' "$RESUMED_PHASE_TWO_BOUNDARY" "$RESUME_LAST_COMPLETED_STEP"`], { cwd: root });
+      expect(fresh.toString()).toContain("false:2");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the installed plan and review skill names in the welcome text", () => {
+    const welcome = readPhase("04-welcome.md");
+    expect(welcome).toContain("/oh-my-claudecode:omc-plan");
+    expect(welcome).toContain("/oh-my-claudecode:omc-review");
+    expect(welcome).not.toContain("/oh-my-claudecode:plan");
+    expect(welcome).not.toContain("/oh-my-claudecode:review");
+  });
+
+  it("executes the team config normalizer for a backslash-tilde path", () => {
+    const phase = readPhase("03-integrations.md");
+    const block = phase.match(/Store the team configuration[\s\S]*?```bash\n([\s\S]*?)\n```/)?.[1];
+    expect(block, "team config block must remain executable").toBeTruthy();
+    const preamble = block!.split("\n").slice(0, 8).join("\n");
+    const root = mkdtempSync(join(tmpdir(), "setup-drift-team-path-"));
+    try {
+      const output = execFileSync("bash", ["-c", `${preamble}\nprintf '%s\\n' "$CONFIG_FILE"`], {
+        cwd: root,
+        env: { ...process.env, HOME: root, CLAUDE_CONFIG_DIR: "~\\claude" },
+      });
+      expect(output.toString().trim()).toBe(join(root, "claude", ".omc-config.json"));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- remove setup instructions that write or invoke retired 5.0.0 `ultrawork` / `mcp-setup` surfaces
- clear stale `defaultExecutionMode` values during setup and route MCP guidance to Claude Code native configuration
- flag the retired config key in doctor diagnostics and add setup-phase drift regression coverage

## Recovery evidence
- Reused the preserved dedicated worktree and branch `fix/issue-3871-current-dev-v2` at recovered HEAD `e76c9e5d69ebdf86fd14a2189bcc148567ccb1bc` with all staged changes preserved.
- Refreshed `origin/dev` through merged PR #3874 (`98bf032fd4b38b275dae9d2fce0702e6cdd2d25c`), reconciled the branch onto current `dev`, and retained the issue-owned patch.
- Validation: `npm run test:run -- src/__tests__/doctor-conflicts.test.ts tests/lint/setup-phases-drift.test.ts`; `npx tsc --noEmit`; `npm run lint`; `npm run generate:inventory:verify`.
- No main merge, release, tag, publish, or duplicate owner was created.

Closes #3871