### PR TITLE
fix(team): stop cursor workers stalling on workspace trust

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "367375e9ca11fe5ee506b4a3c112763acf37f405",
-    "sourceSha256": "98414b9b5c9702444ba058de5ef735847061ee0b69ea405060e44156e6dc1b5a",
+    "head": "9b3ed7b401aa7f5e0ff02944b23d9a63c422a0f3",
+    "sourceSha256": "1e8ded40499f0186f205f657c90c9eab2ef8174b6fdbfd4ccaf2848f5f781e35",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "367375e9ca11fe5ee506b4a3c112763acf37f405",
-  "sourceSha256": "98414b9b5c9702444ba058de5ef735847061ee0b69ea405060e44156e6dc1b5a",
+  "head": "9b3ed7b401aa7f5e0ff02944b23d9a63c422a0f3",
+  "sourceSha256": "1e8ded40499f0186f205f657c90c9eab2ef8174b6fdbfd4ccaf2848f5f781e35",
   "counts": {
     "public": {
       "skills": 32,
@@ -60864,6 +60864,11 @@
         "kind": "imports"
       },
       {
+        "from": "src/hooks/team-dispatch-hook.ts",
+        "to": "src/team/tmux-session.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/hooks/team-leader-nudge-hook.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -76361,11 +76366,11 @@
     ],
     "stats": {
       "nodeCount": 6832,
-      "edgeCount": 7184,
-      "importEdgeCount": 5900,
+      "edgeCount": 7185,
+      "importEdgeCount": 5901,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "9ed7fa9ef40352f405ba061bec184886b6d03f6f4c96dd907e1efc4e867f1b12"
+  "manifestSha256": "005212013533769c02f675ac2b10233a12770dd6d8c375efc57d5047c51f87b0"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "9b3ed7b401aa7f5e0ff02944b23d9a63c422a0f3",
-    "sourceSha256": "1e8ded40499f0186f205f657c90c9eab2ef8174b6fdbfd4ccaf2848f5f781e35",
+    "head": "ac0e3999771b6c801ecafd452d4f696b30d90fce",
+    "sourceSha256": "7abdac468d9ab48612aa02674f2de6d98fe2ebcca4e11ae319a2a5a40bcae00d",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "9b3ed7b401aa7f5e0ff02944b23d9a63c422a0f3",
-  "sourceSha256": "1e8ded40499f0186f205f657c90c9eab2ef8174b6fdbfd4ccaf2848f5f781e35",
+  "head": "ac0e3999771b6c801ecafd452d4f696b30d90fce",
+  "sourceSha256": "7abdac468d9ab48612aa02674f2de6d98fe2ebcca4e11ae319a2a5a40bcae00d",
   "counts": {
     "public": {
       "skills": 32,
@@ -40387,6 +40387,11 @@
         "path": "tests/lint/inventory-graph-drift.test.ts"
       },
       {
+        "id": "tests/lint/setup-phases-drift.test.ts",
+        "kind": "other",
+        "path": "tests/lint/setup-phases-drift.test.ts"
+      },
+      {
         "id": "tests/lint/skill-parallel-caveats.test.ts",
         "kind": "other",
         "path": "tests/lint/skill-parallel-caveats.test.ts"
@@ -76264,6 +76269,31 @@
         "kind": "imports"
       },
       {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/setup-phases-drift.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/lint/skill-parallel-caveats.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -76365,12 +76395,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6832,
-      "edgeCount": 7185,
-      "importEdgeCount": 5901,
+      "nodeCount": 6833,
+      "edgeCount": 7190,
+      "importEdgeCount": 5906,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "005212013533769c02f675ac2b10233a12770dd6d8c375efc57d5047c51f87b0"
+  "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
+  "manifestSha256": "03f3480bbcd693936ddc3efad835dbc86f6c25a4b8eb7dd0b6e6cc3817dae335"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2f4b1ec9ed0bc1233d6f359f229518a9bbfe8e4e",
-    "sourceSha256": "a92d33ca8d0d44e776e886fb07a2af47a6e558efd940e61e44c999840f6c6fb4",
+    "head": "367375e9ca11fe5ee506b4a3c112763acf37f405",
+    "sourceSha256": "98414b9b5c9702444ba058de5ef735847061ee0b69ea405060e44156e6dc1b5a",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2f4b1ec9ed0bc1233d6f359f229518a9bbfe8e4e",
-  "sourceSha256": "a92d33ca8d0d44e776e886fb07a2af47a6e558efd940e61e44c999840f6c6fb4",
+  "head": "367375e9ca11fe5ee506b4a3c112763acf37f405",
+  "sourceSha256": "98414b9b5c9702444ba058de5ef735847061ee0b69ea405060e44156e6dc1b5a",
   "counts": {
     "public": {
       "skills": 32,
@@ -40387,11 +40387,6 @@
         "path": "tests/lint/inventory-graph-drift.test.ts"
       },
       {
-        "id": "tests/lint/setup-phases-drift.test.ts",
-        "kind": "other",
-        "path": "tests/lint/setup-phases-drift.test.ts"
-      },
-      {
         "id": "tests/lint/skill-parallel-caveats.test.ts",
         "kind": "other",
         "path": "tests/lint/skill-parallel-caveats.test.ts"
@@ -68064,6 +68059,11 @@
         "kind": "imports"
       },
       {
+        "from": "src/team/__tests__/model-contract.test.ts",
+        "to": "src/team/model-contract.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/team/__tests__/multirepo-workspace-team.test.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -76259,31 +76259,6 @@
         "kind": "imports"
       },
       {
-        "from": "tests/lint/setup-phases-drift.test.ts",
-        "to": "external:child_process",
-        "kind": "imports"
-      },
-      {
-        "from": "tests/lint/setup-phases-drift.test.ts",
-        "to": "external:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "tests/lint/setup-phases-drift.test.ts",
-        "to": "external:os",
-        "kind": "imports"
-      },
-      {
-        "from": "tests/lint/setup-phases-drift.test.ts",
-        "to": "external:path",
-        "kind": "imports"
-      },
-      {
-        "from": "tests/lint/setup-phases-drift.test.ts",
-        "to": "external:vitest",
-        "kind": "imports"
-      },
-      {
         "from": "tests/lint/skill-parallel-caveats.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -76385,12 +76360,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6833,
-      "edgeCount": 7188,
-      "importEdgeCount": 5905,
+      "nodeCount": 6832,
+      "edgeCount": 7184,
+      "importEdgeCount": 5900,
       "registerEdgeCount": 53
     }
   },
-  "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
-  "manifestSha256": "a814f4b00a41a0ac1eb2c7ff4cd3c7fa1f629efd0a189fe81de588d71df03aef"
+  "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
+  "manifestSha256": "9ed7fa9ef40352f405ba061bec184886b6d03f6f4c96dd907e1efc4e867f1b12"
 }

--- a/src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts
+++ b/src/hooks/__tests__/team-dispatch-prompt-readiness.test.ts
@@ -192,4 +192,32 @@ describe('team dispatch provider-aware prompt readiness', () => {
       last_reason: 'tmux_send_keys_confirmed_active_task',
     });
   });
+
+  it('fails closed without sending keys when Cursor exits on the workspace-trust banner', async () => {
+    await seed('cursor');
+    tmuxUtilsMocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'display-message') return { stdout: '0\n', stderr: '' };
+      if (args[0] === 'capture-pane') {
+        return {
+          stdout: [
+            '⚠ Workspace Trust Required',
+            'Do you trust the contents of this directory?',
+            'Pass --trust, --yolo, or -f if you trust this directory',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const { result, request } = await runDefaultInjector();
+
+    expect(result).toMatchObject({ processed: 1, skipped: 0, failed: 1 });
+    expect(request).toMatchObject({
+      status: 'failed',
+      attempt_count: 1,
+      last_reason: 'cursor_workspace_untrusted',
+    });
+    expect(tmuxUtilsMocks.tmuxExecAsync.mock.calls.some(([args]) => args[0] === 'send-keys')).toBe(false);
+  });
 });

--- a/src/hooks/team-dispatch-hook.ts
+++ b/src/hooks/team-dispatch-hook.ts
@@ -21,6 +21,7 @@ import { tmuxExecAsync } from '../cli/tmux-utils.js';
 import { getOmcRoot } from '../lib/worktree-paths.js';
 import type { CliAgentType } from '../team/model-contract.js';
 import { isCliAgentType, paneLineLooksLikeIdlePrompt } from '../team/pane-readiness.js';
+import { paneHasCursorWorkspaceTrustPrompt } from '../team/tmux-session.js';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -401,13 +402,19 @@ async function defaultInjector(request: DispatchRequest, config: TeamConfig, _cw
   const attemptCountAtStart = Number.isFinite(request.attempt_count) ? Math.max(0, Math.floor(request.attempt_count)) : 0;
 
   let preCaptureHasTrigger = false;
-  if (attemptCountAtStart >= 1) {
-    try {
-      const preCapture = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], { timeout: 2000 });
-      preCaptureHasTrigger = capturedPaneContainsTrigger(preCapture.stdout, request.trigger_message);
-    } catch {
-      preCaptureHasTrigger = false;
+  let preCapture = '';
+  try {
+    const captured = await tmuxExecAsync(['capture-pane', '-t', paneTarget, '-p', '-S', '-8'], { timeout: 2000 });
+    preCapture = safeString(captured.stdout);
+    if (targetProvider === 'cursor' && paneHasCursorWorkspaceTrustPrompt(preCapture)) {
+      return { ok: false, reason: 'cursor_workspace_untrusted' };
     }
+    if (attemptCountAtStart >= 1) {
+      preCaptureHasTrigger = capturedPaneContainsTrigger(preCapture, request.trigger_message);
+    }
+  } catch {
+    preCapture = '';
+    preCaptureHasTrigger = false;
   }
 
   const shouldTypePrompt = attemptCountAtStart === 0 || !preCaptureHasTrigger;

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -21,6 +21,7 @@ import {
   buildValidatedWorkerLaunchDescriptor,
   validateWorkerLaunchDescriptor,
 } from '../model-contract.js';
+import type { CliAgentType } from '../model-contract.js';
 
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -372,31 +373,50 @@ describe('model-contract', () => {
       const withModel = buildLaunchArgs('grok', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'grok-4-fast' });
       expect(withModel).toEqual(['--always-approve', '--model', 'grok-4-fast']);
     });
-    it('cursor emits no flags without a model and appends --model <m> when given (issue #3880)', () => {
+    it('cursor leads with --force --trust and appends --model <m> when given (issue #3880)', () => {
       const noModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp' });
-      expect(noModel).toEqual([]);
+      expect(noModel).toEqual(['--force', '--trust']);
       expect(noModel).not.toContain('--model');
 
       const emptyModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: '' });
-      expect(emptyModel).toEqual([]);
+      expect(emptyModel).toEqual(['--force', '--trust']);
       expect(emptyModel).not.toContain('--model');
 
       const withModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'cursor-grok-4.6-high' });
-      expect(withModel).toEqual(['--model', 'cursor-grok-4.6-high']);
+      expect(withModel).toEqual(['--force', '--trust', '--model', 'cursor-grok-4.6-high']);
     });
     it('cursor appends extraFlags after the model flag (issue #3880)', () => {
       const args = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'composer-2.5', extraFlags: ['--foo'] });
