### PR TITLE
fix(context): stabilize v5.0.1 release test isolation

### DIFF
--- a/bridge/cli.cjs
+++ b/bridge/cli.cjs
@@ -31514,9 +31514,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return (0, import_path18.join)(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root2 = resolveStateAnchorRoot(worktreeRoot);
+  const root2 = worktreeRoot ? (0, import_path18.resolve)(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root2)) {
-    return (0, import_path18.join)(resolveNonGitStateAnchor(root2), OmcPaths.ROOT);
+    return (0, import_path18.join)(worktreeRoot ? root2 : resolveNonGitStateAnchor(root2), OmcPaths.ROOT);
   }
   return (0, import_path18.join)(root2, OmcPaths.ROOT);
 }

--- a/bridge/mcp-server.cjs
+++ b/bridge/mcp-server.cjs
@@ -21704,9 +21704,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return (0, import_path12.join)(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  const root = worktreeRoot ? (0, import_path12.resolve)(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return (0, import_path12.join)(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return (0, import_path12.join)(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return (0, import_path12.join)(root, OmcPaths.ROOT);
 }

--- a/bridge/runtime-cli.cjs
+++ b/bridge/runtime-cli.cjs
@@ -3135,9 +3135,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return (0, import_path12.join)(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  const root = worktreeRoot ? (0, import_path12.resolve)(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return (0, import_path12.join)(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return (0, import_path12.join)(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return (0, import_path12.join)(root, OmcPaths.ROOT);
 }

--- a/bridge/team-bridge.cjs
+++ b/bridge/team-bridge.cjs
@@ -677,9 +677,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return (0, import_path3.join)(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  const root = worktreeRoot ? (0, import_path3.resolve)(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return (0, import_path3.join)(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return (0, import_path3.join)(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return (0, import_path3.join)(root, OmcPaths.ROOT);
 }

--- a/bridge/team-mcp.cjs
+++ b/bridge/team-mcp.cjs
@@ -18438,9 +18438,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return (0, import_path2.join)(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  const root = worktreeRoot ? (0, import_path2.resolve)(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return (0, import_path2.join)(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return (0, import_path2.join)(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return (0, import_path2.join)(root, OmcPaths.ROOT);
 }

--- a/bridge/team.js
+++ b/bridge/team.js
@@ -511,9 +511,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return join2(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  const root = worktreeRoot ? resolve(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return join2(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return join2(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return join2(root, OmcPaths.ROOT);
 }

--- a/dist/hooks/skill-bridge.cjs
+++ b/dist/hooks/skill-bridge.cjs
@@ -588,9 +588,9 @@ function getOmcRoot(worktreeRoot) {
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
     return (0, import_path2.join)(workspaceAnchor, OmcPaths.ROOT);
   }
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  const root = worktreeRoot ? (0, import_path2.resolve)(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return (0, import_path2.join)(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return (0, import_path2.join)(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return (0, import_path2.join)(root, OmcPaths.ROOT);
 }

--- a/dist/lib/worktree-paths.js
+++ b/dist/lib/worktree-paths.js
@@ -824,9 +824,12 @@ export function getOmcRoot(worktreeRoot) {
     if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
         return join(workspaceAnchor, OmcPaths.ROOT);
     }
-    const root = resolveStateAnchorRoot(worktreeRoot);
+    // An explicit root is an authoritative state anchor, including for
+    // non-git callers and isolated test/fixture directories. Only implicit
+    // resolution adopts the stable non-git fallback.
+    const root = worktreeRoot ? resolve(worktreeRoot) : resolveStateAnchorRoot();
     if (!getGitTopLevel(root)) {
-        return join(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+        return join(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
     }
     return join(root, OmcPaths.ROOT);
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "4e0c406d0c2bc8f4021ac21cc5619a5621d23289",
-    "sourceSha256": "3c264e96dd2a5b266f05d63c59aea34c68cda24423f314aa31a67498428950f5",
+    "head": "6b8b0c5689ebd6d17171edd1f91421f8027933c6",
+    "sourceSha256": "9d83b9b77bf035ebb08c28805de02d53bdfe509ce038a88b728f9f32b87758ba",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "4e0c406d0c2bc8f4021ac21cc5619a5621d23289",
-  "sourceSha256": "3c264e96dd2a5b266f05d63c59aea34c68cda24423f314aa31a67498428950f5",
+  "head": "6b8b0c5689ebd6d17171edd1f91421f8027933c6",
+  "sourceSha256": "9d83b9b77bf035ebb08c28805de02d53bdfe509ce038a88b728f9f32b87758ba",
   "counts": {
     "public": {
       "skills": 32,
@@ -76480,5 +76480,5 @@
     }
   },
   "inventorySha256": "d34ebca442eea63fe880245c9973a6450b99ecf04856906bcd66c03d35ee5c5b",
-  "manifestSha256": "805a2f7ca05a9214c78f4a1812c546d67081a156da77aeec1a10695dc1bc2888"
+  "manifestSha256": "5e2ce82f2c87721f2aa692f232d2f4dee6e42d0336575acb12c6d176b50e4056"
 }

--- a/scripts/lib/context-usage.mjs
+++ b/scripts/lib/context-usage.mjs
@@ -122,7 +122,10 @@ export async function resolveHudCacheContextPercent(data, directory) {
       return null;
     }
 
-    const root = getWorktreeRoot(directory || undefined) || directory || process.cwd();
+    // An explicit directory is already the caller's state anchor. Resolve a
+    // worktree root only for the process-wide fallback; otherwise temporary
+    // or non-git callers would read a different .omc tree than they supplied.
+    const root = directory || getWorktreeRoot() || process.cwd();
     // Mirror the HUD's own session-identity resolution exactly
     // (src/hud/stdin.ts getStdinCachePath): walk the candidates — payload
     // session id first, then the env-var candidates in priority order —

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -881,9 +881,12 @@ export function getOmcRoot(worktreeRoot?: string): string {
     return join(workspaceAnchor, OmcPaths.ROOT);
   }
 
-  const root = resolveStateAnchorRoot(worktreeRoot);
+  // An explicit root is an authoritative state anchor, including for
+  // non-git callers and isolated test/fixture directories. Only implicit
+  // resolution adopts the stable non-git fallback.
+  const root = worktreeRoot ? resolve(worktreeRoot) : resolveStateAnchorRoot();
   if (!getGitTopLevel(root)) {
-    return join(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
+    return join(worktreeRoot ? root : resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
   return join(root, OmcPaths.ROOT);
 }


### PR DESCRIPTION
Owner-approved release fix-forward under Discord approval 1542761907411361853. Stabilizes explicit non-git state anchors so HUD cache tests and real callers use the supplied root; regenerates shipped bridge runtime. Focused context and SessionEnd tests pass 32/32. Prior failed tag commit a055279be8cbf24df37a92446816f421ec6a2d86 is superseded and will be replaced only after full validation.