### PR TITLE
fix(graph): complete issue 3893 safe filesystem containment

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "6803fceeb01d5e58a50258dfbfb72ec2e56620f9",
-    "sourceSha256": "20ac9072884ef297dd0c550ad9f7f74ac1f17c3f0cb1cbc68ef0e7275a4f222f",
+    "head": "96b341e64e49e70a9b7528e39ce9d38696635031",
+    "sourceSha256": "02d8af3144c3ef9c1d8184ae9a2e627a1ca15157d856b374e4a28dc1dc171b5c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "6803fceeb01d5e58a50258dfbfb72ec2e56620f9",
-  "sourceSha256": "20ac9072884ef297dd0c550ad9f7f74ac1f17c3f0cb1cbc68ef0e7275a4f222f",
+  "head": "96b341e64e49e70a9b7528e39ce9d38696635031",
+  "sourceSha256": "02d8af3144c3ef9c1d8184ae9a2e627a1ca15157d856b374e4a28dc1dc171b5c",
   "counts": {
     "public": {
       "skills": 32,
@@ -53695,12 +53695,27 @@
       },
       {
         "from": "src/graph/runtime/fence.ts",
+        "to": "external:fs",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
         "to": "external:path",
         "kind": "imports"
       },
       {
         "from": "src/graph/runtime/fence.ts",
         "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "src/graph/runtime/safe-fs.ts",
         "kind": "imports"
       },
       {
@@ -76431,11 +76446,11 @@
     ],
     "stats": {
       "nodeCount": 6834,
-      "edgeCount": 7196,
-      "importEdgeCount": 5912,
+      "edgeCount": 7199,
+      "importEdgeCount": 5913,
       "registerEdgeCount": 53
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "eb93bf7a50e730779a1291777abb98a9ddbae64d47b1462bd370d798b70fcbdc"
+  "manifestSha256": "539c7204ae706bb16a4f1fc7c5286e0fa9de9d536bdc3e078b20c81994e8f1e8"
 }

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -28,6 +28,7 @@ import { createAsciiProgressReporter } from '../graph/runtime/progress.js';
 import { resolveRunDirHandle } from '../graph/runtime/run-dir.js';
 import type { RunDirHandle } from '../graph/runtime/run-dir.js';
 import {
+  assertContainedFsSupported,
   readContainedFileNoFollow,
   readFileNoFollow,
 } from '../graph/runtime/safe-fs.js';
@@ -111,6 +112,15 @@ async function loadSealedDescriptor(
 }
 
 async function runAction(descriptorPath: string, runsRoot: string): Promise<void> {
+  try {
+    // Reject unsupported POSIX before descriptor/run-directory resolution so
+    // the fail-closed contract cannot create persistence state as a side
+    // effect of a CLI preflight.
+    assertContainedFsSupported(process.platform);
+  } catch (error) {
+    fail(`graph runtime is unavailable on ${process.platform}: ${errorMessage(error)}`, 1);
+    return;
+  }
   const sealed = await loadSealedDescriptor(descriptorPath, runsRoot);
   if (sealed === null) return;
 

--- a/src/graph/__tests__/runtime/cli.test.ts
+++ b/src/graph/__tests__/runtime/cli.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { sealGraphDescriptor } from '../../descriptor.js';
@@ -178,5 +178,25 @@ describe('graphCommand run subcommand', () => {
       missingPath,
     );
     expect(mocks.runGraph).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on unsupported POSIX before creating run state', async () => {
+    const runsRoot = join(workDir, '.omc', 'graph-runs');
+    const fixturePath = join(workDir, 'descriptor.json');
+    writeFileSync(fixturePath, JSON.stringify(descriptorInput('run-darwin', 'unsupported')));
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+
+    try {
+      await parseCli(['run', fixturePath, '--runs-root', runsRoot]);
+    } finally {
+      platform.mockRestore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(mocks.runGraph).not.toHaveBeenCalled();
+    expect(existsSync(runsRoot)).toBe(false);
+    expect(errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')).toContain(
+      'graph runtime is unavailable on darwin',
+    );
   });
 });

--- a/src/graph/__tests__/runtime/fence.test.ts
+++ b/src/graph/__tests__/runtime/fence.test.ts
@@ -17,6 +17,8 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  symlinkSync,
+  unlinkSync,
   utimesSync,
   writeFileSync,
 } from "fs";
