### PR TITLE
fix(team): pass --model through to cursor workers (#3880)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "33fb4d9441b1fb7a620ca8d6fa1f7f94540822b0",
-    "sourceSha256": "27fd77817aeb62a7a053e46fa48e37eb85d7cdf0a2af0870f7287c0ce5e0765f",
+    "head": "be832f7feb47373c404af469c666c653f4624a4b",
+    "sourceSha256": "98a4db325ccee540430e13a820a591d35eb3168ded8c46b8b60d731455c3e46b",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "33fb4d9441b1fb7a620ca8d6fa1f7f94540822b0",
-  "sourceSha256": "27fd77817aeb62a7a053e46fa48e37eb85d7cdf0a2af0870f7287c0ce5e0765f",
+  "head": "be832f7feb47373c404af469c666c653f4624a4b",
+  "sourceSha256": "98a4db325ccee540430e13a820a591d35eb3168ded8c46b8b60d731455c3e46b",
   "counts": {
     "public": {
       "skills": 32,
@@ -76357,5 +76357,5 @@
     }
   },
   "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "2ce1b253635639171a6149ae5a3971dce2d401425614224a7b843ac6bf00f87c"
+  "manifestSha256": "33fe5b19a36e99233cf4b4ddcb7a144cfd38dced0645307bbdb2cda600feefc2"
 }

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -377,6 +377,10 @@ describe('model-contract', () => {
       expect(noModel).toEqual([]);
       expect(noModel).not.toContain('--model');
 
+      const emptyModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: '' });
+      expect(emptyModel).toEqual([]);
+      expect(emptyModel).not.toContain('--model');
+
       const withModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'cursor-grok-4.6-high' });
       expect(withModel).toEqual(['--model', 'cursor-grok-4.6-high']);
     });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -372,6 +372,28 @@ describe('model-contract', () => {
       const withModel = buildLaunchArgs('grok', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'grok-4-fast' });
       expect(withModel).toEqual(['--always-approve', '--model', 'grok-4-fast']);
     });
