### PR TITLE
feat(prompt-ssot): add native minimal-code discipline policy section

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -13,6 +13,19 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>
 
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
+
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,19 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>
 
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
+
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.

--- a/bridge/claude-md-coordinator.cjs
+++ b/bridge/claude-md-coordinator.cjs
@@ -876,7 +876,7 @@ function executeClaudeMdTransaction(request) {
 // src/cli/claude-md-coordinator.ts
 var CLAUDE_MD_COORDINATOR_SCHEMA_VERSION = 1;
 var COMPILED_ENGINE_VERSION = true ? "5.0.0" : "";
-var COMPILED_SOURCE_SHA256 = true ? "8bce08203735392b969ded8e96bafa3aed47055d60e32865cf820e9be9c5e3e7" : "";
+var COMPILED_SOURCE_SHA256 = true ? "d26a2730a8f2e60ab75e287fd33f2c96c7bc04db4308e617a3254da8f509b7c7" : "";
 function runClaudeMdCoordinatorHandshake() {
   if (!COMPILED_ENGINE_VERSION || !COMPILED_SOURCE_SHA256) {
     return { exitCode: 2, response: coordinatorError(2, "Coordinator build handshake is unavailable") };

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -13,6 +13,19 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>
 
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
+
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.

--- a/generated/prompt-ssot/coordinator.md
+++ b/generated/prompt-ssot/coordinator.md
@@ -1,10 +1,10 @@
 <!-- PROMPT-SSOT:GENERATED
 schemaVersion: 1
 projection: coordinator
-sourceRevision: 2026-08-13.1
+sourceRevision: 2026-08-26.1
 overlay.provider: none
 overlay.modelTier: none
-sha256: 792614403b5edf077c985160db28fb6def407ea330bb6cd15fbb4ba7771edd00
+sha256: 9c9e8f177c3c5f36613c1dfc983236ac22066ac1ddac2d6f81085219234de31f
 Regenerate: npm run prompt-ssot:build. Do not edit by hand.
 -->
 
@@ -28,6 +28,19 @@ Trailers (skip for trivial commits like typos or formatting):
 - Work directly only for trivial operations: small clarifications, quick status checks, single commands.
 - Route substantive code changes to the executor lane.
 - Route non-trivial SDK/API/framework questions to documentation research before implementing.
+
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
 
 ## Model Routing
 - Low tier: quick lookups and narrow checks.

--- a/generated/prompt-ssot/role-executor.md
+++ b/generated/prompt-ssot/role-executor.md
@@ -1,12 +1,25 @@
 <!-- PROMPT-SSOT:GENERATED
 schemaVersion: 1
 projection: role-executor
-sourceRevision: 2026-08-13.1
+sourceRevision: 2026-08-26.1
 overlay.provider: none
 overlay.modelTier: none
-sha256: 83f7eb2012efec5801788453826702a3745ac12ebb68b6d6fb79479036a77cef
+sha256: 02f5065cc9e7b16b67d9189281b4f4df9a924123a004c77a801538cb88884881
 Regenerate: npm run prompt-ssot:build. Do not edit by hand.
 -->
+
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
 
 ## Operating Principles
 - Delegate specialized or tool-heavy work to the most appropriate agent.

--- a/generated/prompt-ssot/role-planner.md
+++ b/generated/prompt-ssot/role-planner.md
@@ -1,12 +1,25 @@
 <!-- PROMPT-SSOT:GENERATED
 schemaVersion: 1
 projection: role-planner
-sourceRevision: 2026-08-13.1
+sourceRevision: 2026-08-26.1
 overlay.provider: none
 overlay.modelTier: none
-sha256: c155324ee8af33b16495e8dd29b8ce5faad2f2d3e32ff5cbd9cf5e9ef5bc17b6
+sha256: 5473541e9974d97bb9cc104cb4a19aed94ac4cf0dffa09bbd9a90d74a950e5da
 Regenerate: npm run prompt-ssot:build. Do not edit by hand.
 -->
+
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
 
 ## Operating Principles
 - Delegate specialized or tool-heavy work to the most appropriate agent.

--- a/generated/prompt-ssot/role-reviewer.md
+++ b/generated/prompt-ssot/role-reviewer.md
@@ -1,12 +1,25 @@
 <!-- PROMPT-SSOT:GENERATED
 schemaVersion: 1
 projection: role-reviewer
-sourceRevision: 2026-08-13.1
+sourceRevision: 2026-08-26.1
 overlay.provider: none
 overlay.modelTier: none
-sha256: f67aea3bfa90beb2ecc5dddec1ecfa63de5a0df1bb9b8e3cdb1a0829d9d5db4a
+sha256: 176556979468c2c1cb51a05a404056f7a713add796985ee1b69dbc8d33954444
 Regenerate: npm run prompt-ssot:build. Do not edit by hand.
 -->
+
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
 
 ## Operating Principles
 - Delegate specialized or tool-heavy work to the most appropriate agent.

--- a/generated/prompt-ssot/role-verifier.md
+++ b/generated/prompt-ssot/role-verifier.md
@@ -1,12 +1,25 @@
 <!-- PROMPT-SSOT:GENERATED
 schemaVersion: 1
 projection: role-verifier
-sourceRevision: 2026-08-13.1
+sourceRevision: 2026-08-26.1
 overlay.provider: none
 overlay.modelTier: none
-sha256: 6da80baeb3440c4cd4d62c3462cd817bca45ac780fe816f9f8229a3563f5799f
+sha256: 72fff43a7e435b1a95d13e0d155ce06c8d0f9d0e7567c85771dadeeab7f7fc50
 Regenerate: npm run prompt-ssot:build. Do not edit by hand.
 -->
+
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
 
 ## Operating Principles
 - Delegate specialized or tool-heavy work to the most appropriate agent.

--- a/src/agents/prompt-ssot/manifest.ts
+++ b/src/agents/prompt-ssot/manifest.ts
@@ -11,7 +11,7 @@ import type { PromptSsotManifest } from './types.js';
 
 export const PROMPT_SSOT_MANIFEST: PromptSsotManifest = {
   schemaVersion: 1,
-  sourceRevision: '2026-08-13.1',
+  sourceRevision: '2026-08-26.1',
   requiredSections: ['policy/operating-principles', 'safety/hard-boundaries'],
   projections: [
     {
@@ -19,6 +19,7 @@ export const PROMPT_SSOT_MANIFEST: PromptSsotManifest = {
       description: 'Coordinator (CLAUDE.md-style) system prompt projection',
       sections: [
         'policy/operating-principles',
+        'policy/minimal-code-discipline',
         'policy/delegation-rules',
         'policy/model-routing',
         'task-contract/verification',
@@ -38,6 +39,7 @@ export const PROMPT_SSOT_MANIFEST: PromptSsotManifest = {
       description: `Tier-0 role prompt projection: ${role}`,
       sections: [
         'policy/operating-principles',
+        'policy/minimal-code-discipline',
         'task-contract/verification',
         'task-contract/execution-protocols',
         'safety/hard-boundaries',

--- a/src/agents/prompt-ssot/sections.ts
+++ b/src/agents/prompt-ssot/sections.ts
@@ -33,6 +33,24 @@ export const PROMPT_SECTIONS: readonly PromptSection[] = [
 - Keep diffs small, reversible, and easy to review.`,
   },
   {
+    id: 'policy/minimal-code-discipline',
+    kind: 'policy',
+    owner: 'prompt-ssot-owner',
+    version: 1,
+    body: `## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.`,
+  },
+  {
     id: 'policy/delegation-rules',
     kind: 'policy',
     owner: 'prompt-ssot-owner',

--- a/tests/fixtures/prompt-projection/claude-body.normalized
+++ b/tests/fixtures/prompt-projection/claude-body.normalized
@@ -11,6 +11,19 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>
 
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
+
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.

--- a/tests/fixtures/prompt-projection/claude-managed-block.golden
+++ b/tests/fixtures/prompt-projection/claude-managed-block.golden
@@ -13,6 +13,19 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 - Consult official docs before implementing with SDKs/frameworks/APIs.
 </operating_principles>
 
+## Minimal-Code Discipline
+- Ask first whether the change needs to exist at all; skip work that serves only a speculative future need.
+- Search the codebase for an existing helper, type, or pattern before writing anything new.
+- Never copy a helper that already lives a few files away; reuse it or extract it to one shared location.
+- Reach for the standard library first, then platform-native capability, then an already-installed dependency; hand-written code is the last resort.
+- Do not introduce a new dependency when a few lines of code suffice.
+- Understand the problem completely before minimizing: read the affected code and follow its execution path first.
+- Ship the shortest correct diff once the problem is understood; code you never write never breaks.
+- Prefer boring, obviously-correct code over clever code.
+- Mark deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+- Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+- Never minimize away validation wherever a trust boundary is crossed, error handling that guards against data loss, security controls, accessibility fundamentals, or scope the user explicitly requested.
+
 <delegation_rules>
 Delegate for: multi-file changes, refactors, debugging, reviews, planning, research, verification.
 Work directly for: trivial ops, small clarifications, single commands.


### PR DESCRIPTION
## Summary

Adds `policy/minimal-code-discipline` to the prompt SSOT and registers it in all five projections (coordinator + planner/executor/reviewer/verifier), so OMC sessions — main loop and delegated Tier-0 roles alike — default to efficient, concise code without any external plugin or activation step.

The 11 clauses distill a YAGNI-ladder coding discipline natively: existence-first, reuse before writing, stdlib > platform > installed dep > hand-written, understand fully before minimizing, shortest correct diff, boring over clever, marked ceilings with upgrade paths, root-cause bug fixes, and non-negotiables (trust-boundary validation, data-loss error handling, security, accessibility basics, explicit user scope).

### What changed
- `src/agents/prompt-ssot/sections.ts` — new section (id: `policy/minimal-code-discipline`, kind: policy, version 1), placed after `policy/operating-principles`
- `src/agents/prompt-ssot/manifest.ts` — section registered in coordinator + all four role projections; `sourceRevision` bumped to `2026-08-26.1`
- `docs/CLAUDE.md` managed block mirrored; CLAUDE.md / .github/CLAUDE.md regenerated via documented chain
- `generated/prompt-ssot/*.md` (5) + golden fixtures regenerated via `npm run prompt-ssot:build` / `generate:prompt-projections`
- `bridge/claude-md-coordinator.cjs` — single required artifact delta: parity handshake test (`src/projection/__tests__/parity.test.ts`) hard-requires this bundle to embed the current docs sha. Per CONTRIBUTING's governance note, expect this generated delta to be held with `OWNER_CONFIRMATION_REQUIRED`; all other dist/bridge churn was deliberately excluded.

## Test plan
- [x] `npm run prompt-ssot:check` — 5 projections fresh (sourceRevision 2026-08-26.1)
- [x] `npx vitest run src/agents/prompt-ssot src/projection` — 38 passed / 0 failed (prompt-ssot 28, parity 7, fixtures 3)
- [x] Byte-level drift check across TS source + 9 markdown surfaces — identical discipline text everywhere
- [x] No TODO/stub/skip markers in changed set; tsc clean
- [ ] CI full suite on PR

## Notes for reviewers
- Content is distilled/rewritten natively (no verbatim third-party text); three clauses deliberately reinforce existing operating-principles wording with sharper operational guidance.
- The TS SSOT pipeline is not yet wired into runtime CLAUDE.md (tracked by #3705); the docs/CLAUDE.md mirror is what carries the always-on effect today. Future sections should follow the same dual registration until that rewiring lands.