### PR TITLE
fix(team): repair post-merge worker verdict lifecycle

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "aa7e21df8e595d509c0634fee80f7c5267a0652d",
-    "sourceSha256": "44f0043423f8aa3a6d6513701c324026740dc64260a5eb8487a29f078d6ba511",
+    "head": "bbf86c38e627c20cf111d375e1cab3c8516d89b8",
+    "sourceSha256": "cd39c3630247e96097e8b3a2f0b45e96fe64f836d1ee9b7a79ed7652de57b9a4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "aa7e21df8e595d509c0634fee80f7c5267a0652d",
-  "sourceSha256": "44f0043423f8aa3a6d6513701c324026740dc64260a5eb8487a29f078d6ba511",
+  "head": "bbf86c38e627c20cf111d375e1cab3c8516d89b8",
+  "sourceSha256": "cd39c3630247e96097e8b3a2f0b45e96fe64f836d1ee9b7a79ed7652de57b9a4",
   "counts": {
     "public": {
       "skills": 32,
@@ -68824,6 +68824,11 @@
         "kind": "imports"
       },
       {
+        "from": "src/team/__tests__/runtime-v2-role-routing.test.ts",
+        "to": "src/team/state-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/team/__tests__/runtime-v2.cursor-routing.test.ts",
         "to": "external:vitest",
         "kind": "imports"
@@ -76356,11 +76361,11 @@
     ],
     "stats": {
       "nodeCount": 6832,
-      "edgeCount": 7183,
-      "importEdgeCount": 5899,
+      "edgeCount": 7184,
+      "importEdgeCount": 5900,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "c30385d45701c539596412c30ce611ee970d6abc22843842fa5aa026f097013e"
+  "manifestSha256": "49b0337d8b7e62afea41303fbb6b6cb883a8393aa8be199f0b46247554def94c"
 }

--- a/src/team/__tests__/cli-worker-contract.test.ts
+++ b/src/team/__tests__/cli-worker-contract.test.ts
@@ -108,6 +108,13 @@ describe('cli-worker-contract', () => {
       const p = cliWorkerOutputFilePath('C:\\proj\\.omc\\state\\team\\foo', 'worker-1');
       expect(p).toBe('C:/proj/.omc/state/team/foo/workers/worker-1/verdict.json');
     });
+
+    it('scopes replacement artifacts to the assignment and launch attempt', () => {
+      const p = cliWorkerOutputFilePath('/repo/.omc/state/team/foo', 'worker-1', {
+        taskId: '7', assignmentId: 'recovery-2-attempt-9',
+      });
+      expect(p).toBe('/repo/.omc/state/team/foo/workers/worker-1/verdict-7-recovery-2-attempt-9.json');
+    });
   });
 
   describe('parseCliWorkerVerdict', () => {

--- a/src/team/__tests__/recovery-reservation-claim.test.ts
+++ b/src/team/__tests__/recovery-reservation-claim.test.ts
@@ -87,4 +87,24 @@ describe('recovery reservation claim protocol', () => {
     const replay = await adoptRecoveryReservations(['1', '2'], 'replacement', { recoveryId: 'recovery', requestId: 'request', replacementGeneration: 2, adoptionToken: 'adoption-token' }, d);
     expect(replay.map((result) => result.ok && result.replayed)).toEqual([true, true]);
   });
+
+  it('rebinds a replayed adoption to the active replacement launch attempt', async () => {
+    const task: TeamTaskV2 = {
+      ...liveTask(),
+      owner: 'replacement',
+      claim: { owner: 'replacement', token: 'replacement-token', leased_until: '2099-01-01T00:00:00.000Z', launch_attempt_id: 'stale-attempt' },
+      recovery_adoption: {
+        recovery_id: 'recovery', request_id: 'request', continuation_sequence: 4,
+        checkpoint_path: '/checkpoint', checkpoint_hash: 'checkpoint-hash',
+        replacement_worker: 'replacement', replacement_generation: 2,
+        adopted_at: '2026-01-01T00:00:00.000Z',
+      },
+    };
+    const tasks = { '1': task };
+    const adopted = await adoptRecoveryReservations(['1'], 'replacement', {
+      recoveryId: 'recovery', requestId: 'request', replacementGeneration: 2, adoptionToken: 'adoption-token',
+    }, { ...deps(tasks), launchAttemptId: 'active-attempt' });
+
+    expect(adopted[0]).toMatchObject({ ok: true, replayed: true, task: { claim: { launch_attempt_id: 'active-attempt' } } });
+  });
 });

