### PR TITLE
fix(team): allow cursor workers on reviewer roles (#3880)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "688fcb137e74493d8c7601ed28bfa47ce6019ebe",
-    "sourceSha256": "77bb6d397659842fad642089a3ac6a910181f04caaa1e3e18ab0a205176e3417",
+    "head": "2972c31047acec5181a16d7824879231de479621",
+    "sourceSha256": "056d1324b951cba3d6aca551236bc78e464503cdd03e6063c9c7af4924a95cab",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "688fcb137e74493d8c7601ed28bfa47ce6019ebe",
-  "sourceSha256": "77bb6d397659842fad642089a3ac6a910181f04caaa1e3e18ab0a205176e3417",
+  "head": "2972c31047acec5181a16d7824879231de479621",
+  "sourceSha256": "056d1324b951cba3d6aca551236bc78e464503cdd03e6063c9c7af4924a95cab",
   "counts": {
     "public": {
       "skills": 32,
@@ -76362,5 +76362,5 @@
     }
   },
   "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "174ece14b21c9e7b82598255f4a23657061c82a7f883a9d5eba0f63b7ffb58c4"
+  "manifestSha256": "c807502026fb6be08424b3d761ab12ab8b71c3fdf712a499f3b6cb6dae4d8b5e"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "bbf86c38e627c20cf111d375e1cab3c8516d89b8",
-    "sourceSha256": "cd39c3630247e96097e8b3a2f0b45e96fe64f836d1ee9b7a79ed7652de57b9a4",
+    "head": "688fcb137e74493d8c7601ed28bfa47ce6019ebe",
+    "sourceSha256": "77bb6d397659842fad642089a3ac6a910181f04caaa1e3e18ab0a205176e3417",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "bbf86c38e627c20cf111d375e1cab3c8516d89b8",
-  "sourceSha256": "cd39c3630247e96097e8b3a2f0b45e96fe64f836d1ee9b7a79ed7652de57b9a4",
+  "head": "688fcb137e74493d8c7601ed28bfa47ce6019ebe",
+  "sourceSha256": "77bb6d397659842fad642089a3ac6a910181f04caaa1e3e18ab0a205176e3417",
   "counts": {
     "public": {
       "skills": 32,
@@ -72150,11 +72150,6 @@
       },
       {
         "from": "src/team/runtime-v2.ts",
-        "to": "src/team/role-router.ts",
-        "kind": "type-imports"
-      },
-      {
-        "from": "src/team/runtime-v2.ts",
         "to": "src/team/runtime-flags.ts",
         "kind": "exports"
       },
@@ -76361,11 +76356,11 @@
     ],
     "stats": {
       "nodeCount": 6832,
-      "edgeCount": 7184,
+      "edgeCount": 7183,
       "importEdgeCount": 5900,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "db481b228ec987748679677b625486401e0b8f99957b8c56b0cfee841eee737f",
-  "manifestSha256": "49b0337d8b7e62afea41303fbb6b6cb883a8393aa8be199f0b46247554def94c"
+  "manifestSha256": "174ece14b21c9e7b82598255f4a23657061c82a7f883a9d5eba0f63b7ffb58c4"
 }

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -212,8 +212,7 @@ or the Claude Code slash compatibility surface:
 ```
 
 Limitations:
-- Cursor workers are executor-style only: implementation, file edits, build/test fixes, and other plan execution tasks.
-- Keep reviewer, critic, security-review, validation verdict, and final approval roles on native Claude/OMC reviewer agents unless explicit safe support is added later.
+- Cursor workers support implementation and reviewer-style team roles. `critic`, `code-reviewer`, `security-reviewer`, and `test-engineer` workers must emit the structured verdict file consumed by the team leader; final approval remains a lead-session responsibility.
 - Cursor requires the `cursor-agent` CLI to be installed and authenticated. If `cursor-agent` is unavailable, report that setup requirement instead of silently falling back to Claude-only execution.
 
 ## Resume

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -940,7 +940,7 @@ User-friendly aliases normalize via `normalizeDelegationRole()` — e.g. `review
 
 `orchestrator` is pinned to `claude`; only `model` is user-configurable. Any other key on `orchestrator` is rejected by the validator.
 
-`cursor` launches `cursor-agent` as an interactive executor/refactor worker. Do not route reviewer/verdict roles (`critic`, `code-reviewer`, `security-reviewer`, `test-engineer`) to Cursor unless its CLI gains a compatible verdict-output mode; the runtime intentionally skips the structured verdict contract for Cursor panes.
+`cursor` launches `cursor-agent` as an interactive worker. Reviewer/verdict roles (`critic`, `code-reviewer`, `security-reviewer`, `test-engineer`) are supported and receive the same structured verdict-output contract as other non-Claude providers. The leader owns the terminal task transition after consuming the verdict; final approval remains a lead-session responsibility.
 
 ### Env override
 

--- a/src/cli/commands/__tests__/team.test.ts
+++ b/src/cli/commands/__tests__/team.test.ts
@@ -563,13 +563,23 @@ describe('parseTeamArgs comma-separated multi-type specs', () => {
     expect(parsed.task).toBe('compare edits');
   });
 
-  it('rejects cursor with non-executor explicit roles', () => {
-    expect(() => parseTeamArgs(['1:cursor:architect', 'design auth'])).toThrow(
-      /Cursor workers are executor-style only/,
-    );
-    expect(() => parseTeamArgs(['1:cursor:security-reviewer', 'review auth'])).toThrow(
-      /Cursor workers are executor-style only/,
-    );
+  it('accepts cursor with non-executor explicit roles (issue #3880)', () => {
+    expect(parseTeamArgs(['1:cursor:architect', 'design auth']).workerSpecs).toEqual([
+      { agentType: 'cursor', role: 'architect' },
+    ]);
+    expect(parseTeamArgs(['1:cursor:security-reviewer', 'review auth']).workerSpecs).toEqual([
+      { agentType: 'cursor', role: 'security-reviewer' },
+    ]);
+  });
+
+  it('accepts a mixed cursor-reviewer / codex-critic spec (issue #3880)', () => {
+    const parsed = parseTeamArgs(['1:cursor:code-reviewer,1:codex:critic', 'review the change']);
+    expect(parsed.workerCount).toBe(2);
+    expect(parsed.agentTypes).toEqual(['cursor', 'codex']);
+    expect(parsed.workerSpecs).toEqual([
+      { agentType: 'cursor', role: 'code-reviewer' },
+      { agentType: 'codex', role: 'critic' },
+    ]);
   });
 
   it('parses single-type spec 2:antigravity into uniform agentTypes', () => {

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -27,7 +27,6 @@ const HELP_TOKENS = new Set(['--help', '-h', 'help']);
 const MIN_WORKER_COUNT = 1;
 const MAX_WORKER_COUNT = 20;
 const VALID_TEAM_CLI_AGENT_TYPES = new Set(['claude', 'codex', 'gemini', 'grok', 'cursor', 'antigravity']);
-const CURSOR_ALLOWED_TEAM_ROLES = new Set(['executor']);
 const DEFAULT_TEAM_CLI_AGENT_TYPE: CliAgentType = 'claude';
 
 const TEAM_HELP = `
@@ -61,8 +60,6 @@ Auto-merge (v2-only):
 
 Roles (optional): architect, executor, planner, analyst, critic, debugger, verifier,
   code-reviewer, security-reviewer, test-engineer, designer, writer, scientist
-
-Cursor workers are executor-style only; use 1:cursor or 1:cursor:executor, not reviewer/critic/security/verdict roles.
 `;
 
 const TEAM_API_HELP = `
@@ -377,12 +374,6 @@ function normalizeWorkerSpecSegment(match: RegExpMatchArray): NormalizedWorkerSp
         `Invalid agent type "${token}" in worker spec "${match[0]}". ` +
         `Expected one of: ${[...VALID_TEAM_CLI_AGENT_TYPES].join(', ')}. ` +
         `For a role-only shorthand on the default agent, use "${count}:${explicitRole}".`,
-      );
-    }
-    if (token === 'cursor' && !CURSOR_ALLOWED_TEAM_ROLES.has(explicitRole)) {
-      throw new Error(
-        `Invalid Cursor worker role "${explicitRole}" in worker spec "${match[0]}". ` +
-        `Cursor workers are executor-style only; use "${count}:cursor" or "${count}:cursor:executor".`,
       );
     }
     return { count, agentType: token, role: explicitRole };

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -533,7 +533,7 @@ describe("team.roleRouting (Option E)", () => {
 
 
 
-  it("rejects cursor for non-executor team roleRouting providers", () => {
+  it("accepts cursor for reviewer team roleRouting providers (issue #3880)", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "omc-team-routing-cursor-reviewer-"));
     try {
       const claudeDir = join(tempDir, ".claude");
@@ -543,13 +543,19 @@ describe("team.roleRouting (Option E)", () => {
         JSON.stringify({
           team: {
             roleRouting: {
-              "code-reviewer": { provider: "cursor" },
+              "code-reviewer": { provider: "cursor", model: "cursor-grok-4.6-high" },
+              "critic": { provider: "cursor" },
             },
           },
         }),
       );
       process.chdir(tempDir);
-      expect(() => loadConfig()).toThrow(/cursor is only supported for executor-style roles/);
+      const config = loadConfig();
+      expect(config.team?.roleRouting?.["code-reviewer"]).toEqual({
+        provider: "cursor",
+        model: "cursor-grok-4.6-high",
+      });
+      expect(config.team?.roleRouting?.critic).toEqual({ provider: "cursor" });
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -19,7 +19,6 @@ import type {
 } from "../shared/types.js";
 import {
   CANONICAL_TEAM_ROLES,
-  CURSOR_EXECUTOR_TEAM_ROLES,
   KNOWN_AGENT_NAMES,
 } from "../shared/types.js";
 import { getConfigDir } from "../utils/paths.js";
@@ -496,7 +495,6 @@ function warnOnDeprecatedDelegationRouting(config: PluginConfig): void {
  * Throws a descriptive error naming offending key + allowed values.
  */
 const CANONICAL_TEAM_ROLE_SET = new Set<string>(CANONICAL_TEAM_ROLES);
-const CURSOR_EXECUTOR_TEAM_ROLE_SET = new Set<string>(CURSOR_EXECUTOR_TEAM_ROLES);
 const KNOWN_AGENT_NAME_SET = new Set<string>(KNOWN_AGENT_NAMES);
 // /team CLI workers — codex/gemini/grok/cursor here are CLI integrations, NOT the deprecated MCP delegationRouting providers.
 const TEAM_ROLE_PROVIDERS = new Set(["claude", "codex", "gemini", "grok", "cursor", "antigravity"]);
@@ -569,11 +567,6 @@ export function validateTeamConfig(config: PluginConfig): void {
       if (typeof spec.provider !== "string" || !TEAM_ROLE_PROVIDERS.has(spec.provider)) {
         throw new Error(
           `[OMC] team.roleRouting.${rawRoleKey}.provider: invalid value "${String(spec.provider)}". Allowed: ${[...TEAM_ROLE_PROVIDERS].join(", ")}`,
-        );
-      }
-      if (spec.provider === "cursor" && !CURSOR_EXECUTOR_TEAM_ROLE_SET.has(normalized)) {
-        throw new Error(
-          `[OMC] team.roleRouting.${rawRoleKey}.provider: cursor is only supported for executor-style roles (${[...CURSOR_EXECUTOR_TEAM_ROLE_SET].join(", ")})`,
         );
       }
     }

--- a/src/hooks/autopilot/__tests__/pipeline.test.ts
+++ b/src/hooks/autopilot/__tests__/pipeline.test.ts
@@ -667,7 +667,7 @@ describe("autopilot team CLI worker configuration", () => {
     expect(config.team?.agentTypes).toEqual(["cursor"]);
   });
 
-  it("instructs team execution to use omc team for Cursor executor workers", () => {
+  it("instructs team execution to use omc team for Cursor workers", () => {
     const prompt = executionAdapter.getPrompt({
       idea: "test",
       directory: "/tmp",
@@ -682,10 +682,8 @@ describe("autopilot team CLI worker configuration", () => {
     expect(prompt).toContain("CLI Team Runtime Required");
     expect(prompt).toContain("omc team 1:cursor");
     expect(prompt).toContain("/omc-teams 1:cursor");
-    expect(prompt).toContain("executor-style only");
-    expect(prompt).toContain(
-      "reviewer, critic, security-review, validation verdict",
-    );
+    expect(prompt).toContain("including reviewer-style roles");
+    expect(prompt).toContain("structured verdict-output contract");
     expect(prompt).toContain("cursor-agent");
     expect(prompt).toContain("installed and authenticated");
     expect(prompt).not.toContain("TeamCreate");

--- a/src/hooks/autopilot/adapters/execution-adapter.ts
+++ b/src/hooks/autopilot/adapters/execution-adapter.ts
@@ -66,7 +66,7 @@ Or from Claude Code slash commands:
 /omc-teams ${agentSpec} "<implementation task from ${planPath}>"
 \`\`\`
 
-Requested worker types: ${requested}. Keep these CLI workers executor-style only: implementation, file edits, build/test fixes, and other plan execution tasks. Keep reviewer, critic, security-review, validation verdict, and final approval roles on the native Claude/OMC reviewer agents unless this repository explicitly adds safe role support for that CLI worker type.${cursorGuidance}`;
+Requested worker types: ${requested}. CLI workers may receive their assigned team roles, including reviewer-style roles. The roles \`critic\`, \`code-reviewer\`, \`security-reviewer\`, and \`test-engineer\` use the structured verdict-output contract, with the team leader owning the terminal task transition. Final approval remains a lead-session responsibility.${cursorGuidance}`;
 }
 
 export const executionAdapter: PipelineStageAdapter = {
@@ -120,7 +120,7 @@ Every teammate response must stay concise: return ONLY a short execution summary
 
 ### Agent Selection
 
-${useCliTeamRuntime ? `Use the requested CLI worker spec for executor-style implementation tasks only. Keep task prompts framed as implementation/build/test-fix work; do not ask Cursor/CLI workers to act as reviewers, critics, security reviewers, or final verdict agents.` : `Match agent types to task complexity:
+${useCliTeamRuntime ? `Use the requested CLI worker spec for assigned implementation or reviewer tasks. For \`critic\`, \`code-reviewer\`, \`security-reviewer\`, and \`test-engineer\` work, require the structured verdict output and let the leader perform the terminal transition; do not assign final approval to a worker.` : `Match agent types to task complexity:
 - Simple tasks (single file, config): \`executor\` with \`model="haiku"\`
 - Standard implementation: \`executor\` with \`model="sonnet"\`
 - Complex work (architecture, refactoring): \`executor\` with \`model="opus"\`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -474,9 +474,6 @@ export const CANONICAL_TEAM_ROLES = [
 
 export type CanonicalTeamRole = typeof CANONICAL_TEAM_ROLES[number];
 
-/** Cursor team workers are currently supported only for executor-style tasks. */
-export const CURSOR_EXECUTOR_TEAM_ROLES = ["executor"] as const;
-
 /** Provider for /team role routing. */
 export type TeamRoleProvider = 'claude' | 'codex' | 'gemini' | 'grok' | 'cursor' | 'antigravity';
 

--- a/src/team/__tests__/runtime-v2.cursor-routing.test.ts
+++ b/src/team/__tests__/runtime-v2.cursor-routing.test.ts
@@ -10,10 +10,17 @@ const binaries: Partial<Record<CliAgentType, string>> = {
   cursor: '/usr/bin/cursor-agent',
 };
 
-describe('runtime-v2 Cursor task assignment guard', () => {
+/**
+ * Cursor used to be pinned to the executor role: reviewer-style roles threw,
+ * and a keyword heuristic silently rewrote inferred roles to `executor` so the
+ * throw would not fire on ordinary implementation work. Both are gone (issue
+ * #3880) — cursor now resolves roles the same way every other CLI provider
+ * does.
+ */
+describe('runtime-v2 cursor task assignment', () => {
   it('keeps inferred executor-style implementation tasks on cursor', () => {
     const assignment = resolveTaskAssignment(
-      { subject: 'Implement plan', description: 'apply the implementation plan', },
+      { subject: 'Implement plan', description: 'apply the implementation plan' },
       resolvedRouting,
       undefined,
       binaries,
@@ -41,7 +48,7 @@ describe('runtime-v2 Cursor task assignment guard', () => {
         'cursor',
       );
 
-      expect(assignment).toEqual({ agentType: 'cursor', model: '', role: 'executor' });
+      expect(assignment.agentType).toBe('cursor');
     }
   });
 
@@ -57,7 +64,22 @@ describe('runtime-v2 Cursor task assignment guard', () => {
     expect(assignment).toEqual({ agentType: 'cursor', model: '', role: 'executor' });
   });
 
-  it('rejects inferred review/security/verdict-style roles for cursor workers', () => {
+  it('accepts explicit reviewer-style roles for cursor workers (issue #3880)', () => {
+    for (const role of ['code-reviewer', 'critic', 'security-reviewer', 'test-engineer'] as const) {
+      const assignment = resolveTaskAssignment(
+        { subject: 'Review the change', description: 'inspect without editing', role },
+        resolvedRouting,
+        undefined,
+        binaries,
+        'cursor',
+      );
+
+      expect(assignment.agentType).toBe('cursor');
+      expect(assignment.role).toBe(role);
+    }
+  });
+
+  it('no longer throws on inferred review/security/verdict-style tasks (issue #3880)', () => {
     const cases = [
       { subject: 'Review auth', description: 'review the auth module for maintainability' },
       { subject: 'Security review', description: 'review auth for vulnerabilities and injection issues' },
@@ -67,7 +89,24 @@ describe('runtime-v2 Cursor task assignment guard', () => {
     for (const task of cases) {
       expect(() =>
         resolveTaskAssignment(task, resolvedRouting, undefined, binaries, 'cursor'),
-      ).toThrow(/Cursor workers are executor-style only/);
+      ).not.toThrow();
     }
+  });
+
+  it('routes an inferred reviewer task to the role the router picked, not a coerced executor', () => {
+    // The removed heuristic forced `executor` here to dodge the guard. The role
+    // the router infers must now survive, or reviewer work would silently run
+    // with executor guidance and never emit a verdict.
+    const assignment = resolveTaskAssignment(
+      { subject: 'Review auth', description: 'review the auth module for maintainability' },
+      resolvedRouting,
+      undefined,
+      binaries,
+      'cursor',
+    );
+
+    expect(assignment.agentType).toBe('cursor');
+    expect(assignment.role).not.toBeNull();
+    expect(assignment.role).not.toBe('executor');
   });
 });

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -1062,6 +1062,61 @@ describe('runtime v2 startup inbox dispatch', () => {
     expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith('gemini', expect.any(Object));
   });
 
+  it('routes an inferred reviewer task to a cursor worker carrying the verdict contract (issue #3880)', async () => {
+    // This is the path the removed gates blocked end to end: `team.roleRouting`
+    // naming cursor for a reviewer role was rejected at config load (loader) and
+    // again at resolution (stage-router), and an inferred reviewer role threw in
+    // resolveTaskAssignment. Nothing here passes an explicit role, so it
+    // exercises inference rather than the explicit-role shortcut.
+    cwd = await mkdtempFixture('omc-runtime-v2-cursor-role-routing-');
+    await mkdir(join(cwd, '.claude'), { recursive: true });
+    await writeFile(
+      join(cwd, '.claude', 'omc.jsonc'),
+      JSON.stringify({
+        team: {
+          roleRouting: {
+            'code-reviewer': { provider: 'cursor', model: 'cursor-grok-4.6-high' },
+          },
+        },
+      }),
+      'utf-8',
+    );
+    process.chdir(cwd);
+
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'cursor-routing-team',
+      workerCount: 1,
+      agentTypes: ['claude'],
+      tasks: [{ subject: 'Review component naming', description: 'code review pass for PR' }],
+      cwd,
+    });
+
+    // Routing snapshot honors cursor for a reviewer role.
+    expect(runtime.config.resolved_routing?.['code-reviewer']?.primary.provider).toBe('cursor');
+    expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith('cursor', expect.any(Object));
+
+    // The worker is a cursor reviewer and owns a verdict-output file, which is
+    // what lets the leader transition the task. Without it the task would
+    // strand in_progress — the failure mode that kept these gates closed.
+    const persisted = JSON.parse(await readFile(
+      join(cwd, '.omc', 'state', 'team', 'cursor-routing-team', 'config.json'),
+      'utf-8',
+    ));
+    expect(persisted.workers[0].worker_cli).toBe('cursor');
+    expect(persisted.workers[0].role).toBe('code-reviewer');
+    expect(persisted.workers[0].output_file).toBeTruthy();
+
+    // And the reviewer contract actually reached the worker.
+    const inbox = await readFile(
+      join(cwd, '.omc', 'state', 'team', 'cursor-routing-team', 'workers', 'worker-1', 'inbox.md'),
+      'utf-8',
+    );
+    expect(inbox).toContain('REQUIRED: Structured Verdict Output');
+    expect(inbox).toContain('do NOT edit, create, or delete any file');
+  });
+
   it('passes through dedicated-window startup requests', async () => {
     cwd = await mkdtempFixture('omc-runtime-v2-new-window-');
     const { startTeamV2 } = await import('../runtime-v2.js');

--- a/src/team/__tests__/stage-router.test.ts
+++ b/src/team/__tests__/stage-router.test.ts
@@ -125,13 +125,15 @@ describe('stage-router resolveRoleAssignment', () => {
     });
 
 
-    it('rejects provider=cursor for reviewer/verdict roles', () => {
-      const cfg: PluginConfig = {
-        team: { roleRouting: { 'code-reviewer': { provider: 'cursor' } } },
-      };
-      expect(() => resolveRoleAssignment('code-reviewer', cfg)).toThrow(
-        /cursor is only supported for executor-style roles/,
-      );
+    it('accepts provider=cursor for reviewer/verdict roles (issue #3880)', () => {
+      // Cursor reviewers emit the verdict-file contract like every other
+      // non-Claude provider, so the role gate that used to throw here is gone.
+      for (const role of ['code-reviewer', 'critic', 'security-reviewer', 'test-engineer'] as const) {
+        const cfg: PluginConfig = {
+          team: { roleRouting: { [role]: { provider: 'cursor' } } },
+        };
+        expect(resolveRoleAssignment(role, cfg).provider).toBe('cursor');
+      }
     });
 
     it('grok resolves configured externalModels.defaults.grokModel when model omitted', () => {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -117,10 +117,10 @@ import {
 import { formatOmcCliInvocation } from '../utils/omc-cli-rendering.js';
 import { createSwallowedErrorLogger } from '../lib/swallowed-error.js';
 import type { CanonicalTeamRole, PluginConfig, RoleAssignment, TeamRoleAssignmentSpec } from '../shared/types.js';
-import { CANONICAL_TEAM_ROLES, CURSOR_EXECUTOR_TEAM_ROLES } from '../shared/types.js';
+import { CANONICAL_TEAM_ROLES } from '../shared/types.js';
 import { loadConfig } from '../config/loader.js';
 import { buildResolvedRoutingSnapshot, getRoleRoutingSpec } from './stage-router.js';
-import { inferLaneIntent, routeTaskToRole, type LaneIntent } from './role-router.js';
+import { routeTaskToRole } from './role-router.js';
 import { normalizeDelegationRole } from '../features/delegation-routing/types.js';
 import {
   CONTRACT_ROLES,
@@ -245,24 +245,7 @@ export function readRecoverDeadWorkerV2Outcome(cwd: string, requestId: string): 
 // ---------------------------------------------------------------------------
 
 const orchestratorByTeam = new Map<string, { handle: OrchestratorHandle; serviceGeneration?: number; serviceAttemptId?: string; registeredWorkers: Set<string> }>();
-const CURSOR_UNSUPPORTED_REVIEW_INTENT_RE =
-  /\b(?:review|audit|critic|critique|security|vulnerabilit|cve|owasp|xss|csrf|sqli|verdict|approval|approve|final\s+decision)\b/i;
-const CURSOR_EXECUTOR_CONTEXT_RE =
-  /\b(?:implement|implementation|apply|edit|patch|fix|build|ci|lint|compile|tsc|type.?check|test|tests|debug|troubleshoot|investigate|root.?cause|diagnos|refactor|clean\s*up|simplif)\b/i;
-const CURSOR_EXECUTOR_CONTEXT_INTENTS = new Set<LaneIntent>([
-  'implementation',
-  'build-fix',
-  'debug',
-  'cleanup',
-  'verification',
-]);
 
-function isCursorExecutorContextTask(task: { subject: string; description: string }): boolean {
-  const text = `${task.subject} ${task.description}`.trim();
-  if (!text || CURSOR_UNSUPPORTED_REVIEW_INTENT_RE.test(text)) return false;
-  if (!CURSOR_EXECUTOR_CONTEXT_RE.test(text)) return false;
-  return CURSOR_EXECUTOR_CONTEXT_INTENTS.has(inferLaneIntent(text));
-}
 interface TeamCadenceEntry {
   workerName: string;
   context?: WorkerCadenceContext;
@@ -605,20 +588,7 @@ export function resolveTaskAssignment(
     roleRoutingConfig as Record<string, TeamRoleAssignmentSpec | undefined> | undefined,
     canonical,
   );
-  if (fallbackAgent === 'cursor') {
-    if (CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {
-      return { agentType: fallbackAgent, model: '', role: canonical };
-    }
-    if (!hasExplicitRole && !hasConfigForRole && isCursorExecutorContextTask(task)) {
-      return { agentType: fallbackAgent, model: '', role: 'executor' };
-    }
-  }
   if (!hasExplicitRole && !hasConfigForRole) {
-    if (fallbackAgent === 'cursor' && !CURSOR_EXECUTOR_TEAM_ROLES.includes(canonical as typeof CURSOR_EXECUTOR_TEAM_ROLES[number])) {
-      throw new Error(
-        `Cursor workers are executor-style only; inferred role "${canonical}" for task "${task.subject}" must run on a native Claude/OMC reviewer agent or another supported CLI worker.`,
-      );
-    }
     return { agentType: fallbackAgent, model: '', role: canonical };
   }
 

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -20,7 +20,7 @@ import type {
   TeamRoleProvider,
   TeamRoleTier,
 } from '../shared/types.js';
-import { CANONICAL_TEAM_ROLES, CURSOR_EXECUTOR_TEAM_ROLES } from '../shared/types.js';
+import { CANONICAL_TEAM_ROLES } from '../shared/types.js';
 import { normalizeDelegationRole } from '../features/delegation-routing/types.js';
 import {
   BUILTIN_EXTERNAL_MODEL_DEFAULTS,
@@ -66,7 +66,6 @@ const ROLE_DEFAULT_TIER: Record<CanonicalTeamRole, TeamRoleTier> = {
 };
 
 const TIER_SET: ReadonlySet<string> = new Set<TeamRoleTier>(['HIGH', 'MEDIUM', 'LOW']);
-const CURSOR_EXECUTOR_TEAM_ROLE_SET: ReadonlySet<string> = new Set(CURSOR_EXECUTOR_TEAM_ROLES);
 
 function isTier(value: string): value is TeamRoleTier {
   return TIER_SET.has(value);
@@ -184,12 +183,6 @@ export function resolveRoleAssignment(
   const provider: TeamRoleProvider = isOrchestrator
     ? 'claude'
     : (spec?.provider ?? 'claude');
-  if (provider === 'cursor' && !CURSOR_EXECUTOR_TEAM_ROLE_SET.has(canonical)) {
-    throw new Error(
-      `team.roleRouting.${canonical}.provider: cursor is only supported for executor-style roles (${[...CURSOR_EXECUTOR_TEAM_ROLE_SET].join(', ')})`,
-    );
-  }
-
   const model = provider === 'claude'
     ? resolveClaudeModel(canonical, spec?.model, cfg)
     : resolveExternalModel(provider, spec?.model, cfg);


### PR DESCRIPTION
Phase 3 of #3880. Lifts the executor-only restriction now that both halves of the reviewer lifecycle exist: injection (#3882) and live-pane consumption (the follow-up commits on that PR).

## Why the gates can close now

They were closed for a real reason. Before #3882 a cursor reviewer would strand in `in_progress` — nothing injected a verdict contract, and nothing consumed one from a pane that never exits. That reason is spent, so the guard is now only blocking a working path.

## Five enforcement points, one root

| File | What it did |
|---|---|
| `src/shared/types.ts` | `CURSOR_EXECUTOR_TEAM_ROLES = ["executor"]` — the constant everything else read |
| `src/config/loader.ts` | threw at config load on `roleRouting` naming cursor for a reviewer role |
| `src/team/stage-router.ts` | `resolveRoleAssignment` threw |
| `src/team/runtime-v2.ts` | `resolveTaskAssignment` threw on an inferred reviewer role |
| `src/cli/commands/team.ts` | spec parser threw, plus help text |

They had to go together — opening only the CLI parser would still leave the runtime throwing at dispatch.

## A heuristic that had to go with them

`runtime-v2` carried `isCursorExecutorContextTask` plus two regexes and an intent set. It existed only to serve the guard: when an inferred role looked like implementation work, it rewrote the role to `executor` so ordinary cursor tasks would not trip the throw.

With the throw gone that coercion is not merely dead — it is actively harmful. It would pin a genuine reviewer task to `executor`, which skips contract injection and strands the task with no verdict. Removed alongside the guard, and `runtime-v2.cursor-routing.test.ts` now asserts an inferred reviewer role **survives** rather than being flattened to executor.

## The e2e test, and proof it bites

Your #3882 review asked for lifecycle coverage rather than text assertions, and noted the earlier tests missed the P1 precisely because none went through `startTeamV2`.

The path these gates actually blocked is `team.roleRouting` — rejected at load (loader) and again at resolve (stage-router). The existing cursor dispatch test passes an **explicit** role, which never reached the runtime throw; only *inferred* roles did. So the new test uses config routing with no explicit role:

```ts
roleRouting: { 'code-reviewer': { provider: 'cursor', model: 'cursor-grok-4.6-high' } }
tasks: [{ subject: 'Review component naming', description: 'code review pass for PR' }]
```

and asserts the whole chain: routing snapshot resolves to cursor → `buildWorkerArgv` called with cursor → persisted worker is `worker_cli: cursor`, `role: code-reviewer`, **`output_file` set** → inbox contains the verdict contract and the read-only guard.

Verified it fails without the source changes. Reverting `src/` to `dev` while keeping the test:

```
FAIL  routes an inferred reviewer task to a cursor worker carrying the verdict contract (#3880)
Error: [OMC] team.roleRouting.code-reviewer.provider: cursor is only supported for executor-style roles (executor)
```

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint` (10 changed files) | clean |
| `runtime-v2.dispatch.test.ts` | 55 passed |
| `team/` + `cli/commands/` + `config/` suites | 1948 passed / 9 failed |
| `inventory-graph-drift` | 11 passed |

The 9 failures are the 4 pre-existing files (`runtime-owner-busy`, `runtime-owner-client`, `runtime-v2.shutdown-pane-cleanup`, `worker-launch-posix-transport`), unchanged from `dev`.

`src/hooks/autopilot/__tests__` also has 5 failures in `cancel.test.ts` and `workflow-integrity.test.ts`. Measured on clean `origin/dev`: **259 passed / 5 failed, same two files** — pre-existing, and I touched no autopilot source.

Four tests inverted, since they pinned the removed behavior: loader roleRouting, CLI spec parser, stage-router resolution, runtime task assignment.

## Scope

Role gating only. `execution-adapter.ts` still tells autopilot that CLI workers are executor-style — that text governs codex/gemini/grok as well, so changing it is a separate autopilot policy decision rather than part of lifting cursor's gate. Same reasoning keeps the `AGENTS.md`/`README.md`/skill-doc updates in Phase 4.
