### PR TITLE
fix(state): anchor non-git session state safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ OMC writes runtime state, session data, plans, logs, handoffs, research notes, a
 
 For linked git worktrees, the default `.omc/` directory lives inside that worktree, so deleting the worktree deletes its local OMC state. Set `OMC_STATE_DIR` if you want state to survive worktree deletion, or add a `.omc-workspace` marker when several independent repos should share one parent-level state root. See [OMC state, gitignore, worktree, and workspace contract](docs/REFERENCE.md#omc-state-gitignore-worktree-and-workspace-contract).
 
+Outside a git repository, OMC reuses the nearest safe existing `.omc/` ancestor and otherwise anchors state at `~/.omc/`; it does not create a new state root for every cwd or write state into sensitive directories such as `~/.ssh` or `~/Downloads`. State MCP tools honor an explicit `workingDirectory` while retaining repository-boundary checks for git-backed sessions.
+
 [Full feature list →](docs/REFERENCE.md)
 
 ### Multi-repo workspaces

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -9,11 +9,35 @@ This guide covers all migration paths for oh-my-claudecode. Find your current ve
 - [v4.x → v5.0: Workflow Retirement](#v4x--v50-workflow-retirement)
 - [Unreleased: Team MCP Runtime Deprecation (CLI-Only)](#unreleased-team-mcp-runtime-deprecation-cli-only)
 - [Unreleased: Native Team Worktree Mode (Opt-In)](#unreleased-native-team-worktree-mode-opt-in)
+- [Unreleased: Git-less State Root Recovery](#unreleased-git-less-state-root-recovery)
 - [v3.5.3 → v3.5.5: Test Fixes & Cleanup](#v353--v355-test-fixes--cleanup)
 - [v3.5.2 → v3.5.3: Skill Consolidation](#v352--v353-skill-consolidation)
 - [v2.x → v3.0: Package Rename & Auto-Activation](#v2x--v30-package-rename--auto-activation)
 - [v3.0 → v3.1: Notepad Wisdom & Enhanced Features](#v30--v31-notepad-wisdom--enhanced-features)
 - [v3.x → v4.0: Major Architecture Overhaul](#v3x--v40-major-architecture-overhaul)
+
+---
+
+## Unreleased: Git-less State Root Recovery
+
+### TL;DR
+
+Sessions launched outside a Git repository no longer create a separate `.omc/`
+directory for every cwd. OMC adopts the nearest safe existing state root and
+otherwise uses `~/.omc/`; protected locations such as `~/.ssh`, `~/.claude`,
+and user content directories are never used as anchors.
+
+### Migration and compatibility
+
+- Existing safe non-git `.omc/` roots remain visible through ancestor adoption.
+- Existing state under protected locations is never moved or deleted
+  automatically. Copy only the state you intend to keep into the new safe root.
+- `OMC_STATE_DIR` remains the explicit centralized option. In git-less sessions
+  it uses one fixed `non-git` child rather than hashing each cwd.
+- `workingDirectory` on state tools is honored within the validated context;
+  foreign repositories and failed Git probes are rejected visibly.
+- Session-scoped state remains owned by its `session_id`. No time-based cleanup
+  or cancellation was added.
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -151,9 +151,20 @@ Git handling is intentionally conservative. The repository `.gitignore` keeps `.
 Worktree behavior follows the resolved state root:
 
 - **Default single repo / monorepo**: `getOmcRoot()` uses the git toplevel, so every package below one git root shares `{repo}/.omc/`.
+- **Git-less directories**: OMC reuses the nearest existing safe `.omc/` ancestor so legacy state remains visible. When none exists, all git-less cwd variants anchor at `$HOME/.omc/` instead of creating state in the current directory. Protected home directories such as `~/.ssh`, `~/.claude`, `~/.config`, `~/Downloads`, and `~/Desktop` are never selected as anchors; existing state there is left untouched. This is an anchor change only: session ownership still comes from `session_id`, and no time-based cleanup is performed.
 - **Linked git worktrees**: without `OMC_STATE_DIR`, each linked worktree has its own `{worktree}/.omc/`; removing that worktree removes its local OMC state. Re-run setup from the worktree you are actively using so installed hooks and generated instructions match that checkout.
 - **Persistent state across worktree deletion**: set `OMC_STATE_DIR`; OMC writes to `$OMC_STATE_DIR/{project-id}/`, where the project id is stable across linked worktrees when a remote or primary git dir is available.
 - **Multi-repo workspace**: add `.omc-workspace` to a non-git parent when independent sibling repos should share `{parent}/.omc/`. This is for multi-repo workspaces, not ordinary monorepos.
+
+State MCP tools honor an explicit `workingDirectory`. In a git-less session, the requested existing directory is used for resolution while state storage still follows the safe non-git anchor above; in a git-backed session, repository and linked-worktree boundary checks remain enforced. A path from another repository is rejected rather than silently substituted with the session cwd.
+
+#### Session-scoped state cannot capture another session (#3873)
+
+Mode-state files that carry a `session_id` under `.omc/state/sessions/<id>/` are authoritative only for that session. They cannot attach to, resume, or disarm a different session. Only legacy flat-layout files without a `session_id` can bind to whatever session starts next in that directory.
+
+Do not treat idle time as evidence that a session has ended. OMC performs no time-based cancellation of session-scoped state; cleanup tooling must preserve session-owned files and must not use a time threshold to delete active state.
+
+When migrating to `OMC_STATE_DIR`, remember that setting the variable does not migrate existing contents. Copy or migrate legacy state first, then enable the centralized root; otherwise old plans, notepads, and project memory remain in their original `.omc/` location and are no longer visible.
 
 Plan persistence follows the same rule. Default generated plans under `.omc/plans/` are local operational artifacts and are ignored. If a plan should become durable project documentation, move it to a tracked docs path or configure `planOutput.directory` to a reviewed directory such as `docs/plans`; keep machine-local session state in `.omc/`.
 

--- a/src/__tests__/state-root-resolution.test.ts
+++ b/src/__tests__/state-root-resolution.test.ts
@@ -15,7 +15,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { getOmcRoot, clearWorktreeCache } from '../lib/worktree-paths.js';
+import { getOmcRoot, clearWorktreeCache, validateWorkingDirectory } from '../lib/worktree-paths.js';
 
 const NODE = process.execPath;
 const REPO_ROOT = resolve(join(__dirname, '..', '..'));
@@ -576,5 +576,110 @@ describe('OMC_STATE_DIR state-root resolution (issue #2532)', () => {
     );
     expect(existsSync(centralizedPath)).toBe(true);
     expect(existsSync(defaultPath)).toBe(false);
+  });
+
+  it('anchors git-less directories at one stable home state root', () => {
+    const fakeHome = join(tempDir, 'home');
+    const firstCwd = join(fakeHome, 'workspace', 'first');
+    const secondCwd = join(fakeHome, 'workspace', 'second', 'nested');
+    mkdirSync(firstCwd, { recursive: true });
+    mkdirSync(secondCwd, { recursive: true });
+
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    const previousCwd = process.cwd();
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    try {
+      clearWorktreeCache();
+      const expected = join(fakeHome, '.omc');
+      process.chdir(firstCwd);
+      expect(getOmcRoot()).toBe(expected);
+      process.chdir(secondCwd);
+      expect(getOmcRoot()).toBe(expected);
+      expect(existsSync(join(firstCwd, '.omc'))).toBe(false);
+      expect(existsSync(join(secondCwd, '.omc'))).toBe(false);
+    } finally {
+      process.chdir(previousCwd);
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousUserProfile;
+      clearWorktreeCache();
+    }
+  });
+
+  it('reuses a safe existing git-less state root for legacy visibility', () => {
+    const fakeHome = join(tempDir, 'home');
+    const project = join(fakeHome, 'workspace', 'project');
+    const nestedCwd = join(project, 'deep', 'path');
+    mkdirSync(join(project, '.omc'), { recursive: true });
+    mkdirSync(nestedCwd, { recursive: true });
+
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    const previousCwd = process.cwd();
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    try {
+      clearWorktreeCache();
+      process.chdir(nestedCwd);
+      expect(getOmcRoot()).toBe(join(project, '.omc'));
+    } finally {
+      process.chdir(previousCwd);
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousUserProfile;
+      clearWorktreeCache();
+    }
+  });
+
+  it('does not reuse state roots under protected home directories', () => {
+    const fakeHome = join(tempDir, 'home');
+    const sensitiveCwd = join(fakeHome, '.ssh', 'nested');
+    mkdirSync(join(fakeHome, '.ssh', '.omc'), { recursive: true });
+    mkdirSync(sensitiveCwd, { recursive: true });
+
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    try {
+      clearWorktreeCache();
+      expect(getOmcRoot(sensitiveCwd)).toBe(join(fakeHome, '.omc'));
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousUserProfile;
+      clearWorktreeCache();
+    }
+  });
+
+  it('honors an explicit workingDirectory when both directories are git-less', () => {
+    const fakeHome = join(tempDir, 'home');
+    const currentCwd = join(fakeHome, 'current');
+    const requestedCwd = join(currentCwd, 'requested');
+    mkdirSync(currentCwd, { recursive: true });
+    mkdirSync(requestedCwd, { recursive: true });
+
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    const originalCwd = process.cwd();
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
+    process.chdir(currentCwd);
+    try {
+      clearWorktreeCache();
+      expect(validateWorkingDirectory(requestedCwd)).toBe(resolve(requestedCwd));
+    } finally {
+      process.chdir(originalCwd);
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousUserProfile;
+      clearWorktreeCache();
+    }
   });
 });

--- a/src/lib/__tests__/worktree-paths-nongit-anchor.test.ts
+++ b/src/lib/__tests__/worktree-paths-nongit-anchor.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Non-git state-root anchoring contract (#3873).
+ *
+ * Covers the three defects reported in the issue:
+ *  1. cwd-fragmentation: every non-git working directory became its own
+ *     `.omc/` state root.
+ *  2. sensitive-location writes: `.omc/` was created inside `~/.ssh`,
+ *     `~/.claude`, and similar locations.
+ *  3. ignored `workingDirectory`: state tools silently resolved a provided
+ *     non-git directory back to the session's trusted root, so state_clear
+ *     reported "no state found" while state lived elsewhere.
+ *
+ * All tests are deterministic: no real HOME is touched (`os.homedir` is
+ * mocked to a per-suite temp dir), no network, no time dependence.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const osPaths: { home: string; tmp: string } = { home: '', tmp: '' };
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return {
+    ...actual,
+    homedir: vi.fn(() => osPaths.home),
+    tmpdir: vi.fn(() => osPaths.tmp),
+  };
+});
+
+const realTmp = (() => {
+  try { return process.env.TMPDIR || process.env.TEMP || process.env.TMP || '/tmp'; }
+  catch { return '/tmp'; }
+})();
+const suiteRoot = mkdtempSync(join(resolve(realTmp), 'omc-3873-suite-'));
+osPaths.home = join(suiteRoot, 'home');
+mkdirSync(osPaths.home, { recursive: true });
+osPaths.tmp = join(suiteRoot, 'tmp');
+mkdirSync(osPaths.tmp, { recursive: true });
+const fakeHome = osPaths.home;
+
+import {
+  getOmcRoot,
+  validateWorkingDirectory,
+  resolveStateWorkingDirectory,
+  resolveNonGitStateAnchor,
+  isSensitiveStateLocation,
+  clearWorktreeCache,
+  ensureAllOmcDirs,
+} from '../worktree-paths.js';
+
+const gitAvailable = (() => {
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+let scratch: string;
+const prevCwd = process.cwd();
+const prevStateDir = process.env.OMC_STATE_DIR;
+const prevDisableMultirepo = process.env.OMC_DISABLE_MULTIREPO;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(suiteRoot, 'scratch-'));
+  if (prevStateDir === undefined) delete process.env.OMC_STATE_DIR;
+  else process.env.OMC_STATE_DIR = prevStateDir;
+  if (prevDisableMultirepo === undefined) delete process.env.OMC_DISABLE_MULTIREPO;
+  else process.env.OMC_DISABLE_MULTIREPO = prevDisableMultirepo;
+  clearWorktreeCache();
+});
+
+afterEach(() => {
+  process.chdir(prevCwd);
+  rmSync(scratch, { recursive: true, force: true });
+  if (prevStateDir === undefined) delete process.env.OMC_STATE_DIR;
+  else process.env.OMC_STATE_DIR = prevStateDir;
+  if (prevDisableMultirepo === undefined) delete process.env.OMC_DISABLE_MULTIREPO;
+  else process.env.OMC_DISABLE_MULTIREPO = prevDisableMultirepo;
+  clearWorktreeCache();
+});
+
+function isDir(path: string): boolean {
+  try { return statSync(path).isDirectory(); }
+  catch { return false; }
+}
+
+describe('#3873 non-git state-root anchoring', () => {
+  describe('fragmentation collapse (getOmcRoot no-arg)', () => {
+    it('three non-git cwds resolve to one state root before and after an anchor exists', () => {
+      const base = join(scratch, 'nogit');
+      mkdirSync(join(base, 'a', 'b'), { recursive: true });
+
+      const roots = new Set<string>();
+      for (const dir of [base, join(base, 'a'), join(base, 'a', 'b')]) {
+        process.chdir(dir);
+        clearWorktreeCache();
+        roots.add(getOmcRoot());
+      }
+      expect(roots.size).toBe(1);
+      expect([...roots][0]).toBe(join(fakeHome, '.omc'));
+
+      mkdirSync(join(base, '.omc'), { recursive: true });
+      const rootsAfter = new Set<string>();
+      for (const dir of [base, join(base, 'a'), join(base, 'a', 'b')]) {
+        process.chdir(dir);
+        clearWorktreeCache();
+        rootsAfter.add(getOmcRoot());
+      }
+      expect(rootsAfter.size).toBe(1);
+      expect([...rootsAfter][0]).toBe(join(base, '.omc'));
+    });
+
+    it('nested hook directories adopt an existing project root', () => {
+      const project = join(scratch, 'dotfiles');
+      const hookDirs = [
+        join(project, '.claude'),
+        join(project, '.claude', 'hooks'),
+        join(project, '.claude', 'hooks', 'lib'),
+        join(project, '.claude', 'hooks', 'experiments'),
+      ];
+      for (const directory of hookDirs) mkdirSync(directory, { recursive: true });
+      mkdirSync(join(project, '.omc'), { recursive: true });
+
+      process.chdir(project);
+      const projectRoot = getOmcRoot();
+      expect(projectRoot).toBe(join(project, '.omc'));
+      for (const directory of hookDirs) {
+        process.chdir(directory);
+        clearWorktreeCache();
+        expect(getOmcRoot()).toBe(projectRoot);
+      }
+    });
+  });
+
+  describe('sensitive-location refusal', () => {
+    it('cwd inside ~/.ssh never anchors state in ~/.ssh', () => {
+      const ssh = join(fakeHome, '.ssh');
+      const nested = join(ssh, 'nested');
+      mkdirSync(join(nested, '.omc'), { recursive: true });
+      process.chdir(nested);
+      clearWorktreeCache();
+      const root = getOmcRoot();
+      expect(root).not.toBe(join(nested, '.omc'));
+      expect(root.startsWith(join(ssh))).toBe(false);
+    });
+
+    it('cwd directly in HOME anchors to ~/.omc, not HOME itself', () => {
+      process.chdir(fakeHome);
+      expect(getOmcRoot()).toBe(join(fakeHome, '.omc'));
+    });
+
+    it('cwd in a user content directory never anchors there', () => {
+      const downloads = join(fakeHome, 'Downloads');
+      mkdirSync(join(downloads, '.omc'), { recursive: true });
+      process.chdir(downloads);
+      clearWorktreeCache();
+      expect(getOmcRoot()).not.toBe(join(downloads, '.omc'));
+    });
+
+    it('isSensitiveStateLocation marks well-known sensitive dirs', () => {
+      for (const name of ['.ssh', '.gnupg', '.aws', '.config', '.claude', '.codex', '.cache', '.npm']) {
+        expect(isSensitiveStateLocation(join(fakeHome, name)), name).toBe(true);
+      }
+      expect(isSensitiveStateLocation(fakeHome)).toBe(true);
+      for (const name of ['Desktop', 'Documents', 'Downloads', 'Pictures', 'Music']) {
+        expect(isSensitiveStateLocation(join(fakeHome, name)), name).toBe(true);
+      }
+      if (process.platform !== 'win32') {
+        for (const path of ['/tmp', '/var', '/usr', '/etc', '/opt']) {
+          expect(isSensitiveStateLocation(path), path).toBe(true);
+        }
+        expect(isSensitiveStateLocation('/')).toBe(true);
+      }
+    });
+
+    it('does not flag ordinary project directories', () => {
+      const project = join(scratch, 'my-project');
+      mkdirSync(project, { recursive: true });
+      expect(isSensitiveStateLocation(project)).toBe(false);
+      expect(isSensitiveStateLocation(join(project, 'src'))).toBe(false);
+    });
+
+    it('walk-up skips sensitive ancestors and adopts the nearest safe .omc', () => {
+      const project = join(scratch, 'proj');
+      mkdirSync(join(project, '.config', 'work'), { recursive: true });
+      mkdirSync(join(project, '.omc'), { recursive: true });
+      expect(resolveNonGitStateAnchor(join(project, '.config', 'work'))).toBe(project);
+    });
+  });
+
+  describe('non-git fallback is the per-user root', () => {
+    it('falls back to ~/.omc when no ancestor has .omc', () => {
+      const deep = join(scratch, 'nowhere', 'a', 'b');
+      mkdirSync(deep, { recursive: true });
+      expect(resolveNonGitStateAnchor(deep)).toBe(fakeHome);
+    });
+
+    it('adopts the nearest ancestor .omc directory, not an .omc file', () => {
+      const base = join(scratch, 'anchor-tree');
+      const mid = join(base, 'x');
+      mkdirSync(join(base, 'x', 'y'), { recursive: true });
+      mkdirSync(join(base, '.omc'), { recursive: true });
+      writeFileSync(join(mid, '.omc'), 'not a directory');
+      expect(resolveNonGitStateAnchor(join(base, 'x', 'y'))).toBe(base);
+    });
+  });
+
+  describe('invariants unchanged', () => {
+    it('git repos still anchor at the git toplevel from any subdir', () => {
+      if (!gitAvailable) return;
+      const repo = join(scratch, 'repo');
+      mkdirSync(join(repo, 'x', 'y'), { recursive: true });
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+      for (const dir of [repo, join(repo, 'x'), join(repo, 'x', 'y')]) {
+        process.chdir(dir);
+        clearWorktreeCache();
+        expect(getOmcRoot()).toBe(join(repo, '.omc'));
+      }
+    });
+
+    it('OMC_STATE_DIR still centralizes non-git state', () => {
+      const central = join(scratch, 'central-state');
+      mkdirSync(central, { recursive: true });
+      process.env.OMC_STATE_DIR = central;
+      const dir = join(scratch, 'anywhere', 'deep');
+      mkdirSync(dir, { recursive: true });
+      process.chdir(dir);
+      clearWorktreeCache();
+      const root = getOmcRoot();
+      expect(root.startsWith(central)).toBe(true);
+      expect(root).not.toBe(join(dir, '.omc'));
+    });
+
+    it('OMC_STATE_DIR uses one fixed non-git child for multiple directories', () => {
+      const central = join(scratch, 'central-fixed');
+      const first = join(scratch, 'first');
+      const second = join(scratch, 'second');
+      mkdirSync(central, { recursive: true });
+      mkdirSync(first, { recursive: true });
+      mkdirSync(second, { recursive: true });
+      process.env.OMC_STATE_DIR = central;
+      process.chdir(first);
+      clearWorktreeCache();
+      expect(getOmcRoot()).toBe(join(central, 'non-git'));
+      process.chdir(second);
+      clearWorktreeCache();
+      expect(getOmcRoot()).toBe(join(central, 'non-git'));
+    });
+
+    it('a git repository named Downloads still uses its own repository root', () => {
+      if (!gitAvailable) return;
+      const repo = join(fakeHome, 'Downloads');
+      mkdirSync(repo, { recursive: true });
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+      process.chdir(repo);
+      clearWorktreeCache();
+      expect(getOmcRoot()).toBe(join(repo, '.omc'));
+    });
+
+    it('.omc-workspace marker still wins over walk-up adoption', () => {
+      const parent = join(scratch, 'ws-parent');
+      const inner = join(parent, 'repo-a', 'sub');
+      mkdirSync(inner, { recursive: true });
+      mkdirSync(join(parent, 'repo-b', '.omc'), { recursive: true });
+      writeFileSync(join(parent, '.omc-workspace'), '{}');
+      const anchor = resolveNonGitStateAnchor(inner);
+      expect(anchor).not.toBe(join(parent, 'repo-b', '.omc'));
+      mkdirSync(join(parent, '.omc'), { recursive: true });
+      clearWorktreeCache();
+      expect(resolveNonGitStateAnchor(inner)).toBe(parent);
+    });
+  });
+
+  describe('workingDirectory is honored (#3873)', () => {
+    it('returns a provided non-git subdirectory instead of the trusted root', () => {
+      const base = join(scratch, 'nogit-wd');
+      const sub = join(base, 'work');
+      mkdirSync(sub, { recursive: true });
+      process.chdir(base);
+      clearWorktreeCache();
+      expect(validateWorkingDirectory(sub)).toBe(resolve(sub));
+    });
+
+    it('git sessions still normalize subdirs to the git toplevel', () => {
+      if (!gitAvailable) return;
+      const repo = join(scratch, 'gitrepo');
+      const sub = join(repo, 'pkg');
+      mkdirSync(sub, { recursive: true });
+      execFileSync('git', ['init', '-q'], { cwd: repo });
+      process.chdir(sub);
+      clearWorktreeCache();
+      expect(validateWorkingDirectory(sub)).toBe(resolve(repo));
+    });
+
+    it('outside the trusted root still throws', () => {
+      const base = join(scratch, 'nogit-wd2');
+      const outside = join(scratch, 'elsewhere');
+      mkdirSync(base, { recursive: true });
+      mkdirSync(outside, { recursive: true });
+      process.chdir(base);
+      clearWorktreeCache();
+      expect(() => validateWorkingDirectory(outside)).toThrow();
+    });
+
+    it('foreign repositories are rejected instead of falling back to the startup root', () => {
+      if (!gitAvailable) return;
+      const first = join(scratch, 'first-repo');
+      const second = join(scratch, 'second-repo');
+      mkdirSync(first, { recursive: true });
+      mkdirSync(second, { recursive: true });
+      execFileSync('git', ['init', '-q'], { cwd: first });
+      execFileSync('git', ['init', '-q'], { cwd: second });
+      process.chdir(first);
+      clearWorktreeCache();
+      expect(() => resolveStateWorkingDirectory(second)).toThrow(/different repository/);
+    });
+  });
+
+  describe('end-to-end state placement', () => {
+    it('creates no per-cwd state roots across nested non-git cwds', () => {
+      const base = join(scratch, 'e2e');
+      mkdirSync(join(base, 'one', 'two'), { recursive: true });
+      process.chdir(base);
+      ensureAllOmcDirs();
+      const root = getOmcRoot();
+
+      for (const dir of [join(base, 'one'), join(base, 'one', 'two')]) {
+        process.chdir(dir);
+        clearWorktreeCache();
+        ensureAllOmcDirs();
+        expect(getOmcRoot()).toBe(root);
+      }
+      expect(root).toBe(join(fakeHome, '.omc'));
+      expect(isDir(join(base, '.omc'))).toBe(false);
+      expect(isDir(join(base, 'one', '.omc'))).toBe(false);
+      expect(isDir(join(base, 'one', 'two', '.omc'))).toBe(false);
+    });
+  });
+});

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -11,7 +11,7 @@
 
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFileSync, unlinkSync, statSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFileSync, unlinkSync, statSync, lstatSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
 import { pathToFileURL } from 'url';
@@ -59,6 +59,9 @@ const worktreeCacheMap = new Map<string, string>();
 /** LRU cache for outermost superproject root lookups, including negative results. */
 const superprojectCacheMap = new Map<string, string | null>();
 const canonicalWorkingDirectoryRoots = new WeakMap<object, { providedRoot: string; trustedRoot: string }>();
+
+/** LRU cache for non-git state-anchor lookups. */
+const nonGitAnchorCacheMap = new Map<string, string>();
 
 /**
  * LRU cache for workspace marker lookups.
@@ -205,24 +208,131 @@ function resolveSuperprojectRoot(cwd: string): string | null {
   return anchor;
 }
 
+// ============================================================================
+// NON-GIT STATE ANCHORING (#3873)
+// ============================================================================
+
+const SENSITIVE_DIR_BASENAMES = new Set([
+  '.ssh', '.gnupg', '.aws', '.azure', '.gcloud', '.kube', 'ssh', '.pki',
+  '.config', '.claude', '.claude.json', '.codex', '.gemini', '.cursor',
+  '.vscode', '.ollama', '.docker', '.npm', '.cache', '.local',
+  'desktop', 'documents', 'downloads', 'pictures', 'photos', 'music',
+  'movies', 'videos', 'public', 'library',
+]);
+
+function sensitiveAbsoluteRoots(): string[] {
+  const roots: string[] = [];
+  const home = (() => { try { return resolve(homedir()); } catch { return null; } })();
+  const temp = (() => { try { return resolve(tmpdir()); } catch { return null; } })();
+  if (home) roots.push(home);
+  if (temp) roots.push(temp);
+  if (process.platform === 'win32') {
+    roots.push('C:\\Windows', 'C:\\Program Files', 'C:\\Program Files (x86)', 'C:\\ProgramData');
+    const drive = (home && /^[a-zA-Z]:/.exec(home))?.[0];
+    if (drive) roots.push(`${drive}\\Windows`, `${drive}\\Program Files`, `${drive}\\Program Files (x86)`, `${drive}\\ProgramData`);
+  } else {
+    roots.push('/', '/tmp', '/var', '/usr', '/etc', '/opt', '/private/var', '/private/tmp');
+  }
+  return roots;
+}
+
+function isFilesystemRoot(dir: string): boolean {
+  return dirname(dir) === dir;
+}
+
+/** Return true when state must not be anchored at this directory. */
+export function isSensitiveStateLocation(dir: string): boolean {
+  let candidate: string;
+  try {
+    candidate = resolve(dir);
+  } catch {
+    return true;
+  }
+  const home = (() => { try { return resolve(homedir()); } catch { return null; } })();
+  let cursor = candidate;
+  for (;;) {
+    const name = basename(cursor);
+    const lowerName = name.toLowerCase();
+    if (home && cursor === candidate && (cursor === home || (process.platform === 'win32' && cursor.toLowerCase() === home.toLowerCase()))) return true;
+    if (name.startsWith('.') && name !== OmcPaths.ROOT) return true;
+    if (SENSITIVE_DIR_BASENAMES.has(lowerName)) return true;
+    if (isFilesystemRoot(cursor)) break;
+    cursor = dirname(cursor);
+  }
+  return sensitiveAbsoluteRoots().some((root) => candidate === root || (process.platform === 'win32' && candidate.toLowerCase() === root.toLowerCase()));
+}
+
+function resolveNonGitFallbackRoot(): string {
+  const home = resolve(homedir());
+  if (isFilesystemRoot(home)) {
+    throw new Error('Cannot resolve a safe non-git OMC state root: home resolves to the filesystem root.');
+  }
+  return home;
+}
+
+/**
+ * Resolve a stable anchor directory for a non-git cwd.
+ * Existing safe `.omc/` ancestors are adopted; otherwise `$HOME/.omc` is used.
+ * This function never creates or deletes state.
+ */
+export function resolveNonGitStateAnchor(startDir?: string): string {
+  let current: string;
+  try {
+    current = resolve(startDir || process.cwd());
+    try { current = realpathSync(current); } catch { /* keep lexical path for a missing cwd */ }
+  } catch {
+    current = resolveNonGitFallbackRoot();
+  }
+
+  const cached = nonGitAnchorCacheMap.get(current);
+  if (cached !== undefined) return cached;
+
+  let cursor = current;
+  let anchor: string | undefined;
+  for (let depth = 0; depth < 128; depth++) {
+    if (!isSensitiveStateLocation(cursor)) {
+      try {
+        const candidate = join(cursor, OmcPaths.ROOT);
+        const candidateStat = lstatSync(candidate);
+        const safeSymlink = candidateStat.isSymbolicLink() && (() => {
+          try {
+            return !isSensitiveStateLocation(realpathSync(candidate)) && statSync(candidate).isDirectory();
+          } catch {
+            return false;
+          }
+        })();
+        if (candidateStat.isDirectory() || safeSymlink) {
+          anchor = cursor;
+          break;
+        }
+      } catch {
+        // Missing or inaccessible legacy roots are ignored.
+      }
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+
+  if (anchor) {
+    if (nonGitAnchorCacheMap.size >= MAX_WORKTREE_CACHE_SIZE) {
+      const oldest = nonGitAnchorCacheMap.keys().next().value;
+      if (oldest !== undefined) nonGitAnchorCacheMap.delete(oldest);
+    }
+    nonGitAnchorCacheMap.set(current, anchor);
+    return anchor;
+  }
+  return resolveNonGitFallbackRoot();
+}
+
 /**
  * Resolve the state-anchor root for an optional worktreeRoot argument.
- *
- * Many callers pass a raw cwd as `worktreeRoot` (e.g. hooks forwarding
- * `process.cwd()`). When that cwd is inside a git submodule we climb to the
- * outermost superproject so `.omc/` anchors to the monorepo root rather than
- * the submodule (#3349).
- *
- * Crucially, when the provided dir is NOT inside a submodule the path is used
- * VERBATIM (the historical contract) — it is NOT resolved up to its git
- * toplevel. Callers that pass an explicit directory (including tests that
- * isolate state under a per-process subdir of the repo) rely on it being the
- * literal `.omc` base; resolving such a subdir up to the repo root would
- * collapse separately-scoped state dirs into one and corrupt them.
+ * Explicit git-backed directories retain the historical literal contract;
+ * non-git directories use the stable non-git anchor.
  */
 function resolveStateAnchorRoot(worktreeRoot?: string): string {
   if (worktreeRoot) return resolveSuperprojectRoot(worktreeRoot) || worktreeRoot;
-  return getWorktreeRoot() || process.cwd();
+  return getWorktreeRoot() || resolveNonGitStateAnchor();
 }
 
 /**
@@ -774,7 +884,10 @@ export function getOmcRoot(worktreeRoot?: string): string {
     // an explicit worktreeRoot keeps its own centralized id rather than merging
     // into the parent project's (preserves submodule identity).
     const root = worktreeRoot || getGitTopLevel() || process.cwd();
-    const projectId = getProjectIdentifier(root);
+    const workspaceRoot = findWorkspaceRoot(root);
+    const projectId = !worktreeRoot && !workspaceRoot && !getGitTopLevel(root)
+      ? 'non-git'
+      : getProjectIdentifier(root);
     const centralizedPath = join(customDir, projectId);
 
     // Log notice if both legacy .omc/ and new centralized dir exist
@@ -795,11 +908,14 @@ export function getOmcRoot(worktreeRoot?: string): string {
   // workspaces where the parent dir is not itself a git repo: all sub-repos
   // share the same .omc/ at the marker location.
   const workspaceAnchor = findWorkspaceRoot(worktreeRoot);
-  if (workspaceAnchor) {
+  if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return join(workspaceAnchor, OmcPaths.ROOT);
   }
 
   const root = resolveStateAnchorRoot(worktreeRoot);
+  if (isSensitiveStateLocation(root) && !getGitTopLevel(root)) {
+    return join(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+  }
   return join(root, OmcPaths.ROOT);
 }
 
@@ -956,6 +1072,7 @@ export function clearWorktreeCache(): void {
   worktreeCacheMap.clear();
   superprojectCacheMap.clear();
   workspaceCacheMap.clear();
+  nonGitAnchorCacheMap.clear();
 }
 
 // ============================================================================
@@ -1581,9 +1698,38 @@ export function validateWorkingDirectory(workingDirectory?: string): string {
     throw new Error(formatOutsideTrustedRootMessage(workingDirectory, trustedRoot));
   }
 
-  // Directory is under trusted root but git failed — return trusted root,
-  // never the subdirectory, to prevent .omc/ creation in subdirs (#576).
-  return trustedRoot;
+  if (trustedRootReal === resolvedReal) {
+    return trustedRoot;
+  }
+
+  // Git-backed sessions still normalize subdirectories to the repository
+  // root. A git-less session has no repository root to normalize to, so keep
+  // the explicitly requested directory; getOmcRoot() applies the stable
+  // non-git anchor and prevents a per-directory .omc/ from being created.
+  if (getGitTopLevel(process.cwd())) {
+    return trustedRoot;
+  }
+  return resolvedReal;
+}
+
+/**
+ * Resolve a state-tool workingDirectory with visible repository-boundary
+ * failures. Git sessions may target the same repository or a linked worktree;
+ * git-less sessions retain an explicit child directory while still rejecting
+ * paths outside the trusted non-git context.
+ */
+export function resolveStateWorkingDirectory(workingDirectory?: string): string {
+  if (!workingDirectory) return validateWorkingDirectory();
+
+  if (getGitTopLevel(process.cwd())) {
+    return validateWorkingDirectoryOrLinkedWorktree(workingDirectory);
+  }
+
+  // Run the strict resolver first so a mixed git/non-git or foreign-repository
+  // request cannot be silently substituted with the startup cwd.
+  validateWorkingDirectoryOrLinkedWorktree(workingDirectory);
+  const validated = validateWorkingDirectory(workingDirectory);
+  return resolveNonGitStateAnchor(validated);
 }
 
 function getGitCommonDir(cwd: string): string | null {

--- a/src/tools/__tests__/cancel-integration.test.ts
+++ b/src/tools/__tests__/cancel-integration.test.ts
@@ -14,6 +14,9 @@ vi.mock('../../lib/worktree-paths.js', async () => {
     validateWorkingDirectory: vi.fn((workingDirectory?: string) => {
       return workingDirectory || process.cwd();
     }),
+    resolveStateWorkingDirectory: vi.fn((workingDirectory?: string) => {
+      return workingDirectory || process.cwd();
+    }),
   };
 });
 

--- a/src/tools/__tests__/state-tools.test.ts
+++ b/src/tools/__tests__/state-tools.test.ts
@@ -22,6 +22,9 @@ vi.mock('../../lib/worktree-paths.js', async () => {
     validateWorkingDirectory: vi.fn((workingDirectory?: string) => {
       return workingDirectory || process.cwd();
     }),
+    resolveStateWorkingDirectory: vi.fn((workingDirectory?: string) => {
+      return workingDirectory || process.cwd();
+    }),
   };
 });
 

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -13,7 +13,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'pat
 import {
   resolveStatePath,
   ensureOmcDir,
-  validateWorkingDirectory,
+  resolveStateWorkingDirectory,
   resolveSessionStatePath,
   ensureSessionStateDir,
   listSessionIds,
@@ -840,7 +840,7 @@ export const stateReadTool: ToolDefinition<{
     const { mode, workingDirectory, session_id } = args;
 
     try {
-      const root = validateWorkingDirectory(workingDirectory);
+      const root = resolveStateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
 
       // If session_id provided, read from session-scoped path
@@ -1019,7 +1019,7 @@ export const stateWriteTool: ToolDefinition<{
     } = args;
 
     try {
-      const root = validateWorkingDirectory(workingDirectory);
+      const root = resolveStateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
 
       // Validate custom state payload size if provided
@@ -1257,7 +1257,7 @@ export const stateClearTool: ToolDefinition<{
     const { mode, workingDirectory, session_id } = args;
 
     try {
-      const root = validateWorkingDirectory(workingDirectory);
+      const root = resolveStateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
 
       // Merge-readiness is an audit gate, so clearing it must leave a durable
@@ -1815,7 +1815,7 @@ export const stateListActiveTool: ToolDefinition<{
     const { workingDirectory, session_id, all } = args;
 
     try {
-      const root = validateWorkingDirectory(workingDirectory);
+      const root = resolveStateWorkingDirectory(workingDirectory);
 
       // Resolve the effective session ID:
       //   1. Explicit session_id arg wins (back-compat for callers that pass it directly).
@@ -1992,7 +1992,7 @@ export const stateGetStatusTool: ToolDefinition<{
     const { mode, workingDirectory, session_id } = args;
 
     try {
-      const root = validateWorkingDirectory(workingDirectory);
+      const root = resolveStateWorkingDirectory(workingDirectory);
       const sessionId = session_id as string | undefined;
 
       if (mode) {
@@ -2173,7 +2173,7 @@ export const stateTools = [
     },
     handler: async (args: { summary: string; workingDirectory?: string; session_id?: string; baseRef?: string }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const directory = resolveStateWorkingDirectory(args.workingDirectory);
       const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
       const state = createInitialMergeReadinessState(directory, args.summary, sessionId, args.baseRef);
       const blocked = state.result === 'blocked';
@@ -2194,7 +2194,7 @@ export const stateTools = [
     },
     handler: async (args: { why: string; whatChanged: string; tradeoffs: string; risksConsidered: string; teamUnderstanding: string; questions: Array<any>; workingDirectory?: string; session_id?: string }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const directory = resolveStateWorkingDirectory(args.workingDirectory);
       const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
       const state = setMergeReadinessContent(directory, args, sessionId);
       if (!state || !state.active) {
@@ -2218,7 +2218,7 @@ export const stateTools = [
     },
     handler: async (args: { questionId: string; optionId: string; workingDirectory?: string; session_id?: string }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const directory = resolveStateWorkingDirectory(args.workingDirectory);
       const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: "cli" });
       const state = recordMergeReadinessMCQAnswer(directory, args.questionId, args.optionId, sessionId);
       if (!state) {
@@ -2245,7 +2245,7 @@ export const stateTools = [
     schema: { workingDirectory: z.string().optional(), session_id: z.string().optional() },
     handler: async (args: { workingDirectory?: string; session_id?: string }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const directory = resolveStateWorkingDirectory(args.workingDirectory);
       const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: 'cli' });
       const state = readMergeReadinessState(directory, sessionId);
       if (!state) {
@@ -2264,7 +2264,7 @@ export const stateTools = [
     schema: { workingDirectory: z.string().optional(), session_id: z.string().optional() },
     handler: async (args: { workingDirectory?: string; session_id?: string }) => {
       try {
-      const directory = validateWorkingDirectory(args.workingDirectory || process.cwd());
+      const directory = resolveStateWorkingDirectory(args.workingDirectory);
       const sessionId = (args.session_id && args.session_id.trim()) || (process.env.CLAUDE_SESSION_ID && process.env.CLAUDE_SESSION_ID.trim()) || resolveSessionId({ context: 'cli' });
       const state = cancelMergeReadiness(directory, sessionId);
       const persistFailed = state?.result === 'blocked' && (state.validation_errors ?? []).some((e) => e.includes('persisted'));


### PR DESCRIPTION
Closes #3873

## Recovery and scope
- Reused the preserved dedicated worktree/branch; no reset, duplicate owner, or generated-output sweep.
- Reconciled the pre-tmux-recreation stash without applying it: c6c232eb5781fad0a0c409b7d17184ce21e2ee50, untracked companion 9f8e2a83ac4e102a97df657a23598e56dafadb3b, index f7769a638df06348b0c108b68ae3e14a60c4898a.
- Base is origin/dev 98bf032fd4b38b275dae9d2fce0702e6cdd2d25c; exact head is d7f05f9e847ee805610048109c9f405fd98c0c8d.

## Fix
- Collapse non-git cwd fragmentation onto safe existing anchors or ~/.omc.
- Refuse sensitive roots and unsafe symlink targets while preserving git/workspace behavior.
- Make state-tool workingDirectory resolution visible and repository-boundary safe.
- Keep session_id ownership semantics; add no time-based destructive cleanup.

## Verification
- bunx tsc --noEmit
- focused ESLint on changed TypeScript
- 4 focused Vitest files, 150 tests passed
- signed commit (GPG good signature)

No main merge, release, tag, or publish.