+    it('cursor emits no flags without a model and appends --model <m> when given (issue #3880)', () => {
+      const noModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp' });
+      expect(noModel).toEqual([]);
+      expect(noModel).not.toContain('--model');
+
+      const withModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'cursor-grok-4.6-high' });
+      expect(withModel).toEqual(['--model', 'cursor-grok-4.6-high']);
+    });
+    it('cursor appends extraFlags after the model flag (issue #3880)', () => {
+      const args = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'composer-2.5', extraFlags: ['--foo'] });
+      expect(args).toEqual(['--model', 'composer-2.5', '--foo']);
+
+      const noModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', extraFlags: ['--foo'] });
+      expect(noModel).toEqual(['--foo']);
+    });
+    it('cursor worker argv leads with the cursor-agent binary then --model (issue #3880)', () => {
+      const argv = buildWorkerArgv('cursor', {
+        teamName: 'cursor-team', workerName: 'w', cwd: '/tmp',
+        model: 'cursor-grok-4.6-high', resolvedBinaryPath: '/usr/local/bin/cursor-agent',
+      });
+      expect(argv).toEqual(['/usr/local/bin/cursor-agent', '--model', 'cursor-grok-4.6-high']);
+    });
     it('passes model flag when specified', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4' });
       expect(args).toContain('--model');

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -291,15 +291,16 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     agentType: 'cursor',
     binary: 'cursor-agent',
     installInstructions: 'Install Cursor Agent CLI: see https://docs.cursor.com/cli',
-    // cursor-agent runs as an interactive REPL — no exit-on-complete prompt mode.
-    // Keep supportsPromptMode false so the verdict-file contract path
-    // (CONTRACT_ROLES + shouldInjectContract) skips this provider; cursor
-    // workers participate as executors only.
+    // Team workers must be persistent interactive panes, so the one-shot
+    // `-p/--print` path is deliberately unused here (same stance as codex).
     supportsPromptMode: false,
-    buildLaunchArgs(_model?: string, extraFlags: string[] = []): string[] {
-      // Minimal flags — cursor-agent owns its own session/auth state.
-      // The model is selected interactively inside cursor-agent itself.
-      return [...extraFlags];
+    buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
+      // cursor-agent owns its own session/auth state, so no approval flags are
+      // needed. `--model <id>` is a documented global option; ids come from
+      // `cursor-agent --list-models` (e.g. cursor-grok-4.6-high, composer-2.5).
+      const args: string[] = [];
+      if (model) args.push('--model', model);
+      return [...args, ...extraFlags];
     },
     parseOutput(rawOutput: string): string {
       return rawOutput.trim();


### PR DESCRIPTION
Phase 1 of #3880. Standalone bug fix — no behavior change beyond honoring a
setting that was already accepted by config validation.

## Problem

`CONTRACTS.cursor.buildLaunchArgs` discarded its `model` parameter:

```ts
buildLaunchArgs(_model?: string, extraFlags: string[] = []): string[] {
  // Minimal flags — cursor-agent owns its own session/auth state.
  // The model is selected interactively inside cursor-agent itself.
  return [...extraFlags];
}
```

Every other provider does `if (model) args.push('--model', model)`. Cursor was
the only exception, and the parameter was renamed `_model` to mark the value as
intentionally unused.

Consequence: a config like

```jsonc
{ "team": { "roleRouting": { "executor": { "provider": "cursor", "model": "cursor-grok-4.6-high" } } } }
```

passes `validateTeamConfig` and is persisted into `TeamConfig.resolved_routing`,
but the launch argv never receives it. The model silently resolves to whatever
default the CLI picks. This is the same gap as the "configurable default model"
request in #3298, which was implemented for the other providers but not Cursor.

## Fix

Append `--model <id>` like every sibling provider. `--model` is a documented
Cursor CLI global option (cursor.com/docs/cli/reference/parameters).

## Verification

Argv generation:

```
no model : []
with     : ["--model","cursor-grok-4.6-high"]
argv     : ["/Users/…/bin/cursor-agent","--model","cursor-grok-4.6-high"]
```

Against the real binary:

```console
$ cursor-agent --model cursor-grok-4.6-high --trust -p --output-format text \
    "Reply with exactly: MODEL_FLAG_OK"
MODEL_FLAG_OK                                                        # exit 0

$ cursor-agent --model definitely-not-a-real-model --trust -p --output-format text "hi"
Cannot use this model: definitely-not-a-real-model. Available models: …  # exit 1
```

The rejection of an unknown id confirms the flag is honored, not ignored.

Gates:

| Check | Result |
|---|---|
| `vitest run src/team/__tests__/model-contract.test.ts` | 77 passed |
| `tsc --noEmit` | clean |
| `eslint` (both changed files) | clean |

`src/team/__tests__` has 5 pre-existing failing files
(`runtime-owner-busy`, `runtime-owner-client`, `runtime-v2.shutdown-pane-cleanup`,
`worker-launch-ack`, `worker-launch-posix-transport`). I stashed this change and
re-ran them on a clean tree: identical results (4 failed / 1 passed, same 9
failing tests). They fail on `worker_launch_provider_cleanup_unverified` and
related pane-teardown assertions — unrelated to launch-arg construction.

## Tests added

`cursor` had **zero** occurrences in `model-contract.test.ts` — the only provider
with no contract coverage. Added three cases, mirroring the existing grok and
antigravity tests:

- no model → `[]`; with model → `['--model', '<id>']`
- `extraFlags` ordering, with and without a model
- `buildWorkerArgv` places the binary first, then `--model`

## Comment correction

The old comment claimed cursor-agent has "no exit-on-complete prompt mode". That
is inaccurate — the CLI does support one-shot `-p/--print` with
`--output-format text|json|stream-json`. `supportsPromptMode` still stays
`false`, but now for the accurate reason, which is the one codex already records:
team workers must be persistent interactive panes, so the one-shot path is
deliberately unused.

This only corrects the comment. The executor-only role restriction is untouched
here and is handled separately in later phases of #3880.

## Scope

Two files, +31 / -8. No changes to role routing, the verdict contract, or the
worker lifecycle. No `dist/` or `bridge/` artifacts.

Refs #3298