--- a/src/team/__tests__/runtime-v2-role-routing.test.ts
+++ b/src/team/__tests__/runtime-v2-role-routing.test.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 import { getOmcRoot } from '../../lib/worktree-paths.js';
+import { TeamPaths, absPath } from '../state-paths.js';
 
 const mocks = vi.hoisted(() => ({
   isWorkerAlive: vi.fn(async () => false),
@@ -91,6 +92,9 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
     verdictRole?: string;
     omitVerdictFile?: boolean;
     invalidVerdictJson?: boolean;
+    staleProcessingVerdict?: 'approve' | 'revise' | 'reject';
+    expiredLease?: boolean;
+    delegationRequired?: boolean;
   }): Promise<{ teamRoot: string; outputFile: string; taskPath: string }> {
     const teamName = 'role-routing-team';
     const teamRoot = join(getOmcRoot(cwd), 'state', 'team', teamName);
@@ -159,9 +163,12 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
           claim: {
             owner: 'worker-1',
             token: 'tk-1',
-            leased_until: new Date(Date.now() + 60000).toISOString(),
+            leased_until: new Date(Date.now() + (opts.expiredLease ? -60000 : 60000)).toISOString(),
             ...(workerCli === 'cursor' ? { launch_attempt_id: launchAttemptId } : {}),
           },
+          ...(opts.delegationRequired ? {
+            delegation: { mode: 'required', skip_allowed_reason_required: true },
+          } : {}),
           created_at: new Date().toISOString(),
         },
         null,
@@ -188,6 +195,18 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
               : [{ severity: 'major', message: 'fix X' }],
           });
       await writeFile(outputFile, body, 'utf-8');
+      if (opts.staleProcessingVerdict) {
+        await writeFile(join(outputFile + '.processing'), JSON.stringify({
+          role: opts.verdictRole ?? 'code-reviewer',
+          task_id: '1',
+          claim_token: 'tk-1',
+          task_version: 1,
+          launch_attempt_id: launchAttemptId,
+          verdict: opts.staleProcessingVerdict,
+          summary: `stale ${opts.staleProcessingVerdict} summary`,
+          findings: [],
+        }), 'utf-8');
+      }
     }
 
     return { teamRoot, outputFile, taskPath };
@@ -272,6 +291,9 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
     });
 
     const { processCliWorkerVerdicts } = await import('../runtime-v2.js');