-      expect(args).toEqual(['--model', 'composer-2.5', '--foo']);
+      expect(args).toEqual(['--force', '--trust', '--model', 'composer-2.5', '--foo']);
 
       const noModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', extraFlags: ['--foo'] });
-      expect(noModel).toEqual(['--foo']);
+      expect(noModel).toEqual(['--force', '--trust', '--foo']);
     });
-    it('cursor worker argv leads with the cursor-agent binary then --model (issue #3880)', () => {
+    it('cursor worker argv leads with the cursor-agent binary then approval flags', () => {
       const argv = buildWorkerArgv('cursor', {
         teamName: 'cursor-team', workerName: 'w', cwd: '/tmp',
         model: 'cursor-grok-4.6-high', resolvedBinaryPath: '/usr/local/bin/cursor-agent',
       });
-      expect(argv).toEqual(['/usr/local/bin/cursor-agent', '--model', 'cursor-grok-4.6-high']);
+      expect(argv).toEqual([
+        '/usr/local/bin/cursor-agent', '--force', '--trust', '--model', 'cursor-grok-4.6-high',
+      ]);
+    });
+    it('every CLI provider carries an approval-bypass flag so no worker pane can block on a prompt', () => {
+      // A team worker pane has nobody to answer an approval or trust question.
+      // cursor was the sole provider launched bare, which stranded it on
+      // "Workspace Trust Required" in any directory cursor had not seen before.
+      const approvalFlags: Record<string, string> = {
+        claude: '--dangerously-skip-permissions',
+        codex: '--dangerously-bypass-approvals-and-sandbox',
+        gemini: '--approval-mode',
+        grok: '--always-approve',
+        antigravity: '--dangerously-skip-permissions',
+        cursor: '--trust',
+      };
+      for (const [agent, flag] of Object.entries(approvalFlags)) {
+        const args = buildLaunchArgs(agent as CliAgentType, { teamName: 't', workerName: 'w', cwd: '/tmp' });
+        expect(args, `${agent} must bypass approval prompts`).toContain(flag);
+      }
     });
     it('passes model flag when specified', () => {
       const args = buildLaunchArgs('codex', { teamName: 't', workerName: 'w', cwd: '/tmp', model: 'gpt-4' });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -816,6 +816,17 @@ describe('model-contract', () => {
       validated.args.push('--changed');
       expect(source.args).toEqual(['--flag']);
     });
+
+    it('normalizes persisted Cursor descriptors to the required trust flags', () => {
+      const validated = validateWorkerLaunchDescriptor({
+        schema_version: 1,
+        provider: 'cursor',
+        model: null,
+        binary: '/usr/local/bin/cursor-agent',
+        args: ['--yolo', '--model', 'composer-2.5', '--trust', '--force'],
+      });
+      expect(validated.args).toEqual(['--force', '--trust', '--model', 'composer-2.5']);
+    });
   });
 
 });

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -401,6 +401,13 @@ describe('model-contract', () => {
       expect(countArg(args, '--force')).toBe(1);
       expect(countArg(args, '--trust')).toBe(1);
     });