@@ -66,7 +68,7 @@ function readLockPayload(dir: string): FenceLockPayload {
 }
 
 describe("FileOwnershipFence", () => {
-  let roots: string[] = [];
+  const roots: string[] = [];
 
   /** Fresh runsRoot + run dir under os.tmpdir(); auto-cleaned after each test. */
   function makeRunDir(): string {
@@ -96,6 +98,30 @@ describe("FileOwnershipFence", () => {
     await expect(makeFence(dir).acquire()).resolves.toEqual({ outcome: "busy" });
   });
 
+  it("fails closed when the run-directory parent is replaced after acquisition", async () => {
+    const dir = makeRunDir();
+    const fence = makeFence(dir);
+    await expect(fence.acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: 1,
+    });
+
+    const originalRoot = dirname(dir);
+    const outsideRoot = mkdtempSync(join(tmpdir(), "omc-fence-outside-"));
+    roots.push(outsideRoot);
+    mkdirSync(join(outsideRoot, basename(dir)), { recursive: true });
+    renameSync(originalRoot, `${originalRoot}-original`);
+    symlinkSync(outsideRoot, originalRoot);
+    try {
+      expect(() => fence.assertEpoch(1)).toThrow();
+      await expect(fence.release(1)).rejects.toThrow("run directory identity changed");
+      expect(existsSync(join(outsideRoot, basename(dir), LOCK_NAME))).toBe(false);
+    } finally {
+      unlinkSync(originalRoot);
+      renameSync(`${originalRoot}-original`, originalRoot);
+    }
+  });
+
   it("takes over a dead holder's lock at old_epoch + 1 (AC-4)", async () => {
     const dir = makeRunDir();
     craftJsonLock(dir, {
@@ -114,6 +140,74 @@ describe("FileOwnershipFence", () => {
       epoch: 2,
     });
     expect(readFileSync(join(dir, EPOCH_FILE_NAME), "utf8").trim()).toBe("2");
+  });
+
+  it.each(["10garbage", "1garbage", "+10", " 10", "10 ", "1.0", "1e2", "0", "9007199254740992"]) (
+    "rejects non-canonical owner.epoch text %j without issuing an epoch",
+    async (sidecar) => {
+      const dir = makeRunDir();
+      writeFileSync(join(dir, EPOCH_FILE_NAME), sidecar, "utf8");
+
+      await expect(makeFence(dir).acquire()).rejects.toThrow("owner.epoch");
+      expect(existsSync(join(dir, LOCK_NAME))).toBe(false);
+    },
+  );
+
+  it("refuses symlinked epoch and lock state instead of reading outside", async () => {
+    const dir = makeRunDir();
+    const outside = mkdtempSync(join(tmpdir(), "omc-fence-symlink-outside-"));
+    roots.push(outside);
+    const outsideEpoch = join(outside, EPOCH_FILE_NAME);
+    const outsideLock = join(outside, LOCK_NAME);
+    writeFileSync(outsideEpoch, "9007199254740992", "utf8");
+    writeFileSync(outsideLock, "not json", "utf8");
+
+    symlinkSync(outsideEpoch, join(dir, EPOCH_FILE_NAME));
+    await expect(makeFence(dir).acquire()).rejects.toThrow(/ELOOP|symbolic link refused/);
+
+    unlinkSync(join(dir, EPOCH_FILE_NAME));
+    symlinkSync(outsideLock, join(dir, LOCK_NAME));
+    await expect(makeFence(dir).acquire()).rejects.toThrow(/ELOOP|symbolic link refused/);
+    expect(readFileSync(outsideEpoch, "utf8")).toBe("9007199254740992");
+    expect(readFileSync(outsideLock, "utf8")).toBe("not json");
+  });
+
+  it.each([1.5, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects stale lock epoch %j instead of issuing an unsafe successor",
+    async (epoch) => {
+      const dir = makeRunDir();
+      craftJsonLock(dir, {
+        pid: spawnDeadPid(),
+        epoch,
+        timestamp: Date.now(),
+      });
+      backdate(join(dir, LOCK_NAME));
+
+      await expect(makeFence(dir).acquire()).rejects.toThrow("stale lock epoch");
+      expect(existsSync(join(dir, LOCK_NAME))).toBe(false);
+    },
+  );
+
+  it("accepts the largest sidecar that still has a safe successor", async () => {
+    const dir = makeRunDir();
+    writeFileSync(
+      join(dir, EPOCH_FILE_NAME),
+      String(Number.MAX_SAFE_INTEGER - 1),
+      "utf8",
+    );
+
+    await expect(makeFence(dir).acquire()).resolves.toEqual({
+      outcome: "acquired",
+      epoch: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
+  it("fails closed when the sidecar has no safe successor", async () => {
+    const dir = makeRunDir();
+    writeFileSync(join(dir, EPOCH_FILE_NAME), String(Number.MAX_SAFE_INTEGER), "utf8");
+
+    await expect(makeFence(dir).acquire()).rejects.toThrow("no representable successor");
+    expect(existsSync(join(dir, LOCK_NAME))).toBe(false);
   });
 
   it("does not take over a replacement lock raced into the stale path", async () => {

--- a/src/graph/__tests__/runtime/safe-fs.test.ts
+++ b/src/graph/__tests__/runtime/safe-fs.test.ts
@@ -1,12 +1,11 @@
 import {
-  constants,
   existsSync,
-  mkdirSync,
   mkdtempSync,
   readFileSync,
   renameSync,
   rmSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "fs";
 import { tmpdir } from "os";
@@ -15,7 +14,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import { resolveRunDirHandle } from "../../runtime/run-dir.js";
 import {
   containedPathForPlatform,
-  openNoFollow,
+  assertSafeContainedFileName,
+  assertContainedFsSupported,
   readContainedFileNoFollow,
   withContainedPathForPlatform,
 } from "../../runtime/safe-fs.js";
@@ -43,11 +43,11 @@ describe("graph runtime safe filesystem", () => {
       containedPathForPlatform(7, "/runs/example", "artifact", "linux"),
     ).toBe("/proc/self/fd/7/artifact");
     expect(
-      containedPathForPlatform(7, "/runs/example", "artifact", "darwin"),
-    ).toBe("/runs/example/artifact");
-    expect(
       containedPathForPlatform(7, "C:/runs/example", "artifact", "win32"),
     ).toBe("C:/runs/example/artifact");
+
+    expect(() => containedPathForPlatform(7, "/runs/example", "artifact", "darwin"))
+      .toThrow("refusing pathname fallback");
 
     expect(process.platform).toBe(before);
   });
@@ -80,31 +80,20 @@ describe("graph runtime safe filesystem", () => {
     expect(existsSync(join(handle.path, "renamed.txt"))).toBe(false);
   });
 
-  it("rejects a final artifact symlink on Linux and darwin path fallback", () => {
+  it("rejects a final artifact symlink on Linux and refuses darwin fallback", () => {
     const { root, handle } = makeRunDir();
     const outside = join(root, "outside.txt");
     writeFileSync(outside, "outside");
     symlinkSync(outside, join(handle.path, "artifact.txt"));
 
     expect(() => readContainedFileNoFollow(handle, "artifact.txt")).toThrow();
-    expect(() =>
-      withContainedPathForPlatform(
-        handle,
-        "artifact.txt",
-        (path) => openNoFollow(path, constants.O_RDONLY),
-        "darwin",
-      ),
-    ).toThrow();
+    expect(() => withContainedPathForPlatform(handle, "artifact.txt", () => undefined, "darwin"))
+      .toThrow("refusing pathname fallback");
     expect(readFileSync(outside, "utf8")).toBe("outside");
   });
 
-  it("rejects an identity change before a darwin fallback operation", () => {
-    const { root, handle } = makeRunDir();
-    const replacement = join(root, "replacement");
-    mkdirSync(replacement);
-    renameSync(handle.path, join(root, "old-run"));
-    renameSync(replacement, handle.path);
-
+  it("rejects non-Linux POSIX operations before any pathname fallback", () => {
+    const { handle } = makeRunDir();
     expect(() =>
       withContainedPathForPlatform(
         handle,
@@ -112,7 +101,7 @@ describe("graph runtime safe filesystem", () => {
         () => undefined,
         "darwin",
       ),
-    ).toThrow("run directory identity changed");
+    ).toThrow("refusing pathname fallback");
   });
 
   it("keeps the Windows path fallback and identity guard unchanged", () => {
@@ -136,5 +125,81 @@ describe("graph runtime safe filesystem", () => {
     expect(() => readContainedFileNoFollow(handle, "missing.txt")).toThrow(
       expect.objectContaining({ code: "ENOENT" }),
     );
+  });
+
+  it.each([
+    "",
+    ".",
+    "..",
+    "../outside.txt",
+    "nested/file.txt",
+    "nested\\file.txt",
+    "/absolute.txt",
+    "C:\\absolute.txt",
+    "artifact\0.txt",
+    "artifact\n.txt",
+    "artifact/../outside.txt",
+  ])("rejects unsafe contained artifact name %j", (fileName) => {
+    expect(() => assertSafeContainedFileName(fileName)).toThrow("invalid contained artifact");
+  });
+
+  it("rejects Windows alternate data stream names even when simulating Windows", () => {
+    expect(() => assertSafeContainedFileName("artifact:stream", "win32")).toThrow(
+      "invalid contained artifact",
+    );
+  });
+
+  it("accepts canonical NFC and rejects decomposed NFD basenames", () => {
+    expect(() => assertSafeContainedFileName("café.txt")).not.toThrow();
+    expect(() => assertSafeContainedFileName("café.txt")).toThrow(
+      "invalid contained artifact",
+    );
+  });
+
+  it.each(["CON", "CON.txt", "NUL.log", "COM1", "LPT9", "AUX.md"]) (
+    "rejects Windows device basename %j",
+    (fileName) => {
+      expect(() => assertSafeContainedFileName(fileName, "win32")).toThrow(
+        "invalid contained artifact",
+      );
+    },
+  );
+
+  it("exposes an explicit fail-closed capability check", () => {
+    expect(() => assertContainedFsSupported("darwin")).toThrow(
+      "refusing pathname fallback",
+    );
+    expect(() => assertContainedFsSupported("linux")).not.toThrow();
+    expect(() => assertContainedFsSupported("win32")).not.toThrow();
+  });
+
+  it("rejects a parent replacement before Linux procfs traversal", () => {
+    const { root, handle } = makeRunDir();
+    const outside = mkdtempSync(join(tmpdir(), "omc-safe-fs-outside-"));
+    tempDirs.push(outside);
+    renameSync(root, `${root}-original`);
+    symlinkSync(outside, root);
+    try {
+      expect(() => readContainedFileNoFollow(handle, "artifact.txt")).toThrow();
+    } finally {
+      unlinkSync(root);
+      renameSync(`${root}-original`, root);
+    }
+  });
+
+  it("validates names before Linux procfs traversal", () => {
+    const { handle } = makeRunDir();
+    expect(() => readContainedFileNoFollow(handle, "../outside.txt")).toThrow(
+      "invalid contained artifact",
+    );
+  });
+
+  it("fails closed for every operation on non-Linux POSIX", () => {
+    const { handle } = makeRunDir();
+    for (const operation of ["read", "write", "rename", "delete"]) {
+      expect(() =>
+        withContainedPathForPlatform(handle, "artifact.txt", () => operation, "darwin"),
+      ).toThrow("refusing pathname fallback");
+    }
   });
 });

--- a/src/graph/runtime/fence.ts
+++ b/src/graph/runtime/fence.ts
@@ -22,19 +22,24 @@ import {
   closeSync,
   constants as fsConstants,
   fstatSync,
+  lstatSync,
   mkdirSync,
-  openSync,
-  readFileSync,
   renameSync,
-  statSync,
   unlinkSync,
   writeSync,
 } from "fs";
+import type { Stats } from "fs";
 import { randomBytes } from "crypto";
 import { dirname, join } from "path";
 import { atomicWriteFileSync } from "../../lib/atomic-write.js";
 import { isProcessAlive } from "../../platform/index.js";
-import { resolveRunDir } from "./run-dir.js";
+import { resolveRunDirHandle } from "./run-dir.js";
+import type { RunDirHandle } from "./run-dir.js";
+import {
+  openNoFollow,
+  readFileNoFollow,
+  withContainedDirectory,
+} from "./safe-fs.js";
 import { FenceError } from "./types.js";
 import type { FenceAcquireResult, FenceLockPayload, OwnershipFence } from "./types.js";
 
@@ -42,17 +47,49 @@ const DEFAULT_STALE_GRACE_MS = 30_000;
 const LOCK_FILE_NAME = "owner.lock";
 const EPOCH_FILE_NAME = "owner.epoch";
 
+function isSafeEpoch(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= 1 &&
+    value <= Number.MAX_SAFE_INTEGER
+  );
+}
+
+function canIssueSuccessor(value: unknown): value is number {
+  return isSafeEpoch(value) && value < Number.MAX_SAFE_INTEGER;
+}
+
 /**
  * Highest epoch ever issued for this run, parsed from the sidecar; null when
  * the sidecar is missing or unreadable (fresh run / lost continuity).
  */
 function readSidecarCeiling(filePath: string): number | null {
+  let text: string;
   try {
-    const value = Number.parseInt(readFileSync(filePath, "utf8").trim(), 10);
-    return Number.isInteger(value) && value >= 1 ? value : null;
-  } catch {
-    return null;
+    text = readFileNoFollow(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
   }
+  if (!/^[1-9][0-9]*$/.test(text)) {
+    throw new Error("owner.epoch is not a canonical plain integer");
+  }
+  const value = Number(text);
+  if (!Number.isSafeInteger(value) || String(value) !== text) {
+    throw new Error("owner.epoch is outside the safe integer range");
+  }
+  return value;
+}
+
+function lstatNoFollow(filePath: string): Stats {
+  const stats = lstatSync(filePath);
+  if (stats.isSymbolicLink()) {
+    const error = new Error(`symbolic link refused: ${filePath}`) as NodeJS.ErrnoException;
+    error.code = "ELOOP";
+    throw error;
+  }
+  return stats;
 }
 
 export interface FileOwnershipFenceOptions {
@@ -67,6 +104,7 @@ export class FileOwnershipFence implements OwnershipFence {
   private readonly runId?: string;
   private readonly staleGraceMs: number;
   private readonly beforeTakeoverRename?: () => void;
+  private handle?: RunDirHandle;
   /** fd of the held lock file while we own the run; null otherwise. */
   private fd: number | null = null;
   private heldEpoch: number | null = null;
@@ -81,24 +119,37 @@ export class FileOwnershipFence implements OwnershipFence {
     runsRoot: string,
     runId?: string,
     options?: FileOwnershipFenceOptions,
+    runDirHandle?: RunDirHandle,
   ) {
     this.runsRoot = runsRoot;
     this.runId = runId;
     this.staleGraceMs = options?.staleGraceMs ?? DEFAULT_STALE_GRACE_MS;
     this.beforeTakeoverRename = options?.beforeTakeoverRename;
+    this.handle = runDirHandle;
   }
 
-  private lockPath(): string {
+  private runDir(): RunDirHandle {
     if (this.runId === undefined) {
       throw new Error(
         "FileOwnershipFence is not bound to a run; pass runId to the constructor",
       );
     }
-    return join(resolveRunDir(this.runsRoot, this.runId), LOCK_FILE_NAME);
+    this.handle ??= resolveRunDirHandle(this.runsRoot, this.runId);
+    return this.handle;
+  }
+
+  private lockPath(directoryPath: string): string {
+    return join(directoryPath, LOCK_FILE_NAME);
   }
 
   async acquire(): Promise<FenceAcquireResult> {
-    const lockPath = this.lockPath();
+    return withContainedDirectory(this.runDir(), (directoryPath) =>
+      this.acquireAt(directoryPath),
+    );
+  }
+
+  private acquireAt(directoryPath: string): FenceAcquireResult {
+    const lockPath = this.lockPath(directoryPath);
     const epochFilePath = join(dirname(lockPath), EPOCH_FILE_NAME);
     let candidateEpoch = 1;
     // Each iteration makes progress toward either acquisition or a
@@ -107,9 +158,15 @@ export class FileOwnershipFence implements OwnershipFence {
     // our attempts.
     for (;;) {
       const ceiling = readSidecarCeiling(epochFilePath);
+      if (ceiling === Number.MAX_SAFE_INTEGER) {
+        throw new Error("owner.epoch has no representable successor");
+      }
       // Never reissue an epoch the sidecar has seen; a missing/corrupt
       // sidecar imposes no floor (fresh runs still start at epoch 1).
       const candidate = Math.max(candidateEpoch, (ceiling ?? 0) + 1);
+      if (!isSafeEpoch(candidate)) {
+        throw new Error("owner epoch has no safe representable value");
+      }
       const fd = this.tryCreate(lockPath, epochFilePath, candidate);
       if (fd !== null) {
         this.fd = fd;
@@ -127,8 +184,9 @@ export class FileOwnershipFence implements OwnershipFence {
       // Dead pid or unparseable content: takeover only past the grace period.
       let ageMs: number;
       try {
-        ageMs = Date.now() - statSync(lockPath).mtimeMs;
-      } catch {
+        ageMs = Date.now() - lstatNoFollow(lockPath).mtimeMs;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ELOOP") throw error;
         continue; // Lock vanished under us; retry exclusive creation.
       }
       if (ageMs <= this.staleGraceMs) {
@@ -175,18 +233,30 @@ export class FileOwnershipFence implements OwnershipFence {
       // old_epoch 1; continuity then rests on the owner.epoch sidecar, and
       // only if BOTH are lost can an epoch value repeat. Ownership safety
       // comes from O_EXCL create + atomic rename, not from the epoch value.
-      let oldEpoch = 1; // fallback per protocol when unreadable
+      let oldEpoch = 1; // preserve corrupt-lock recovery for non-JSON content
       try {
-        const parsed: unknown = JSON.parse(readFileSync(tombstone, "utf8"));
+        const parsed: unknown = JSON.parse(readFileNoFollow(tombstone));
         if (
           parsed !== null &&
           typeof parsed === "object" &&
-          typeof (parsed as Record<string, unknown>).epoch === "number"
+          Object.prototype.hasOwnProperty.call(parsed, "epoch")
         ) {
-          oldEpoch = (parsed as Record<string, unknown>).epoch as number;
+          const epoch = (parsed as Record<string, unknown>).epoch;
+          if (!canIssueSuccessor(epoch)) {
+            throw new Error("stale lock epoch is not a safe integer");
+          }
+          oldEpoch = epoch;
         }
-      } catch {
-        // Unparseable tombstone: keep fallback old_epoch = 1.
+      } catch (error) {
+        if ((error as Error).message === "stale lock epoch is not a safe integer") {
+          try {
+            unlinkSync(tombstone);
+          } catch {
+            // Best effort cleanup of our own tombstone.
+          }
+          throw error;
+        }
+        // Unparseable JSON tombstone: keep fallback old_epoch = 1.
       }
       try {
         unlinkSync(tombstone); // safe: unique name we exclusively own
@@ -198,11 +268,17 @@ export class FileOwnershipFence implements OwnershipFence {
   }
 
   assertEpoch(epoch: number): void {
+    withContainedDirectory(this.runDir(), (directoryPath) =>
+      this.assertEpochAt(epoch, directoryPath),
+    );
+  }
+
+  private assertEpochAt(epoch: number, directoryPath: string): void {
     if (
       this.fd === null ||
       this.heldEpoch === null ||
       epoch !== this.heldEpoch ||
-      !this.holdsLiveLockFile(this.lockPath())
+      !this.holdsLiveLockFile(this.lockPath(directoryPath))
     ) {
       throw new FenceError(
         "fenced_out",
@@ -212,10 +288,16 @@ export class FileOwnershipFence implements OwnershipFence {
   }
 
   async release(epoch: number): Promise<boolean> {
+    return withContainedDirectory(this.runDir(), (directoryPath) =>
+      this.releaseAt(epoch, directoryPath),
+    );
+  }
+
+  private releaseAt(epoch: number, directoryPath: string): boolean {
     if (this.fd === null || this.heldEpoch === null || epoch !== this.heldEpoch) {
       return false;
     }
-    const lockPath = this.lockPath();
+    const lockPath = this.lockPath(directoryPath);
     // Identity check before any mutation: the file at the lock path must
     // still be OUR held file. A stale holder must never rename away a
     // replacement owner's lock planted at the same path.
@@ -259,7 +341,7 @@ export class FileOwnershipFence implements OwnershipFence {
     mkdirSync(dirname(lockPath), { recursive: true });
     let fd: number;
     try {
-      fd = openSync(
+      fd = openNoFollow(
         lockPath,
         fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
         0o600,
@@ -297,7 +379,7 @@ export class FileOwnershipFence implements OwnershipFence {
   /** Best-effort parse of the lock payload; null when absent/unparseable. */
   private readPayload(lockPath: string): FenceLockPayload | null {
     try {
-      const parsed: unknown = JSON.parse(readFileSync(lockPath, "utf8"));
+      const parsed: unknown = JSON.parse(readFileNoFollow(lockPath));
       if (parsed === null || typeof parsed !== "object") {
         return null;
       }
@@ -305,7 +387,7 @@ export class FileOwnershipFence implements OwnershipFence {
       if (
         typeof record.pid !== "number" ||
         !Number.isInteger(record.pid) ||
-        typeof record.epoch !== "number" ||
+        !isSafeEpoch(record.epoch) ||
         typeof record.timestamp !== "number"
       ) {
         return null;
@@ -327,7 +409,7 @@ export class FileOwnershipFence implements OwnershipFence {
     readonly payload: FenceLockPayload | null;
   } | null {
     try {
-      const stats = statSync(lockPath);
+      const stats = lstatNoFollow(lockPath);
       return {
         ino: stats.ino,
         size: stats.size,
@@ -358,16 +440,17 @@ export class FileOwnershipFence implements OwnershipFence {
 
   private pathExists(path: string): boolean {
     try {
-      statSync(path);
+      lstatNoFollow(path);
       return true;
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") throw error;
       return false;
     }
   }
 
   /**
    * Verify the file currently at lockPath is still the exact file we hold an
-   * fd for: same inode and size (fstatSync on our held fd vs statSync on the
+   * fd for: same inode and size (fstatSync on our held fd vs lstatSync on the
    * path) AND payload epoch matching heldEpoch. Any stat failure or mismatch
    * fails closed — the caller must not mutate the path.
    */
@@ -377,7 +460,7 @@ export class FileOwnershipFence implements OwnershipFence {
     }
     try {
       const ours = fstatSync(this.fd);
-      const theirs = statSync(lockPath);
+      const theirs = lstatNoFollow(lockPath);
       if (ours.ino !== theirs.ino || ours.size !== theirs.size) {
         return false;
       }

--- a/src/graph/runtime/journal.ts
+++ b/src/graph/runtime/journal.ts
@@ -92,6 +92,7 @@ function envelopeError(value: unknown): string | null {
 export class FileJournal implements Journal {
   private readonly runsRoot: string;
   private readonly runId?: string;
+  private readonly handle?: RunDirHandle;
 
   /**
    * The frozen `Journal` interface is run-scoped but carries no run id, so an
@@ -99,9 +100,14 @@ export class FileJournal implements Journal {
    * brief's `new FileJournal(runsRoot)` signature constructible; unbound
    * instances fail closed on use.
    */
-  constructor(runsRoot: string, runId?: string) {
+  constructor(
+    runsRoot: string,
+    runId?: string,
+    runDirHandle?: RunDirHandle,
+  ) {
     this.runsRoot = runsRoot;
     this.runId = runId;
+    this.handle = runDirHandle;
   }
 
   async append(record: JournalAppendRecord): Promise<void> {
@@ -147,7 +153,9 @@ export class FileJournal implements Journal {
         "FileJournal is not bound to a run; pass runId to the constructor",
       );
     }
-    return resolveRunDirHandle(this.runsRoot, this.runId);
+    return (
+      this.handle ?? resolveRunDirHandle(this.runsRoot, this.runId)
+    );
   }
 
   async readAll(): Promise<readonly JournalRecord[]> {

--- a/src/graph/runtime/runner.ts
+++ b/src/graph/runtime/runner.ts
@@ -36,7 +36,11 @@ import type { RunDirHandle } from "./run-dir.js";
 import { computeJournalFingerprint, FileJournal } from "./journal.js";
 import { FileOwnershipFence } from "./fence.js";
 import { FileProjectionStore } from "./store.js";
-import { readContainedFileNoFollow, withContainedPath } from "./safe-fs.js";
+import {
+  assertContainedFsSupported,
+  readContainedFileNoFollow,
+  withContainedPath,
+} from "./safe-fs.js";
 
 import { EXIT_CODES, FenceError, JournalCorruptionError } from "./types.js";
 import type {
@@ -491,15 +495,19 @@ export async function runGraph(
   sealed: SealedGraphDescriptor,
   options: RunOptions,
 ): Promise<RunResult> {
+  // Refuse unsupported POSIX platforms before resolving/acquiring any
+  // run-scoped ownership state. Node has no supported openat/f*at API, so a
+  // pathname fallback would make the containment guarantee raceable.
+  assertContainedFsSupported(process.platform);
   const runsRoot =
     options.runsRoot ?? join(process.cwd(), ...DEFAULT_RUNS_ROOT_SEGMENTS);
   const runId = sealed.run_id;
   // Contained run dir (P1-3): validates run_id, rejects symlink escapes, and
   // creates the directory before any persistence component touches disk.
   const runDirHandle: RunDirHandle = resolveRunDirHandle(runsRoot, runId);
-  const fence = new FileOwnershipFence(runsRoot, runId);
-  const journal = new FileJournal(runsRoot, runId);
-  const store = new FileProjectionStore(runsRoot, runId);
+  const fence = new FileOwnershipFence(runsRoot, runId, undefined, runDirHandle);
+  const journal = new FileJournal(runsRoot, runId, runDirHandle);
+  const store = new FileProjectionStore(runsRoot, runId, runDirHandle);
 
   const emit = (event: RuntimeProgressEvent): void => {
     options.reporter?.onEvent(event);

--- a/src/graph/runtime/safe-fs.ts
+++ b/src/graph/runtime/safe-fs.ts
@@ -7,10 +7,59 @@ import {
   readFileSync,
   statSync,
 } from "fs";
-import { join } from "path";
+import { isAbsolute, join, normalize, win32 } from "path";
 import type { RunDirHandle } from "./run-dir.js";
 
 const NO_FOLLOW = process.platform === "win32" ? 0 : fsConstants.O_NOFOLLOW;
+
+const UNSAFE_CONTROL = /[\u0000-\u001f\u007f]/;
+const WINDOWS_DEVICE_NAME = /^(?:con|prn|aux|nul|clock\$|com[1-9¹²³]|lpt[1-9¹²³])(?:\..*)?$/i;
+
+/** Fail closed before acquiring any run-scoped locks on unsupported POSIX. */
+export function assertContainedFsSupported(
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "linux" && platform !== "win32") {
+    throw new Error(
+      `contained directory-FD traversal is unavailable on ${platform}; refusing pathname fallback`,
+    );
+  }
+}
+
+/**
+ * Validate the untrusted final component before it reaches any path API.
+ * Contained artifacts are deliberately a single portable basename: allowing
+ * either platform separator would make the contract depend on the host that
+ * happens to process the descriptor, and Windows also treats `:` as an ADS
+ * separator. Require canonical NFC so the same artifact name has one portable
+ * byte-level spelling across Linux, macOS, and Windows; reject normalization-
+ * changing values rather than attempting to canonicalize untrusted input.
+ */
+export function assertSafeContainedFileName(
+  fileName: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (
+    typeof fileName !== "string" ||
+    fileName.length === 0 ||
+    fileName === "." ||
+    fileName === ".." ||
+    fileName.includes("/") ||
+    fileName.includes("\\") ||
+    fileName.includes("\0") ||
+    UNSAFE_CONTROL.test(fileName) ||
+    fileName.normalize("NFC") !== fileName ||
+    isAbsolute(fileName) ||
+    win32.isAbsolute(fileName) ||
+    normalize(fileName) !== fileName ||
+    win32.normalize(fileName) !== fileName ||
+    (platform === "win32" && fileName.includes(":")) ||
+    (platform === "win32" && WINDOWS_DEVICE_NAME.test(fileName)) ||
+    (fileName.endsWith(".") || fileName.endsWith(" "))
+  ) {
+    throw new RangeError(`invalid contained artifact fileName: ${JSON.stringify(fileName)}`);
+  }
+}
 
 /** Open a runtime artifact without following a symlink at the final path. */
 export function openNoFollow(
@@ -58,9 +107,11 @@ export function containedPathForPlatform(
   fileName: string,
   platform: NodeJS.Platform = process.platform,
 ): string {
+  assertSafeContainedFileName(fileName, platform);
   if (platform === "linux") {
     return join(`/proc/self/fd/${directoryFd}`, fileName);
   }
+  assertContainedFsSupported(platform);
   return join(runDirPath, fileName);
 }
 
@@ -83,17 +134,46 @@ export function withContainedPath<T>(
   );
 }
 
+/** Run several related operations beneath one identity-checked directory FD. */
+export function withContainedDirectory<T>(
+  runDir: RunDirHandle,
+  operation: (directoryPath: string) => T,
+  platform: NodeJS.Platform = process.platform,
+): T {
+  assertContainedFsSupported(platform);
+  if (platform === "win32") {
+    const stats = statSync(runDir.path);
+    if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
+      throw new Error("run directory identity changed");
+    }
+    return operation(runDir.path);
+  }
+  const directoryFd = openNoFollow(
+    runDir.path,
+    fsConstants.O_RDONLY | (fsConstants.O_DIRECTORY ?? 0),
+  );
+  try {
+    const stats = fstatSync(directoryFd);
+    if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
+      throw new Error("run directory identity changed");
+    }
+    return operation(`/proc/self/fd/${directoryFd}`);
+  } finally {
+    closeSync(directoryFd);
+  }
+}
+
 export function withContainedPathForPlatform<T>(
   runDir: RunDirHandle,
   fileName: string,
   operation: (filePath: string) => T,
   platform: NodeJS.Platform,
 ): T {
+  assertSafeContainedFileName(fileName, platform);
   if (platform !== "linux") {
-    // Non-Linux POSIX systems cannot traverse a directory FD via /dev/fd.
-    // The identity check immediately before operation plus O_NOFOLLOW on the
-    // final artifact preserves the available portable guarantees, but cannot
-    // eliminate a parent-directory swap racing this synchronous call.
+    assertContainedFsSupported(platform);
+    // Windows has no POSIX dirfd primitive. Keep its existing identity guard
+    // and final-component no-follow behavior unchanged.
     const stats = statSync(runDir.path);
     if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
       throw new Error("run directory identity changed");

--- a/src/graph/runtime/store.ts
+++ b/src/graph/runtime/store.ts
@@ -112,15 +112,23 @@ function parseStoredEnvelope(raw: unknown): ProjectionSnapshotEnvelope {
 export class FileProjectionStore implements ProjectionStore {
   private readonly runsRoot: string;
   private readonly runId: string;
+  private readonly handle?: RunDirHandle;
 
-  constructor(runsRoot: string, runId: string) {
+  constructor(
+    runsRoot: string,
+    runId: string,
+    runDirHandle?: RunDirHandle,
+  ) {
     this.runsRoot = runsRoot;
     this.runId = runId;
-    resolveRunDirHandle(runsRoot, runId);
+    this.handle = runDirHandle;
+    if (this.handle === undefined) {
+      resolveRunDirHandle(runsRoot, runId);
+    }
   }
 
   private runDir(): RunDirHandle {
-    return resolveRunDirHandle(this.runsRoot, this.runId);
+    return this.handle ?? resolveRunDirHandle(this.runsRoot, this.runId);
   }
 
   async save(envelope: ProjectionSnapshotEnvelope): Promise<void> {


### PR DESCRIPTION
## Summary

Follow-up security completion for #3893 after merged PR #3894. This PR deliberately fails closed on non-Linux POSIX because Node exposes no supported openat/f*at or dirfd-relative pathname API, and macOS /dev/fd/N is not a supported Node portability contract. Linux retains /proc/self/fd/N directory-FD traversal and Windows retains identity/final-component behavior.

- Validate every contained artifact `fileName` as one safe basename.
- Reject traversal, absolute paths, both separators, NUL/control characters, normalization changes, Windows ADS syntax, and trailing dot/space escapes.
- Add adversarial traversal, symlink, parent replacement, and read/write/rename/delete coverage.
- Preserve reporter attribution from Brecht-H and the original #3894 lineage.

## Verification

- Focused safe-fs suite: 21 tests, 5 consecutive passes.
- Full graph suite: 253 tests passed.
- `bunx tsc --noEmit`: passed.
- Changed-file ESLint: no errors.
- Build: passed.
- Inventory refresh + verify: passed.
- Shipping surface verify: passed.
- `npm pack --dry-run`: passed.
- Full repository suite: 702 passed, 33 unrelated pre-existing failures, 3 skipped; failure includes existing session-replay event expectation mismatch.

Closes #3893 only after exact-head CI, independent security review, merge, and post-merge verification.

Signed-off-by: gaebal-gajae <clawdbot@users.noreply.github.com>
Original reporter/implementation lineage: Brecht-H / #3894