+    const eventPath = absPath(cwd, TeamPaths.events('role-routing-team'));
+    let eventsBefore = 0;
+    try { eventsBefore = (await readFile(eventPath, 'utf8')).trim().split('\n').filter(Boolean).length; } catch { /* first event */ }
     const first = await processCliWorkerVerdicts('role-routing-team', cwd);
 
     expect(first).toEqual([expect.objectContaining({
@@ -289,6 +311,12 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
       verdict_role: 'critic',
     });
     await expect(access(outputFile + '.processed')).resolves.toBeUndefined();
+
+    const events = (await readFile(eventPath, 'utf8'))
+      .trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+    expect(events.slice(eventsBefore).filter(event => event.type === 'task_completed' && event.task_id === '1')).toHaveLength(1);
+    const snapshot = JSON.parse(await readFile(absPath(cwd, TeamPaths.monitorSnapshot('role-routing-team')), 'utf8'));
+    expect(snapshot.completedEventTaskIds['1']).toBe(true);
 
     const second = await processCliWorkerVerdicts('role-routing-team', cwd);
     expect(second).toEqual([]);
@@ -312,6 +340,34 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
     expect(results[0]).toMatchObject({ status: 'skipped', reason: 'cursor_verdict_role_mismatch' });
     expect(JSON.parse(await readFile(taskPath, 'utf-8')).status).toBe('in_progress');
     await expect(access(outputFile + '.processed')).resolves.toBeUndefined();
+  });
+
+  it('does not let stale processing output mask the replacement verdict', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-routing-cursor-stale-processing-'));
+    const { taskPath } = await bootstrap({
+      verdict: 'revise', paneAlive: true, workerCli: 'cursor', verdictRole: 'critic',
+      staleProcessingVerdict: 'approve',
+    });
+
+    const { processCliWorkerVerdicts } = await import('../runtime-v2.js');
+    const results = await processCliWorkerVerdicts('role-routing-team', cwd);
+
+    expect(results[0]).toMatchObject({ status: 'failed', verdict: 'revise' });
+    expect(JSON.parse(await readFile(taskPath, 'utf-8')).metadata?.verdict).toBe('revise');
+  });
+
+  it('routes Cursor completion through lease and delegation invariants', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'omc-runtime-routing-cursor-invariants-'));
+    const { taskPath } = await bootstrap({
+      verdict: 'approve', paneAlive: true, workerCli: 'cursor', verdictRole: 'critic',
+      expiredLease: true, delegationRequired: true,
+    });
+
+    const { processCliWorkerVerdicts } = await import('../runtime-v2.js');
+    const results = await processCliWorkerVerdicts('role-routing-team', cwd);
+
+    expect(results[0]).toMatchObject({ status: 'already_terminal' });
+    expect(JSON.parse(await readFile(taskPath, 'utf-8')).status).toBe('in_progress');
   });
 
   it('waits for explicit alive liveness before consuming a Cursor verdict', async () => {

--- a/src/team/cli-worker-contract.ts
+++ b/src/team/cli-worker-contract.ts
@@ -227,8 +227,26 @@ export function parseCliWorkerVerdict(raw: string): CliWorkerOutputPayload {
 export function cliWorkerOutputFilePath(
   teamStateRootAbs: string,
   workerName: string,
+  scope?: { taskId?: string; assignmentId?: string; launchAttemptId?: string },
 ): string {
   // Intentional forward-slash join — consumed by prompts rendered for CLI
   // workers, matches other team state path conventions.
-  return `${teamStateRootAbs.replaceAll('\\', '/')}/workers/${workerName}/verdict.json`;
+  const taskId = scope?.taskId;
+  const assignmentId = scope?.assignmentId ?? scope?.launchAttemptId;
+  const fileName = taskId && assignmentId
+    ? `verdict-${encodeURIComponent(taskId)}-${encodeURIComponent(assignmentId)}.json`
+    : 'verdict.json';
+  return `${teamStateRootAbs.replaceAll('\\', '/')}/workers/${workerName}/${fileName}`;
+}
+
+export function isCliWorkerOutputFilePath(
+  teamStateRootAbs: string,
+  workerName: string,
+  outputFile: string,
+): boolean {
+  const root = `${teamStateRootAbs.replaceAll('\\', '/')}/workers/${workerName}/`;
+  const normalized = outputFile.replaceAll('\\', '/');
+  return normalized.startsWith(root)
+    && (normalized === `${root}verdict.json`
+      || /^verdict-[^/]+-[^/]+\.json$/.test(normalized.slice(root.length)));
 }

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -125,6 +125,7 @@ import { normalizeDelegationRole } from '../features/delegation-routing/types.js
 import {
   CONTRACT_ROLES,
   cliWorkerOutputFilePath,
+  isCliWorkerOutputFilePath,
   parseCliWorkerVerdict,
   renderCliWorkerOutputContract,
   shouldInjectContract,
@@ -152,7 +153,7 @@ import { parseRecoveryIntent, resolveRuntimeCliPath, type RecoverDeadWorkerOwner
 import { scaleUpFenceBlocks } from './scaling.js';
 import { runRecoverySaga, type RecoverySagaDependencies, type RecoverySagaInput } from './recovery-saga.js';
 import { readTaskRecoveryCheckpoint, selectTaskRecoveryCheckpoint } from './task-recovery-checkpoint.js';
-import { teamAdoptRecoveryReservations, teamRequeueRecoveredTask } from './team-ops.js';
+import { teamAdoptRecoveryReservations, teamRequeueRecoveredTask, teamTransitionTaskStatus } from './team-ops.js';
 
 function workerInstructionStateRoot(cwd: string, teamName: string): string {
   return process.platform === 'win32' ? teamStateRoot(cwd, teamName) : '$OMC_TEAM_STATE_ROOT';
@@ -832,6 +833,7 @@ interface SpawnV2WorkerOptions {
    * is populated for the completion handler.
    */
   role?: CanonicalTeamRole;
+  verdictAssignmentId?: string;
 }
 
 interface SpawnV2WorkerResult {
@@ -1126,7 +1128,10 @@ async function spawnV2Worker(opts: SpawnV2WorkerOptions): Promise<SpawnV2WorkerR
 
   const injectContract = shouldInjectContract(opts.role ?? null, opts.agentType);
   const outputFile = injectContract && opts.role
-    ? cliWorkerOutputFilePath(teamStateRoot(opts.cwd, opts.teamName), opts.workerName)
+    ? cliWorkerOutputFilePath(teamStateRoot(opts.cwd, opts.teamName), opts.workerName, {
+      taskId: opts.taskId,
+      assignmentId: opts.verdictAssignmentId,
+    })
     : undefined;
   const cliOutputContract = injectContract && opts.role && outputFile
     ? renderCliWorkerOutputContract(opts.role, outputFile)
@@ -2768,7 +2773,10 @@ export async function executeRecoverDeadWorkerV2Owner(
               ...(pending.startupContext ? { launch_attempt_id: pending.startupContext.attempt.attempt_id } : {}),
               ...(pending.agentType === 'cursor'
                 && shouldInjectContract(normalizeDelegationRole(pending.worker.role) as CanonicalTeamRole, pending.agentType)
-                ? { output_file: cliWorkerOutputFilePath(teamStateRoot(input.cwd, input.teamName), sagaInput.workerName) }
+                ? { output_file: cliWorkerOutputFilePath(teamStateRoot(input.cwd, input.teamName), sagaInput.workerName, {
+                  taskId: pending.worker.assigned_tasks?.[0],
+                  assignmentId: `${sagaInput.recoveryId}-${sagaInput.replacementGeneration}`,
+                }) }
                 : {}),
             }
           : candidate);
@@ -2897,7 +2905,10 @@ export async function executeRecoverDeadWorkerV2Owner(
               && shouldInjectContract(recoveryRole, pending.agentType)
               ? renderCliWorkerOutputContract(
                 recoveryRole,
-                cliWorkerOutputFilePath(teamStateRoot(input.cwd, input.teamName), sagaInput.workerName),
+                cliWorkerOutputFilePath(teamStateRoot(input.cwd, input.teamName), sagaInput.workerName, {
+                  taskId: continuation.taskId,
+                  assignmentId: `${sagaInput.recoveryId}-${sagaInput.replacementGeneration}`,
+                }),
                 {
                   taskId: continuation.taskId,
                   claimToken: continuation.claimToken,
@@ -3350,7 +3361,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
   }
 
   const startupByWorker = new Map(startupAllocations.map(item => [item.workerName, item.taskIndex]));
-  const preparedLaunches = new Map<string, { agentType: CliAgentType; role?: CanonicalTeamRole; descriptor: WorkerLaunchDescriptor }>();
+  const preparedLaunches = new Map<string, { agentType: CliAgentType; role?: CanonicalTeamRole; descriptor: WorkerLaunchDescriptor; verdictAssignmentId?: string }>();
   const resolveDefaultModel = (agentType: CliAgentType): string | undefined => {
     if (agentType === 'codex') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_CODEX_MODEL || process.env.OMC_CODEX_DEFAULT_MODEL || undefined;
     if (agentType === 'gemini') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL || process.env.OMC_GEMINI_DEFAULT_MODEL || undefined;
@@ -3370,8 +3381,12 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
         resolvedBinaryPaths, fallbackAgent);
     const effectiveModel = assignment.model || resolveDefaultModel(assignment.agentType);
     const worktree = workerWorktrees.get(workerName);
+    const verdictAssignmentId = taskIndex !== undefined ? randomUUID() : undefined;
     const outputFile = taskIndex !== undefined && assignment.role && shouldInjectContract(assignment.role, assignment.agentType)
-      ? cliWorkerOutputFilePath(teamStateRoot(leaderCwd, sanitized), workerName) : undefined;
+      ? cliWorkerOutputFilePath(teamStateRoot(leaderCwd, sanitized), workerName, {
+        taskId: String(taskIndex + 1),
+        assignmentId: verdictAssignmentId,
+      }) : undefined;
     const outputContract = outputFile && assignment.role ? renderCliWorkerOutputContract(assignment.role, outputFile) : undefined;
     const binary = resolvedBinaryPaths[assignment.agentType];
     if (!binary) throw new Error(`No validated binary available for ${assignment.agentType}`);
@@ -3388,7 +3403,8 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
       model: effectiveModel,
     }, promptArgs);
     preparedLaunches.set(workerName, { agentType: assignment.agentType,
-      ...(assignment.role ? { role: assignment.role } : {}), descriptor });
+      ...(assignment.role ? { role: assignment.role } : {}), descriptor,
+      ...(verdictAssignmentId ? { verdictAssignmentId } : {}) });
   }
 
   // Set up worker state dirs and overlays (with v2 CLI API instructions)
@@ -3592,6 +3608,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
       worktreePath: workerInfo.worktree_path,
       autoMerge: Boolean(config.autoMerge),
       ...(prepared.role ? { role: prepared.role } : {}),
+      ...(prepared.verdictAssignmentId ? { verdictAssignmentId: prepared.verdictAssignmentId } : {}),
     });
 
     if (workerLaunch.paneId) {
@@ -3848,11 +3865,11 @@ export interface CliWorkerVerdictResult {
  *   - Reads + validates the JSON payload via `parseCliWorkerVerdict`.
  *   - Locates the worker's in_progress task and writes a terminal status
  *     (completed for `approve`, failed for `revise`/`reject`) plus verdict
- *     metadata directly to the task file — the worker process is gone and
- *     cannot re-enter `transitionTaskStatus` with its claim token.
- *   - Renames `verdict.json` to `verdict.processed.json` so a subsequent
- *     monitor cycle does not reprocess it.
- *   - Emits a team event describing the outcome.
+ *     metadata through the canonical `transitionTaskStatus` path so lease,
+ *     delegation, event, and monitor-snapshot invariants remain authoritative.
+ *   - Renames the assignment-scoped verdict artifact to `.processed` so a
+ *     subsequent monitor cycle does not reprocess it.
+ *   - Quarantines stale `.processing` artifacts when replacement output exists.
  * On parse failure, emits a warning event and leaves the task untouched
  * for human review (per plan AC-7).
  */
@@ -3872,7 +3889,7 @@ export async function processCliWorkerVerdicts(
   const { rename } = await import('fs/promises');
   const { renameSync, readFileSync, writeFileSync, existsSync: fsExistsSync } = await import('fs');
   const { withFileLockSync } = await import('../lib/file-lock.js');
-  const { withTaskClaimLock, writeAtomic } = await import('./team-ops.js');
+
 
   for (const worker of config.workers) {
     const outputFile = worker.output_file;
@@ -3893,8 +3910,7 @@ export async function processCliWorkerVerdicts(
     const processedOutputFile = outputFile + '.processed';
     const processingOutputFile = outputFile + '.processing';
     if (cursorReviewer) {
-      const expectedOutputFile = cliWorkerOutputFilePath(teamStateRoot(cwd, sanitized), worker.name);
-      if (outputFile !== expectedOutputFile) {
+      if (!isCliWorkerOutputFilePath(teamStateRoot(cwd, sanitized), worker.name, outputFile)) {
         results.push({
           workerName: worker.name,
           taskId: null,
@@ -3919,9 +3935,10 @@ export async function processCliWorkerVerdicts(
       }
     }
 
-    let verdictFile = cursorReviewer && fsExistsSync(processingOutputFile)
-      ? processingOutputFile
-      : outputFile;
+    let verdictFile = outputFile;
+    if (cursorReviewer && !fsExistsSync(outputFile) && fsExistsSync(processingOutputFile)) {
+      verdictFile = processingOutputFile;
+    }
     let payload: CliWorkerOutputPayload;
     try {
       if (cursorReviewer && verdictFile === outputFile) {
@@ -3930,8 +3947,17 @@ export async function processCliWorkerVerdicts(
         // `.processing` name lets a later cycle finish an interrupted commit.
         withFileLockSync(outputFile + '.lock', () => {
           if (fsExistsSync(processingOutputFile)) {
-            verdictFile = processingOutputFile;
-            return;
+            // A replacement assignment may publish a fresh verdict while a
+            // previous monitor cycle is still holding an interrupted claim.
+            // The fresh assignment file wins; retain the old claim as audit
+            // evidence instead of allowing it to mask replacement output.
+            if (fsExistsSync(outputFile)) {
+              const stalePath = `${processingOutputFile}.stale`;
+              try { renameSync(processingOutputFile, stalePath); } catch { /* leave it for the next cycle */ }
+            } else {
+              verdictFile = processingOutputFile;
+              return;
+            }
           }
           const raw = readFileSync(outputFile, 'utf-8');
           parseCliWorkerVerdict(raw);
@@ -4083,55 +4109,46 @@ export async function processCliWorkerVerdicts(
     let transitionOk = false;
     try {
       if (cursorReviewer) {
-        const transition = await withTaskClaimLock(sanitized, targetTaskId, cwd, async () => {
-          const raw = await readFile(targetTaskPath!, 'utf-8');
-          const taskData = JSON.parse(raw) as Record<string, unknown>;
-          if (taskData.status !== 'in_progress' || taskData.owner !== worker.name) {
-            return false;
-          }
-          const claim = taskData.claim && typeof taskData.claim === 'object'
-            ? taskData.claim as unknown as Record<string, unknown>
-            : null;
-          if (cursorReviewer && (
-            claim?.owner !== worker.name
-            || claim.token !== payload.claim_token
-            || taskData.version !== payload.task_version
-            || (worker.launch_attempt_id !== undefined && claim.launch_attempt_id !== worker.launch_attempt_id)
-            || (worker.launch_attempt_id !== undefined && payload.launch_attempt_id !== worker.launch_attempt_id)
-          )) {
-            return false;
-          }
-          const prevMetadata = (taskData.metadata && typeof taskData.metadata === 'object')
-            ? taskData.metadata as Record<string, unknown>
-            : {};
-          taskData.status = terminalStatus;
-          taskData.completed_at = new Date().toISOString();
-          taskData.claim = undefined;
-          taskData.metadata = {
-            ...prevMetadata,
-            verdict: payload.verdict,
-            verdict_summary: payload.summary,
-            verdict_findings: payload.findings,
-            verdict_role: payload.role,
-            verdict_source: 'cli_worker_output_contract',
-            ...(cursorReviewer ? {
-              verdict_claim_token: payload.claim_token,
-              verdict_task_version: payload.task_version,
-            } : {}),
-            ...(worker.launch_attempt_id
-              ? { verdict_worker_launch_attempt_id: worker.launch_attempt_id }
-              : {}),
-          };
-          if (terminalStatus === 'failed') {
-            taskData.error = `cli_worker_verdict:${payload.verdict}:${payload.summary}`;
-          }
-          taskData.version = typeof taskData.version === 'number' && Number.isFinite(taskData.version)
-            ? taskData.version + 1
-            : 2;
-          await writeAtomic(targetTaskPath!, JSON.stringify(taskData, null, 2));
-          return true;
-        });
-        transitionOk = transition.ok && transition.value;
+        const transition = await teamTransitionTaskStatus(
+          sanitized,
+          targetTaskId,
+          'in_progress',
+          terminalStatus,
+          payload.claim_token!,
+          cwd,
+          terminalStatus === 'completed'
+            ? {
+              result: payload.summary,
+              metadata: {
+                verdict: payload.verdict,
+                verdict_summary: payload.summary,
+                verdict_findings: payload.findings,
+                verdict_role: payload.role,
+                verdict_source: 'cli_worker_output_contract',
+                verdict_claim_token: payload.claim_token,
+                verdict_task_version: payload.task_version,
+                ...(worker.launch_attempt_id
+                  ? { verdict_worker_launch_attempt_id: worker.launch_attempt_id }
+                  : {}),
+              },
+            }
+            : {
+              error: `cli_worker_verdict:${payload.verdict}:${payload.summary}`,
+              metadata: {
+                verdict: payload.verdict,
+                verdict_summary: payload.summary,
+                verdict_findings: payload.findings,
+                verdict_role: payload.role,
+                verdict_source: 'cli_worker_output_contract',
+                verdict_claim_token: payload.claim_token,
+                verdict_task_version: payload.task_version,
+                ...(worker.launch_attempt_id
+                  ? { verdict_worker_launch_attempt_id: worker.launch_attempt_id }
+                  : {}),
+              },
+            },
+        );
+        transitionOk = transition.ok;
       } else {
         // Preserve the existing post-exit path for non-Cursor providers.
         withFileLockSync(targetTaskPath + '.lock', () => {
@@ -4175,12 +4192,14 @@ export async function processCliWorkerVerdicts(
       continue;
     }
 
-    await appendTeamEvent(sanitized, {
-      type: terminalStatus === 'completed' ? 'task_completed' : 'task_failed',
-      worker: worker.name,
-      task_id: targetTaskId,
-      reason: `cli_worker_verdict:${payload.verdict}`,
-    }, cwd).catch(logEventFailure);
+    if (!cursorReviewer) {
+      await appendTeamEvent(sanitized, {
+        type: terminalStatus === 'completed' ? 'task_completed' : 'task_failed',
+        worker: worker.name,
+        task_id: targetTaskId,
+        reason: `cli_worker_verdict:${payload.verdict}`,
+      }, cwd).catch(logEventFailure);
+    }
 
     try {
       await rename(verdictFile, processedOutputFile);

--- a/src/team/state/tasks.ts
+++ b/src/team/state/tasks.ts
@@ -169,7 +169,7 @@ export async function transitionTaskStatus(
   from: TeamTaskStatus,
   to: TeamTaskStatus,
   claimToken: string,
-  terminalData: { result?: string; error?: string } | undefined,
+  terminalData: { result?: string; error?: string; metadata?: Record<string, unknown> } | undefined,
   deps: TransitionDeps,
 ): Promise<TransitionTaskResult> {
   if (!deps.canTransitionTaskStatus(from, to)) return { ok: false, error: 'invalid_transition' };
@@ -206,6 +206,9 @@ export async function transitionTaskStatus(
       delegation_compliance: to === 'completed' ? delegationCompliance ?? v.delegation_compliance : v.delegation_compliance,
       claim: undefined,
       version: v.version + 1,
+      ...(terminalData && 'metadata' in terminalData && terminalData.metadata
+        ? { metadata: { ...(v.metadata ?? {}), ...terminalData.metadata } }
+        : {}),
     };
     await deps.writeAtomic(deps.taskFilePath(deps.teamName, taskId, deps.cwd), JSON.stringify(updated, null, 2));
 
@@ -386,7 +389,17 @@ export async function adoptRecoveryReservations(taskIds: string[], workerName: s
       if (!reservation) {
         if (task.status === 'in_progress' && task.owner === workerName && task.claim && task.recovery_adoption?.recovery_id === proof.recoveryId && task.recovery_adoption.request_id === proof.requestId && task.recovery_adoption.replacement_generation === proof.replacementGeneration) {
           const checkpoint = await deps.readRecoveryCheckpoint(task.recovery_adoption.checkpoint_path);
-          return checkpoint.ok ? { ok: true as const, task, claimToken: task.claim.token, checkpoint: checkpoint.checkpoint, replayed: true } : { ok: false as const, error: checkpointError(checkpoint.error) };
+          if (!checkpoint.ok) return { ok: false as const, error: checkpointError(checkpoint.error) };
+          if (deps.launchAttemptId && task.claim.launch_attempt_id !== deps.launchAttemptId) {
+            const rebound: TeamTaskV2 = {
+              ...task,
+              claim: { ...task.claim, launch_attempt_id: deps.launchAttemptId },
+              version: task.version + 1,
+            };
+            await deps.writeAtomic(deps.taskFilePath(deps.teamName, taskId, deps.cwd), JSON.stringify(rebound, null, 2));
+            return { ok: true as const, task: rebound, claimToken: rebound.claim!.token, checkpoint: checkpoint.checkpoint, replayed: true };
+          }
+          return { ok: true as const, task, claimToken: task.claim.token, checkpoint: checkpoint.checkpoint, replayed: true };
         }
         return { ok: false as const, error: 'claim_conflict' as const };
       }

--- a/src/team/team-ops.ts
+++ b/src/team/team-ops.ts
@@ -532,7 +532,7 @@ export async function teamTransitionTaskStatus(
   to: TeamTaskStatus,
   claimToken: string,
   cwd: string,
-  terminalData?: { result?: string; error?: string },
+  terminalData?: { result?: string; error?: string; metadata?: Record<string, unknown> },
 ): Promise<TransitionTaskResult> {
   return transitionTaskStatusImpl(taskId, from, to, claimToken, terminalData, {
     teamName,

--- a/src/team/types.ts
+++ b/src/team/types.ts
@@ -203,6 +203,7 @@ export interface TeamTask {
   owner?: string;
   result?: string;
   error?: string;
+  metadata?: Record<string, unknown>;
   blocked_by?: string[];
   depends_on?: string[];
   version?: number;


### PR DESCRIPTION
Closes #3880

Resolves the four post-merge P1 lifecycle blockers found on PR #3882:

- assignment-scoped Cursor/CLI verdict artifacts prevent rapid assignment overwrite and stale `.processing` masking; stale processing files are quarantined when replacement output exists
- recovery adoption rebinds replayed claims to the active replacement launch attempt
- Cursor verdicts use canonical task transition, including lease expiry, delegation compliance, terminal events, and monitor snapshots
- Cursor terminalization remains idempotent and emits one terminal event

Evidence from signed commit 3c0b7fda:
- focused regressions: 40 tests passed
- lifecycle matrix: 159 tests passed
- TypeScript: passed
- inventory verify: passed
- build: passed

The full repository matrix was also run; 704 files passed and 15 unrelated timing/environment-sensitive SessionEnd/rate-limit/inventory assertions failed in the existing broad suite. No main/release/tag/publish surfaces were touched.