+    it('cursor removes documented force aliases from extra flags', () => {
+      const args = buildLaunchArgs('cursor', {
+        teamName: 't', workerName: 'w', cwd: '/tmp',
+        extraFlags: ['-f', '--yolo', '--force', '--trust'],
+      });
+      expect(args).toEqual(['--force', '--trust']);
+    });
     it('cursor worker argv leads with the cursor-agent binary then approval flags', () => {
       const argv = buildWorkerArgv('cursor', {
         teamName: 'cursor-team', workerName: 'w', cwd: '/tmp',

--- a/src/team/__tests__/model-contract.test.ts
+++ b/src/team/__tests__/model-contract.test.ts
@@ -392,6 +392,15 @@ describe('model-contract', () => {
       const noModel = buildLaunchArgs('cursor', { teamName: 't', workerName: 'w', cwd: '/tmp', extraFlags: ['--foo'] });
       expect(noModel).toEqual(['--force', '--trust', '--foo']);
     });
+    it('cursor keeps required trust flags singular when extra flags repeat them', () => {
+      const args = buildLaunchArgs('cursor', {
+        teamName: 't', workerName: 'w', cwd: '/tmp',
+        extraFlags: ['--trust', '--force', '--trust', '--foo'],
+      });
+      expect(args).toEqual(['--force', '--trust', '--foo']);
+      expect(countArg(args, '--force')).toBe(1);
+      expect(countArg(args, '--trust')).toBe(1);
+    });
     it('cursor worker argv leads with the cursor-agent binary then approval flags', () => {
       const argv = buildWorkerArgv('cursor', {
         teamName: 'cursor-team', workerName: 'w', cwd: '/tmp',

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -380,6 +380,17 @@ describe('buildWorkerStartCommand', () => {
     expect(cmd).not.toContain('pane_id=%%2');
   });
 
+  it('rejects CRLF injection in native Windows provider argv', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    vi.stubEnv('COMSPEC', 'C:\\Windows\\System32\\cmd.exe');
+
+    expect(() => buildWorkerStartCommand({
+      teamName: 't', workerName: 'w', envVars: {},
+      launchBinary: 'C:\\Program Files\\Cursor\\cursor-agent.exe',
+      launchArgs: ['--model', 'safe\r\nset PWNED=1'], cwd: 'C:\\repo',
+    })).toThrow('contains CR, LF, or NUL');
+  });
+
   it('escapes psmux cmd.exe env vars and quoted launch args without PowerShell syntax', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     vi.stubEnv('PSMUX_SESSION', 'psmux-session-1');
@@ -756,6 +767,20 @@ describe('pane readiness startup banners', () => {
     // The pane is dead: treating it as ready would hand work to a gone process.
     expect(paneLooksReady(capture, 'cursor')).toBe(false);
     expect(paneHasActiveTask(capture, 'cursor')).toBe(false);
+  });
+
+  it('gives the Cursor trust banner precedence and keeps it provider-scoped', () => {
+    const capture = [
+      '⚠ Workspace Trust Required',
+      'Do you trust the contents of this directory?',
+      '› 1. Yes, continue',
+      '  2. No, quit',
+      "  • Pass --trust, --yolo, or -f if you trust this directory",
+    ].join('\n');
+
+    expect(paneHasTrustPrompt(capture, 'cursor')).toBe(true);
+    expect(paneLooksReady(capture, 'cursor')).toBe(false);
+    expect(paneLooksReady(capture, 'claude')).toBe(true);
   });
 
   it('still treats actual prompt lines as ready', () => {

--- a/src/team/__tests__/tmux-session.test.ts
+++ b/src/team/__tests__/tmux-session.test.ts
@@ -735,6 +735,29 @@ describe('pane readiness startup banners', () => {
     expect(paneHasActiveTask(capture)).toBe(false);
   });
 
+  it('detects the cursor-agent workspace-trust banner and refuses to call it ready', () => {
+    // Verbatim capture from `cursor-agent` launched in tmux on an untrusted
+    // directory. It offers no numbered choice and the process exits, unlike
+    // the dismissible Claude/Codex prompts above.
+    const capture = [
+      '⚠ Workspace Trust Required',
+      '',
+      '  Cursor Agent can execute code and access files in this directory.',
+      '  Do you trust the contents of this directory?',
+      '',
+      '    /private/tmp/ct-nf2',
+      '',
+      '  To proceed, you can either:',
+      "    • Run 'agent' interactively to decide",
+      '    • Pass --trust, --yolo, or -f if you trust this directory',
+    ].join('\n');
+
+    expect(paneHasTrustPrompt(capture)).toBe(true);
+    // The pane is dead: treating it as ready would hand work to a gone process.
+    expect(paneLooksReady(capture, 'cursor')).toBe(false);
+    expect(paneHasActiveTask(capture, 'cursor')).toBe(false);
+  });
+
   it('still treats actual prompt lines as ready', () => {
     expect(paneLooksReady('Welcome\n❯ ')).toBe(true);
     expect(paneLooksReady('Welcome\n> ')).toBe(true);

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -303,10 +303,11 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       // created per worker, so they always hit that path. `omc ask cursor`
       // already launches with `--force --trust` for the same reason.
       const args = ['--force', '--trust'];
+      const extra = extraFlags.filter(flag => flag !== '--force' && flag !== '--trust');
       // `--model <id>` is a documented global option; ids come from
       // `cursor-agent --list-models` (e.g. cursor-grok-4.6-high, composer-2.5).
       if (model) args.push('--model', model);
-      return [...args, ...extraFlags];
+      return [...args, ...extra];
     },
     parseOutput(rawOutput: string): string {
       return rawOutput.trim();

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -295,10 +295,16 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
     // `-p/--print` path is deliberately unused here (same stance as codex).
     supportsPromptMode: false,
     buildLaunchArgs(model?: string, extraFlags: string[] = []): string[] {
-      // cursor-agent owns its own session/auth state, so no approval flags are
-      // needed. `--model <id>` is a documented global option; ids come from
+      // `--force` suppresses per-command approval prompts and `--trust` accepts
+      // the workspace, which together are cursor-agent's equivalent of the
+      // approval bypass every other provider already passes. Without them a
+      // worker pane opened on a directory cursor has not seen before stops at
+      // "Workspace Trust Required" and exits; team worktrees are freshly
+      // created per worker, so they always hit that path. `omc ask cursor`
+      // already launches with `--force --trust` for the same reason.
+      const args = ['--force', '--trust'];
+      // `--model <id>` is a documented global option; ids come from
       // `cursor-agent --list-models` (e.g. cursor-grok-4.6-high, composer-2.5).
-      const args: string[] = [];
       if (model) args.push('--model', model);
       return [...args, ...extraFlags];
     },

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -303,7 +303,7 @@ const CONTRACTS: Record<CliAgentType, CliAgentContract> = {
       // created per worker, so they always hit that path. `omc ask cursor`
       // already launches with `--force --trust` for the same reason.
       const args = ['--force', '--trust'];
-      const extra = extraFlags.filter(flag => flag !== '--force' && flag !== '--trust');
+      const extra = extraFlags.filter(flag => !['--force', '-f', '--yolo', '--trust'].includes(flag));
       // `--model <id>` is a documented global option; ids come from
       // `cursor-agent --list-models` (e.g. cursor-grok-4.6-high, composer-2.5).
       if (model) args.push('--model', model);

--- a/src/team/model-contract.ts
+++ b/src/team/model-contract.ts
@@ -424,12 +424,19 @@ export function validateWorkerLaunchDescriptor(value: unknown): WorkerLaunchDesc
     throw new Error('Invalid worker launch descriptor');
   }
   getContract(descriptor.provider as CliAgentType);
+  const args = descriptor.provider === 'cursor'
+    ? [
+        '--force',
+        '--trust',
+        ...descriptor.args.filter(flag => !['--force', '-f', '--yolo', '--trust'].includes(flag)),
+      ]
+    : [...descriptor.args];
   return {
     schema_version: 1,
     provider: descriptor.provider as CliAgentType,
     model: descriptor.model,
     binary: descriptor.binary,
-    args: [...descriptor.args],
+    args,
   };
 }
 

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1585,7 +1585,7 @@ export async function killOwnedWorkerPane(ownership: WorkerPaneOwnership): Promi
   await tmuxExecAsync(['kill-pane', '-t', ownership.paneId]);
 }
 
-type PaneTrustPromptKind = 'directory' | 'codex_hooks';
+type PaneTrustPromptKind = 'directory' | 'codex_hooks' | 'cursor_workspace_trust';
 
 function detectPaneTrustPromptKind(captured: string): PaneTrustPromptKind | null {
   const lines = captured.split('\n').map(l => l.replace(/\r/g, '').trim()).filter(l => l.length > 0);
@@ -1594,6 +1594,18 @@ function detectPaneTrustPromptKind(captured: string): PaneTrustPromptKind | null
   const hasDirectoryQuestion = tail.some(l => /Do you trust the contents of this directory\?/i.test(l));
   const hasDirectoryChoices = tail.some(l => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
   if (hasDirectoryQuestion && hasDirectoryChoices) return 'directory';
+
+  // cursor-agent asks the same question but offers no selectable answer: it
+  // prints "Workspace Trust Required", tells the operator to pass --trust/-f,
+  // and exits. There is nothing to dismiss, so this is reported as its own
+  // kind and never answered with keystrokes. Launch args carry `--force
+  // --trust` precisely so this state is unreachable; seeing it means a pane
+  // was started without them.
+  const hasCursorTrustBanner = tail.some(l => /Workspace Trust Required/i.test(l));
+  const hasCursorTrustHint = tail.some(l => /Pass\s+--trust,\s*--yolo,\s*or\s+-f/i.test(l));
+  if (hasCursorTrustBanner && (hasCursorTrustHint || hasDirectoryQuestion)) {
+    return 'cursor_workspace_trust';
+  }
 
   const hasHookReview = tail.some(l => /Hooks need review/i.test(l));
   const hasHookTrustChoice = tail.some(l => /Continue without trusting/i.test(l));
@@ -1660,6 +1672,10 @@ export function paneLooksReady(captured: string, provider?: CliAgentType): boole
     .map(line => line.replace(/\r/g, '').trimEnd())
     .filter(line => line.trim() !== '');
   if (lines.length === 0) return false;
+  // A dismissible trust prompt still means the CLI is up and answering. The
+  // cursor workspace-trust banner is the opposite: the process already exited,
+  // so the pane is not ready and never will be without `--trust`.
+  if (detectPaneTrustPromptKind(content) === 'cursor_workspace_trust') return false;
   if (paneHasTrustPrompt(content)) return true;
   if (paneIsBootstrapping(content, provider)) return false;
 
@@ -1726,7 +1742,7 @@ async function paneInCopyMode(paneId: string): Promise<boolean> {
 
 export type StartupPaneReadyResult =
   | { ok: true }
-  | { ok: false; reason: 'attempt_inactive' | 'ownership_mismatch' | 'copy_mode' | 'copy_mode_unknown' | 'capture_failed' | 'selector_unsupported' | 'selector_persistent' | 'pane_busy' | 'readiness_timeout' };
+  | { ok: false; reason: 'attempt_inactive' | 'ownership_mismatch' | 'copy_mode' | 'copy_mode_unknown' | 'capture_failed' | 'selector_unsupported' | 'selector_persistent' | 'cursor_workspace_untrusted' | 'pane_busy' | 'readiness_timeout' };
 
 async function sendLiteralPaneText(paneId: string, text: string): Promise<void> {
   if (isCmuxSurfaceTarget(paneId)) {
@@ -1765,6 +1781,12 @@ export async function waitForStartupPaneReady(
     const captured = observation.captured;
     const selector = detectPaneTrustPromptKind(captured);
     if (selector) {
+      // cursor-agent's workspace-trust banner has no selectable answer and the
+      // process is already gone, so there is nothing to drive. Report it under
+      // its own reason instead of blocking until readiness_timeout.
+      if (selector === 'cursor_workspace_trust') {
+        return { ok: false, reason: 'cursor_workspace_untrusted' };
+      }
       const providerSupportsSelector = selector === 'codex_hooks'
         ? context.provider === 'codex'
         : context.provider === 'codex' || context.provider === 'claude';
@@ -1890,6 +1912,11 @@ export async function sendToWorker(
     const paneBusy = paneHasActiveTask(initialCapture);
 
     const trustPromptKind = detectPaneTrustPromptKind(initialCapture);
+    if (trustPromptKind === 'cursor_workspace_trust') {
+      // Nothing to dismiss: cursor-agent printed the banner and exited. Sending
+      // keys here would type into a dead pane.
+      return false;
+    }
     if (trustPromptKind === 'directory') {
       await sendKey('C-m');
       await sleep(120);

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -723,6 +723,10 @@ function escapeForCmdSet(value: string): string {
   return value.replace(/(["%])/g, '$1$1');
 }
 
+function assertSafeCmdValue(value: string): void {
+  if (/[\r\n\0]/.test(value)) throw new Error('Invalid Windows command value: contains CR, LF, or NUL');
+}
+
 
 function shellNameFromPath(shellPath: string): string {
   const shellName = basename(shellPath.replace(/\\/g, '/'));
@@ -805,10 +809,14 @@ export function buildWorkerStartCommand(config: WorkerPaneConfig): string {
     const envPrefix = Object.entries(windowsEnvVars)
       .map(([key, value]) => {
         assertSafeEnvKey(key);
+        assertSafeCmdValue(value);
         return `set "${key}=${escapeForCmdSet(value)}"`;
       })
       .join(' && ');
-    const launch = launchWords.map(part => `"${escapeForCmdSet(part)}"`).join(' ');
+    const launch = launchWords.map(part => {
+      assertSafeCmdValue(part);
+      return `"${escapeForCmdSet(part)}"`;
+    }).join(' ');
     const cmdBody = envPrefix ? `${envPrefix} && ${launch}` : launch;
     return `${shell} /d /s /c "${cmdBody}" & exit /b`;
   }
@@ -1587,9 +1595,16 @@ export async function killOwnedWorkerPane(ownership: WorkerPaneOwnership): Promi
 
 type PaneTrustPromptKind = 'directory' | 'codex_hooks' | 'cursor_workspace_trust';
 
-function detectPaneTrustPromptKind(captured: string): PaneTrustPromptKind | null {
+function detectPaneTrustPromptKind(captured: string, provider?: CliAgentType): PaneTrustPromptKind | null {
   const lines = captured.split('\n').map(l => l.replace(/\r/g, '').trim()).filter(l => l.length > 0);
   const tail = lines.slice(-12);
+
+  const hasCursorTrustBanner = tail.some(l => /Workspace Trust Required/i.test(l));
+  const hasCursorTrustHint = tail.some(l => /Pass\s+--trust,\s*--yolo,\s*or\s+-f/i.test(l));
+  if ((provider === undefined || provider === 'cursor')
+    && hasCursorTrustBanner && (hasCursorTrustHint || tail.some(l => /Do you trust the contents of this directory\?/i.test(l)))) {
+    return 'cursor_workspace_trust';
+  }
 
   const hasDirectoryQuestion = tail.some(l => /Do you trust the contents of this directory\?/i.test(l));
   const hasDirectoryChoices = tail.some(l => /Yes,\s*continue|No,\s*quit|Press enter to continue/i.test(l));
@@ -1601,12 +1616,6 @@ function detectPaneTrustPromptKind(captured: string): PaneTrustPromptKind | null
   // kind and never answered with keystrokes. Launch args carry `--force
   // --trust` precisely so this state is unreachable; seeing it means a pane
   // was started without them.
-  const hasCursorTrustBanner = tail.some(l => /Workspace Trust Required/i.test(l));
-  const hasCursorTrustHint = tail.some(l => /Pass\s+--trust,\s*--yolo,\s*or\s+-f/i.test(l));
-  if (hasCursorTrustBanner && (hasCursorTrustHint || hasDirectoryQuestion)) {
-    return 'cursor_workspace_trust';
-  }
-
   const hasHookReview = tail.some(l => /Hooks need review/i.test(l));
   const hasHookTrustChoice = tail.some(l => /Continue without trusting/i.test(l));
   const hasHookConfirm = tail.some(l => /Press enter to confirm or esc to go back/i.test(l));
@@ -1615,8 +1624,8 @@ function detectPaneTrustPromptKind(captured: string): PaneTrustPromptKind | null
   return null;
 }
 
-export function paneHasTrustPrompt(captured: string): boolean {
-  return detectPaneTrustPromptKind(captured) !== null;
+export function paneHasTrustPrompt(captured: string, provider?: CliAgentType): boolean {
+  return detectPaneTrustPromptKind(captured, provider) !== null;
 }
 
 function paneHasClaudeStartupBanner(captured: string, provider?: CliAgentType): boolean {
@@ -1675,8 +1684,8 @@ export function paneLooksReady(captured: string, provider?: CliAgentType): boole
   // A dismissible trust prompt still means the CLI is up and answering. The
   // cursor workspace-trust banner is the opposite: the process already exited,
   // so the pane is not ready and never will be without `--trust`.
-  if (detectPaneTrustPromptKind(content) === 'cursor_workspace_trust') return false;
-  if (paneHasTrustPrompt(content)) return true;
+  if (detectPaneTrustPromptKind(content, provider) === 'cursor_workspace_trust') return false;
+  if (paneHasTrustPrompt(content, provider)) return true;
   if (paneIsBootstrapping(content, provider)) return false;
 
   const lastLine = lines[lines.length - 1]!;
@@ -1779,7 +1788,7 @@ export async function waitForStartupPaneReady(
     const observation = await capturePaneObservation(context.ownership.paneId, { operation: 'startup-readiness' });
     if (!observation.ok) return { ok: false, reason: 'capture_failed' };
     const captured = observation.captured;
-    const selector = detectPaneTrustPromptKind(captured);
+    const selector = detectPaneTrustPromptKind(captured, context.provider);
     if (selector) {
       // cursor-agent's workspace-trust banner has no selectable answer and the
       // process is already gone, so there is nothing to drive. Report it under

--- a/src/team/tmux-session.ts
+++ b/src/team/tmux-session.ts
@@ -1628,6 +1628,10 @@ export function paneHasTrustPrompt(captured: string, provider?: CliAgentType): b
   return detectPaneTrustPromptKind(captured, provider) !== null;
 }
 
+export function paneHasCursorWorkspaceTrustPrompt(captured: string): boolean {
+  return detectPaneTrustPromptKind(captured, 'cursor') === 'cursor_workspace_trust';
+}
+
 function paneHasClaudeStartupBanner(captured: string, provider?: CliAgentType): boolean {
   const lines = captured
     .split('\n')
@@ -1858,7 +1862,7 @@ export async function retryStartupInboxSubmit(
   const copyMode = await paneCopyModeObservation(context.ownership.paneId);
   if (copyMode !== false) return 'unavailable';
   const observation = await capturePaneObservation(context.ownership.paneId, { operation: 'startup-submit-retry' });
-  if (!observation.ok || detectPaneTrustPromptKind(observation.captured)) return 'unavailable';
+  if (!observation.ok || detectPaneTrustPromptKind(observation.captured, context.provider)) return 'unavailable';
   if (paneHasActiveTask(observation.captured, context.provider)) return 'pane_busy';
   if (!paneTailContainsLiteralLine(observation.captured, message)) return 'unavailable';
   try {


### PR DESCRIPTION
Cursor was the only provider of six launched with no approval-bypass flag, and the trust banner it stops on was invisible to the pane detector. Two halves of one failure; independent of #3880's remaining phases (no file overlap).

## 1. No approval flags

```
claude       --dangerously-skip-permissions
codex        --dangerously-bypass-approvals-and-sandbox
gemini       --approval-mode yolo
grok         --always-approve
antigravity  --dangerously-skip-permissions
cursor       (none)
```

A worker pane has nobody to answer a prompt. On a directory `cursor-agent` has not seen before it prints "Workspace Trust Required" and exits. **Team worktrees are created fresh per worker**, so worktree mode hits this on every launch.

Reproduced in tmux on an untrusted directory:

```console
$ cursor-agent                      # no flags — current dev behavior
⚠ Workspace Trust Required
  Cursor Agent can execute code and access files in this directory.
  Do you trust the contents of this directory?
    /private/tmp/ct-nf2
  To proceed, you can either:
    • Run 'agent' interactively to decide
    • Pass --trust, --yolo, or -f if you trust this directory
EXIT=0                              # pane dead, never reaches a prompt

$ cursor-agent --force --trust
  Cursor Agent v2026.08.11-e8db854
  Tip: Use /run-everything to skip all approvals.
```

`omc ask cursor` already launches as `cursor-agent --print --force --trust --sandbox disabled` (`src/cli/__tests__/ask.test.ts:662`). The repo knew the requirement; only the team launch path missed it.

`--sandbox disabled` is deliberately not carried over — `--force` covers command approval, and the ask path needs the extra latitude for one-shot execution that a persistent pane does not.

**On `--trust` in interactive mode:** the web docs label it "headless mode only". That is wrong, or at least stale. The local `--help` says plain "Trust the current workspace without prompting", and the tmux run above is interactive. Verified rather than assumed.

## 2. The banner was undetectable

`detectPaneTrustPromptKind` matched the question but demanded a selectable answer. Feeding it the real capture:

```
hasDirectoryQuestion: true      ← "Do you trust the contents of this directory?"
hasDirectoryChoices : false     ← no "Yes, continue" / "No, quit"
=> detected: false
```

So the pane burned the full readiness timeout with no diagnosis.

Cursor's banner is **not dismissible** — the process is already gone. Folding it into `'directory'` would send `C-m` into a dead pane, so it gets its own kind:

- `paneLooksReady` excludes it. A dismissible prompt means the CLI is up and answering; this means the opposite.
- Readiness returns `cursor_workspace_untrusted` instead of `readiness_timeout`, and that string reaches operator-visible failure text.
- The send-keys path returns early rather than typing into nothing.

With the launch flags in place this state is unreachable. The detector is defence in depth for panes started some other way, and converts a silent hang into a named cause.

## Verification

| Check | Result |
|---|---|
| `model-contract` + `tmux-session` + `tmux-session.spawn` | 149 passed |
| `tsc --noEmit` | clean |
| `eslint` (4 changed files) | clean |
| `inventory-graph-drift` | 11 passed |
| `src/team/__tests__` | 1721 passed / 9 failed |

The 9 failures are 4 pre-existing files (`runtime-owner-busy`, `runtime-owner-client`, `runtime-v2.shutdown-pane-cleanup`, `worker-launch-posix-transport`), unchanged from `dev`.

Tests added:

- launch args lead with `--force --trust`, with and without a model, and `extraFlags` ordering
- `buildWorkerArgv` places binary → approval flags → model
- **a matrix asserting all six providers carry an approval-bypass flag**, so no provider can regress to bare launch again
- the verbatim tmux capture is a fixture: detected as a trust prompt, and explicitly *not* ready

Related to #3880 (cursor CLI support) but standalone — this is an executor-path bug that predates the reviewer work.
