### PR TITLE
feat(skills): add minimal-code-discipline as opt-in built-in skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "omc",
-  "description": "Claude Code native multi-agent orchestration - intelligent model routing, 28 agents, 32 skills",
+  "description": "Claude Code native multi-agent orchestration - intelligent model routing, 28 agents, 33 skills",
   "owner": {
     "name": "Yeachan Heo",
     "email": "hurrc04@gmail.com"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "oh-my-claudecode",
-      "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 32 powerful skills. Zero learning curve. Maximum power.",
+      "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 33 powerful skills. Zero learning curve. Maximum power.",
       "version": "5.0.0",
       "author": {
         "name": "Yeachan Heo",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -29,6 +29,7 @@
     "./skills/external-context/",
     "./skills/graph/",
     "./skills/hud/",
+    "./skills/minimal-code-discipline/",
     "./skills/omc-doctor/",
     "./skills/omc-setup/",
     "./skills/plan/",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Workflow Skills:
 - `deep-interview`: Socratic deep interview with Ouroboros-inspired mathematical ambiguity gating before execution
 - `ralplan`: Iterative consensus planning with RALPLAN-DR structured deliberation (planner + architect + critic); supports `--deliberate` for high-risk work
 - `ai-slop-cleaner`: Regression-safe cleanup workflow for duplicate code, dead code, needless abstractions, and boundary violations; supports `--review` for reviewer-only passes
+- `minimal-code-discipline`: YAGNI-ladder writing-time discipline — existence-first, reuse before writing, shortest correct diff, with non-negotiables that are never minimized away
 
 Agent Shortcuts:
 - `analyze` -> debugger: Investigation and root-cause analysis

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -863,6 +863,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `execute`                 | Carry an approved task through to working, verified code                       | `/oh-my-claudecode:execute`                |
 | `external-context`        | Parallel document-specialist research                                          | `/oh-my-claudecode:external-context`       |
 | `hud`                     | Configure HUD/statusline                                                        | `/oh-my-claudecode:hud`                     |
+| `minimal-code-discipline` | YAGNI-ladder writing-time discipline: reuse first, shortest correct diff        | `/oh-my-claudecode:minimal-code-discipline` |
 | `omc-doctor`              | Diagnose and fix installation issues                                           | `/oh-my-claudecode:omc-doctor`              |
 | `omc-plan`                | Strategic planning with optional interview and consensus modes                 | `/oh-my-claudecode:omc-plan`               |
 | `omc-review`              | Evaluate finished work for defects, risk, and simplification                   | `/oh-my-claudecode:omc-review`             |
@@ -907,6 +908,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:execute <task>`                      | Carry an approved task through to working, verified code                                      |
 | `/oh-my-claudecode:external-context <topic>`             | Run parallel document-specialist research                                                     |
 | `/oh-my-claudecode:hud [setup\|minimal\|focused\|full\|status]` | Configure HUD/statusline                                                               |
+| `/oh-my-claudecode:minimal-code-discipline`              | Apply the YAGNI-ladder writing-time discipline while implementing                              |
 | `/oh-my-claudecode:omc-doctor`                           | Diagnose and fix installation issues                                                          |
 | `/oh-my-claudecode:omc-plan <description>`               | Start planning session (supports consensus structured deliberation)                           |
 | `/oh-my-claudecode:omc-review [path]`                    | Review finished work for defects and risk                                                       |

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,22 +5,22 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "aa3e4aa31348194d46bc73aa69302d7a6a3dfd8e",
-    "sourceSha256": "00e7c6277180d3c34fc18c3e03d530054274e0e6b80bd56e7ff1af7cf0a0b5eb",
+    "head": "785c12eb6503f3313015f3cd3401129fc80ad1b2",
+    "sourceSha256": "b689583dfbd528d0cd54568e621947c289377b2300f04919392a525f2b481cf4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "aa3e4aa31348194d46bc73aa69302d7a6a3dfd8e",
-  "sourceSha256": "00e7c6277180d3c34fc18c3e03d530054274e0e6b80bd56e7ff1af7cf0a0b5eb",
+  "head": "785c12eb6503f3313015f3cd3401129fc80ad1b2",
+  "sourceSha256": "b689583dfbd528d0cd54568e621947c289377b2300f04919392a525f2b481cf4",
   "counts": {
     "public": {
-      "skills": 32,
+      "skills": 33,
       "commands": 21,
       "workflows": 8,
       "agents": 20,
-      "total": 81
+      "total": 82
     },
     "internal": {
       "hookFiles": 295,
@@ -39,7 +39,7 @@
     "prompt": {
       "promptLikeFiles": 62
     },
-    "skills": 32,
+    "skills": 33,
     "commands": 21,
     "hookFiles": 295,
     "workflows": 8,
@@ -61,6 +61,7 @@
       "external-context",
       "graph",
       "hud",
+      "minimal-code-discipline",
       "omc-doctor",
       "omc-setup",
       "plan",
@@ -33322,6 +33323,11 @@
         "path": "skills/hud/SKILL.md"
       },
       {
+        "id": "skills/minimal-code-discipline/SKILL.md",
+        "kind": "skill",
+        "path": "skills/minimal-code-discipline/SKILL.md"
+      },
+      {
         "id": "skills/omc-doctor/SKILL.md",
         "kind": "skill",
         "path": "skills/omc-doctor/SKILL.md"
@@ -42720,6 +42726,11 @@
       },
       {
         "from": "skills/hud/SKILL.md",
+        "to": "src/features/builtin-skills/skills.ts",
+        "kind": "registers"
+      },
+      {
+        "from": "skills/minimal-code-discipline/SKILL.md",
         "to": "src/features/builtin-skills/skills.ts",
         "kind": "registers"
       },
@@ -76450,12 +76461,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6834,
-      "edgeCount": 7200,
+      "nodeCount": 6835,
+      "edgeCount": 7201,
       "importEdgeCount": 5913,
-      "registerEdgeCount": 53
+      "registerEdgeCount": 54
     }
   },
-  "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "6009cc548ba87cabc9106d1fde5bb17b00fdd7863d3c49f975e578bae2536dbc"
+  "inventorySha256": "ceb2ceb563d2225c5864cd6cd129b3711f2b9bbd4e5c89eae9af72a02f91a8a1",
+  "manifestSha256": "1d840e17bffc49259204b76e1754814bbde3cb4de1b013f51aecf0dda1a21abc"
 }

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,9 +1,9 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-01-28 | Updated: 2026-03-02 -->
+<!-- Generated: 2026-01-28 | Updated: 2026-08-28 -->
 
 # skills
 
-30 skill directories for workflow automation and specialized behaviors.
+33 skill directories for workflow automation and specialized behaviors.
 
 ## Purpose
 
@@ -49,6 +49,7 @@ Skills are reusable workflow templates that can be invoked via `/oh-my-claudecod
 | File | Skill | Purpose |
 |-----------|-------|---------|
 | `ai-slop-cleaner/SKILL.md` | ai-slop-cleaner | Regression-safe cleanup workflow for AI-generated code slop |
+| `minimal-code-discipline/SKILL.md` | minimal-code-discipline | YAGNI-ladder writing-time discipline: existence-first, reuse before writing, shortest correct diff |
 | `skillify/SKILL.md` | skillify | Extract reusable skill from session |
 | `learner/SKILL.md` | learner | Deprecated compatibility alias/internal implementation history for skillify |
 | `ask/SKILL.md` | ask | Ask Claude, Codex, or Gemini via `omc ask` and capture an artifact |

--- a/skills/minimal-code-discipline/SKILL.md
+++ b/skills/minimal-code-discipline/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: minimal-code-discipline
+description: YAGNI-ladder coding discipline for writing changes — existence-first, reuse before writing, dependency ladder, shortest correct diff, with non-negotiables that must never be minimized away
+level: 3
+---
+
+# Minimal Code Discipline
+
+Use this skill to apply a minimal-code (YAGNI-ladder) discipline while planning and writing code changes. It keeps diffs small and obviously correct without sacrificing the checks that keep users safe.
+
+This skill complements `ai-slop-cleaner`: that skill cleans slop after it lands; this one keeps it from being written.
+
+## When to Use
+
+Use this skill when:
+- the user asks for a minimal, lean, YAGNI, or smallest-possible-diff implementation
+- a plan or in-flight change is growing beyond the stated request
+- writing new code where scope creep, reinvented helpers, or speculative generality are likely
+- reviewing a proposed diff for size before implementation
+
+## When Not to Use
+
+Do not use this skill when:
+- the user explicitly asks for a broad, feature-rich, or future-proofed build (their explicit scope wins)
+- the task is exploratory scaffolding the user has marked as throwaway
+- minimization pressure would touch protected behavior (see Non-Negotiables)
+
+## The Discipline
+
+**Existence first.** Ask whether the change needs to exist at all; skip work that serves only a speculative future need.
+
+**Reuse before writing.** Search the codebase for an existing helper, type, or pattern before writing anything new. Never copy a helper that already lives a few files away — reuse it or extract it to one shared location.
+
+**Dependency ladder.** Reach for the standard library first, then platform-native capability, then an already-installed dependency. Hand-written code is the last resort. Do not introduce a new dependency when a few lines of code suffice, unless the user explicitly requested or approved it.
+
+**Understand before minimizing.** Read the affected code and follow its execution path first. Ship the shortest correct diff once the problem is understood — code you never write never breaks.
+
+**Boring over clever.** Prefer boring, obviously-correct code over clever code.
+
+**Mark the ceiling.** Record deliberate simplifications with a short comment naming the accepted limit and what would justify replacing it.
+
+**Root cause, not symptoms.** Fix bugs at the root cause shared by every caller, not with a separate patch for each reported symptom.
+
+## Non-Negotiables
+
+Never minimize away:
+- validation wherever a trust boundary is crossed
+- error handling that guards against data loss
+- security controls
+- accessibility fundamentals
+- scope the user explicitly requested
+
+## Verification
+
+Before reporting completion, confirm:
+- every added line earns its place (no speculative generality, no duplicate helpers)
+- the diff is the shortest one that correctly solves the stated problem
+- non-negotiables are intact
+- tests still pass and behavior is unchanged except as requested

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -69,10 +69,10 @@ describe('Builtin Skills', () => {
   });
 
   describe('createBuiltinSkills()', () => {
-    it('should return correct number of skills (32 canonical + 2 aliases)', () => {
+    it('should return correct number of skills (33 canonical + 2 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 34 entries: 32 canonical skills + 2 aliases (cancel-ralph, psm)
-      expect(skills).toHaveLength(34);
+      // 35 entries: 33 canonical skills + 2 aliases (cancel-ralph, psm)
+      expect(skills).toHaveLength(35);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -138,6 +138,7 @@ describe('Builtin Skills', () => {
         'external-context',
         'graph',
         'hud',
+        'minimal-code-discipline',
         'omc-doctor',
         'omc-plan',
         'omc-review',
@@ -659,8 +660,9 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(32);
+      expect(names).toHaveLength(33);
       expect(names).toContain('ai-slop-cleaner');
+      expect(names).toContain('minimal-code-discipline');
       expect(names).toContain('ask');
       expect(names).toContain('autopilot');
       expect(names).toContain('autoresearch');
@@ -693,7 +695,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; learner retired in 5.0.0; cancel-ralph and psm remain
-      expect(names).toHaveLength(34);
+      expect(names).toHaveLength(35);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/alias-retirement/__tests__/registry.test.ts
+++ b/src/alias-retirement/__tests__/registry.test.ts
@@ -64,15 +64,17 @@ describe('alias-retirement registry', () => {
     }
   });
 
-  it('built-in loader exposes 34 entries (32 canonical + 2 aliases) after the 5.0.0 retirement', () => {
+  it('built-in loader exposes 35 entries (33 canonical + 2 aliases) after the 5.0.0 retirement', () => {
     // This is the baseline that retirement must not silently change without an eligibility receipt.
     // Raised 37 -> 40 canonical when execute/review/research shipped as real
     // skill directories; this is an addition, not an alias retirement.
+    // Raised 32 -> 33 canonical when minimal-code-discipline shipped as a real
+    // skill directory; this is an addition, not an alias retirement.
     const all = createBuiltinSkills();
-    expect(all).toHaveLength(34);
+    expect(all).toHaveLength(35);
     const canonical = all.filter((s) => !s.aliasOf);
     const aliases = all.filter((s) => !!s.aliasOf);
-    expect(canonical).toHaveLength(32);
+    expect(canonical).toHaveLength(33);
     expect(aliases).toHaveLength(2);
     expect(aliases.map((s) => s.name).sort()).toEqual(['cancel-ralph', 'psm'].sort());
   });

--- a/src/workflow/__tests__/projections.test.ts
+++ b/src/workflow/__tests__/projections.test.ts
@@ -43,8 +43,8 @@ describe('registry projections — canonical JSON and digest', () => {
 describe('registry projections — drift check against installed surfaces', () => {
   it('matches the repository skills/ and commands/ surface exactly', () => {
     const installed = enumerateInstalledSurfaces(process.cwd());
-    // 41 + execute/review/research + graph, which ship as real skill directories.
-    expect(installed.skills.length).toBe(32);
+    // 41 + execute/review/research + graph + minimal-code-discipline, which ship as real skill directories.
+    expect(installed.skills.length).toBe(33);
     expect(installed.commands.length).toBe(21);
     const drift = checkProjectionDrift(installed);
     expect(drift.unregistered).toEqual([]);

--- a/src/workflow/__tests__/registry.test.ts
+++ b/src/workflow/__tests__/registry.test.ts
@@ -83,11 +83,11 @@ describe('workflow registry — risk classes and gate policy', () => {
 });
 
 describe('workflow registry — aliases and classification', () => {
-  it('classifies all 32 installed skills and 21 installed commands exactly once', () => {
+  it('classifies all 33 installed skills and 21 installed commands exactly once', () => {
     const skills = WORKFLOW_ENTRIES.filter((e) => e.kind === 'skill' && !e.declaredOnly);
     const commands = WORKFLOW_ENTRIES.filter((e) => e.kind === 'command' && !e.declaredOnly);
     // execute/review/research and graph ship as real skill directories.
-    expect(skills).toHaveLength(32);
+    expect(skills).toHaveLength(33);
     expect(commands).toHaveLength(21);
     const keys = WORKFLOW_ENTRIES.map((e) => `${e.kind}:${e.name}`);
     expect(new Set(keys).size).toBe(keys.length);

--- a/src/workflow/registry.ts
+++ b/src/workflow/registry.ts
@@ -187,6 +187,7 @@ const SKILL_ENTRIES: readonly WorkflowEntry[] = [
   entry({ name: 'configure-notifications', kind: 'skill', decision: 'keep', riskClass: 'secrets-privacy', owner: REGISTRY_OWNER, notes: 'Opt-in integration handling secrets; hard boundary retained.' }),
   entry({ name: 'project-session-manager', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Utility only; workflow-gate behavior removed per plan.' }),
   entry({ name: 'ai-slop-cleaner', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in review tool; never a default gate.' }),
+  entry({ name: 'minimal-code-discipline', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in writing-time discipline; never a default gate.' }),
   entry({ name: 'visual-verdict', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in for visual surfaces.' }),
   entry({ name: 'external-context', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in external evidence tool.' }),
   entry({ name: 'graph', kind: 'skill', decision: 'keep', riskClass: 'security-boundary', owner: REGISTRY_OWNER, notes: 'Declarative graph runtime with command execution and bounded read-only Agent SDK execution; CLI + skill entrypoints.' }),


### PR DESCRIPTION
## Summary

Re-submits the minimal-code discipline content from closed PR #3879 on the contribution surface suggested by the maintainer disposition there: an **opt-in built-in skill** instead of an always-on prompt-SSOT policy section. The disposition noted that core prompt/agent policy is a maintainer-owned product-direction surface; this PR changes no default behavior — nothing is always-on, no prompt contract is touched, and the skill only runs when explicitly invoked via `/oh-my-claudecode:minimal-code-discipline`.

The content is a YAGNI-ladder writing-time discipline: existence-first, reuse before writing, dependency ladder (stdlib → platform-native → installed dep → hand-written), understand-before-minimizing, shortest correct diff, boring over clever, marked ceilings with upgrade paths, root-cause fixes — plus non-negotiables (trust-boundary validation, data-loss error handling, security controls, accessibility fundamentals, explicitly requested scope) that are never minimized away. It is the writing-time counterpart to `ai-slop-cleaner` (which cleans slop after it lands).

## What changed

- `skills/minimal-code-discipline/SKILL.md` — the skill (frontmatter: `name`, `description`, `level: 3`)
- `src/workflow/registry.ts` — one `keep` / `advisory` entry, noted "Opt-in writing-time discipline; never a default gate."
- `.claude-plugin/plugin.json` — the native skill shim registry the inventory generator derives its public manifest from; one path entry added alphabetically
- Test count baselines 32→33 canonical / 34→35 with aliases in `src/__tests__/skills.test.ts`, `src/alias-retirement/__tests__/registry.test.ts`, `src/workflow/__tests__/registry.test.ts`, `src/workflow/__tests__/projections.test.ts` — an addition, not an alias retirement (same pattern as the documented execute/review/research raise)
- Docs: `skills/AGENTS.md`, `docs/REFERENCE.md`, root `AGENTS.md`
- `inventory/inventory-graph.json` regenerated via `npm run generate:inventory` (public skills manifest derives from the plugin.json shims)

Deliberately excluded: keyword-detector triggers (no auto-activation), prompt-ssot sections, role projections, and the `docs/CLAUDE.md` managed block — nothing in this PR alters default or always-on behavior.

## Verification

- [x] `npx vitest run src/__tests__/skills.test.ts src/alias-retirement/__tests__/registry.test.ts src/workflow/__tests__/registry.test.ts src/workflow/__tests__/projections.test.ts` — 79 passed / 0 failed
- [x] `npx vitest run tests/lint/inventory-graph-drift.test.ts src/__tests__/plugin-skill-budget.test.ts` — 17 passed / 0 failed (the two suites that failed in the first CI pass before the plugin.json shim registration follow-up)
- [x] `npx vitest run src/skills src/installer/__tests__/user-skill-compat.test.ts` — 103 passed; the 10 `skill-config-dir.test.ts` failures are pre-existing on the untouched base (verified identical on an unmodified checkout) and unrelated to this change — the new skill passes all of that suite's prose checks
- [x] `npx tsc --noEmit` — clean
- [x] `npm run prompt-ssot:check` — 5 projections fresh, untouched by this PR
- [x] `npm run generate:inventory` + `npm run generate:inventory:verify` — fresh (manifest sha `ceb2ceb5…`)
- [x] `npm run verify:skill-entitlements` — current
- [x] No committed build artifacts: zero `dist/` or `bridge/` deltas, so no generated-artifact authorization is required

## Notes for reviewers

- Per the #3879 disposition ("a future proposal would need … a narrowly specified contract"), the contract here is deliberately narrow: one opt-in skill directory + its registrations. If an opt-in skill is still outside maintained scope, closing without a mutation lane is fine — no salvage iteration expected.
- Two commits off current `dev` (`9d4d6c834`): 11 files, +106/−26.
