### PR TITLE
fix(config): give cursor a default-model hook (#3880)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For mixed Codex + Antigravity work in one command, run `/ask codex` and `/ask an
 | `omc team N:gemini "..."`       | N Gemini CLI panes            | UI/UX design, docs, large-context tasks (enterprise/API-key) |
 | `omc team N:antigravity "..."`  | N Antigravity (`agy`) panes   | UI/UX design, docs, large-context tasks                      |
 | `omc team N:grok "..."`         | N Grok Build CLI panes        | Code review, analysis cross-check            |
-| `omc team N:cursor "..."`       | N Cursor agent panes          | Executor-style implementation tasks          |
+| `omc team N:cursor "..."`       | N Cursor agent panes          | Implementation and reviewer-style tasks      |
 | `omc team N:claude "..."`       | N Claude CLI panes            | General tasks via Claude CLI in tmux         |
 | `/ask codex` + `/ask antigravity` | Tri-model advisor synthesis | Mixed Codex + Antigravity review in one pass |
 
@@ -235,7 +235,9 @@ Autopilot can prefer Cursor executor workers during team execution via `.claude/
 }
 ```
 
-This config makes the autopilot execution stage use `omc team 1:cursor "..."` or `/team 1:cursor "..."` for executor-style implementation work. Reviewer, critic, security-review, validation verdict, and final approval roles remain native Claude/OMC reviewer roles; Cursor requires an installed/authenticated `cursor-agent`.
+This config makes the autopilot execution stage use `omc team 1:cursor "..."` or `/team 1:cursor "..."` for implementation work. Cursor also supports reviewer-style roles (`critic`, `code-reviewer`, `security-reviewer`, `test-engineer`): those workers emit the structured verdict file the team leader consumes to transition the task, and final approval stays a lead-session responsibility. Cursor requires an installed/authenticated `cursor-agent`.
+
+Pin a Cursor model with `externalModels.defaults.cursorModel` (or `OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL`); ids come from `cursor-agent --list-models`, for example `cursor-grok-4.6-high` or `composer-2.5`. Left unset, `cursor-agent` chooses its own model.
 
 Native team worker worktrees are being added behind an opt-in/config gate. See [Native Team Worktree Mode](docs/TEAM-WORKTREE-MODE.md) for the workspace contract, canonical state-root rules, dirty-worktree preservation policy, and verification checklist.
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Autopilot can prefer Cursor executor workers during team execution via `.claude/
 
 This config makes the autopilot execution stage use `omc team 1:cursor "..."` or `/team 1:cursor "..."` for implementation work. Cursor also supports reviewer-style roles (`critic`, `code-reviewer`, `security-reviewer`, `test-engineer`): those workers emit the structured verdict file the team leader consumes to transition the task, and final approval stays a lead-session responsibility. Cursor requires an installed/authenticated `cursor-agent`.
 
-Pin a Cursor model with `externalModels.defaults.cursorModel` (or `OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL`); ids come from `cursor-agent --list-models`, for example `cursor-grok-4.6-high` or `composer-2.5`. Left unset, `cursor-agent` chooses its own model.
+Pin a Cursor model with the `OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL` environment variable, or per role with `team.roleRouting.<role>.model`. `externalModels.defaults.cursorModel` applies to workers routed through `team.roleRouting`. Ids come from `cursor-agent --list-models`, for example `cursor-grok-4.6-high` or `composer-2.5`. Left unset, `cursor-agent` chooses its own model.
 
 Native team worker worktrees are being added behind an opt-in/config gate. See [Native Team Worktree Mode](docs/TEAM-WORKTREE-MODE.md) for the workspace contract, canonical state-root rules, dirty-worktree preservation policy, and verification checklist.
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "96b341e64e49e70a9b7528e39ce9d38696635031",
-    "sourceSha256": "02d8af3144c3ef9c1d8184ae9a2e627a1ca15157d856b374e4a28dc1dc171b5c",
+    "head": "a2cfaf1df1c60f81c15f18179be5bffdb47f0bb9",
+    "sourceSha256": "e00ffd47f9055567489adb9276db9fcb10e0d1b26d3f95ee181a320490780c55",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "96b341e64e49e70a9b7528e39ce9d38696635031",
-  "sourceSha256": "02d8af3144c3ef9c1d8184ae9a2e627a1ca15157d856b374e4a28dc1dc171b5c",
+  "head": "a2cfaf1df1c60f81c15f18179be5bffdb47f0bb9",
+  "sourceSha256": "e00ffd47f9055567489adb9276db9fcb10e0d1b26d3f95ee181a320490780c55",
   "counts": {
     "public": {
       "skills": 32,
@@ -76452,5 +76452,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "539c7204ae706bb16a4f1fc7c5286e0fa9de9d536bdc3e078b20c81994e8f1e8"
+  "manifestSha256": "8a6e5cc0dbba37cb8841e6a490432265ca1d1dd2babfe2709ffac8fbd2887ca3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "5bf4955d777bb9d011f7e1a1ed74d3bb0fd9b5c6",
-    "sourceSha256": "d05e94f174e5e8e6e47ab6f6141e3b3695b7dccfa0f76cbbec65fe5e6bc32eda",
+    "head": "c88ca625356db8b01b88d4b6828d51714cc13a29",
+    "sourceSha256": "6de4cf237dfd14219c2231d99cdd567d2acb568d603291bc06bec40a3d5f42bb",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "5bf4955d777bb9d011f7e1a1ed74d3bb0fd9b5c6",
-  "sourceSha256": "d05e94f174e5e8e6e47ab6f6141e3b3695b7dccfa0f76cbbec65fe5e6bc32eda",
+  "head": "c88ca625356db8b01b88d4b6828d51714cc13a29",
+  "sourceSha256": "6de4cf237dfd14219c2231d99cdd567d2acb568d603291bc06bec40a3d5f42bb",
   "counts": {
     "public": {
       "skills": 32,
@@ -76452,5 +76452,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "04d6a3396296281efc2d216684f64fb6141a255d735df7c548dfb7892ab23c58"
+  "manifestSha256": "8fceaadf02b82fbf8e3f7241032a826961b52a3073af208332450789658353e7"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "a2cfaf1df1c60f81c15f18179be5bffdb47f0bb9",
-    "sourceSha256": "e00ffd47f9055567489adb9276db9fcb10e0d1b26d3f95ee181a320490780c55",
+    "head": "5bf4955d777bb9d011f7e1a1ed74d3bb0fd9b5c6",
+    "sourceSha256": "d05e94f174e5e8e6e47ab6f6141e3b3695b7dccfa0f76cbbec65fe5e6bc32eda",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "a2cfaf1df1c60f81c15f18179be5bffdb47f0bb9",
-  "sourceSha256": "e00ffd47f9055567489adb9276db9fcb10e0d1b26d3f95ee181a320490780c55",
+  "head": "5bf4955d777bb9d011f7e1a1ed74d3bb0fd9b5c6",
+  "sourceSha256": "d05e94f174e5e8e6e47ab6f6141e3b3695b7dccfa0f76cbbec65fe5e6bc32eda",
   "counts": {
     "public": {
       "skills": 32,
@@ -76452,5 +76452,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "8a6e5cc0dbba37cb8841e6a490432265ca1d1dd2babfe2709ffac8fbd2887ca3"
+  "manifestSha256": "04d6a3396296281efc2d216684f64fb6141a255d735df7c548dfb7892ab23c58"
 }

--- a/src/config/__tests__/loader.test.ts
+++ b/src/config/__tests__/loader.test.ts
@@ -533,6 +533,26 @@ describe("team.roleRouting (Option E)", () => {
 
 
 
+  it("loads externalModels.defaults.cursorModel from config", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "omc-external-cursor-model-"));
+    try {
+      const claudeDir = join(tempDir, ".claude");
+      require("node:fs").mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(
+        join(claudeDir, "omc.jsonc"),
+        JSON.stringify({
+          externalModels: { defaults: { cursorModel: "cursor-grok-4.6-high" } },
+        }),
+      );
+      process.chdir(tempDir);
+      expect(loadConfig().externalModels?.defaults?.cursorModel).toBe(
+        "cursor-grok-4.6-high",
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts cursor for reviewer team roleRouting providers (issue #3880)", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "omc-team-routing-cursor-reviewer-"));
     try {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -393,6 +393,14 @@ export function loadEnvConfig(): Partial<PluginConfig> {
     externalModelsDefaults.grokModel = process.env.OMC_GROK_DEFAULT_MODEL;
   }
 
+  if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL) {
+    externalModelsDefaults.cursorModel =
+      process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+  } else if (process.env.OMC_CURSOR_DEFAULT_MODEL) {
+    // Legacy fallback
+    externalModelsDefaults.cursorModel = process.env.OMC_CURSOR_DEFAULT_MODEL;
+  }
+
   if (process.env.OMC_EXTERNAL_MODELS_DEFAULT_ANTIGRAVITY_MODEL) {
     externalModelsDefaults.antigravityModel =
       process.env.OMC_EXTERNAL_MODELS_DEFAULT_ANTIGRAVITY_MODEL;
@@ -1205,6 +1213,10 @@ export function generateConfigSchema(): object {
                 type: "string",
                 default: BUILTIN_EXTERNAL_MODEL_DEFAULTS.antigravityModel,
                 description: "Default Antigravity model",
+              },
+              cursorModel: {
+                type: "string",
+                description: "Default Cursor model (ids from `cursor-agent --list-models`)",
               },
             },
           },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -354,6 +354,7 @@ export interface ExternalModelsDefaults {
   geminiModel?: string;
   grokModel?: string;
   antigravityModel?: string;
+  cursorModel?: string;
 }
 
 /**

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -1893,6 +1893,100 @@ describe('runtime v2 startup inbox dispatch', () => {
     }
   });
 
+  it('direct cursor launch resolves model from cursor env vars, canonical outranking legacy', async () => {
+    // `resolveDefaultModel` hardcoded `undefined` for cursor while every sibling
+    // provider read its env vars, so a plain `omc team 1:cursor` ignored the
+    // configured default entirely — it only applied via team.roleRouting.
+    cwd = await mkdtempFixture('omc-runtime-v2-cursor-env-');
+    const originalCursorModel = process.env.OMC_CURSOR_DEFAULT_MODEL;
+    const originalCursorExternal = process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    process.env.OMC_CURSOR_DEFAULT_MODEL = 'composer-2.5';
+    process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL = 'cursor-grok-4.6-high';
+    try {
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 1,
+        agentTypes: ['cursor'],
+        tasks: [{ subject: 'Cursor dispatch', description: 'Verify cursor env model passthrough' }],
+        cwd,
+      });
+
+      expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+        'cursor',
+        expect.objectContaining({ model: 'cursor-grok-4.6-high' }),
+      );
+      expect(modelContractMocks.resolveClaudeWorkerModel).not.toHaveBeenCalled();
+    } finally {
+      if (originalCursorModel === undefined) delete process.env.OMC_CURSOR_DEFAULT_MODEL;
+      else process.env.OMC_CURSOR_DEFAULT_MODEL = originalCursorModel;
+      if (originalCursorExternal === undefined) delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+      else process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL = originalCursorExternal;
+    }
+  });
+
+  it('direct cursor launch falls back to the legacy OMC_CURSOR_DEFAULT_MODEL', async () => {
+    cwd = await mkdtempFixture('omc-runtime-v2-cursor-legacy-env-');
+    const originalCursorModel = process.env.OMC_CURSOR_DEFAULT_MODEL;
+    const originalCursorExternal = process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    process.env.OMC_CURSOR_DEFAULT_MODEL = 'composer-2.5';
+    try {
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 1,
+        agentTypes: ['cursor'],
+        tasks: [{ subject: 'Cursor dispatch', description: 'Verify legacy cursor env fallback' }],
+        cwd,
+      });
+
+      expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+        'cursor',
+        expect.objectContaining({ model: 'composer-2.5' }),
+      );
+    } finally {
+      if (originalCursorModel === undefined) delete process.env.OMC_CURSOR_DEFAULT_MODEL;
+      else process.env.OMC_CURSOR_DEFAULT_MODEL = originalCursorModel;
+      if (originalCursorExternal === undefined) delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+      else process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL = originalCursorExternal;
+    }
+  });
+
+  it('direct cursor launch with no cursor env leaves the model unset', async () => {
+    cwd = await mkdtempFixture('omc-runtime-v2-cursor-no-env-');
+    const originalCursorModel = process.env.OMC_CURSOR_DEFAULT_MODEL;
+    const originalCursorExternal = process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    delete process.env.OMC_CURSOR_DEFAULT_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    try {
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 1,
+        agentTypes: ['cursor'],
+        tasks: [{ subject: 'Cursor dispatch', description: 'Verify cursor default stays unset' }],
+        cwd,
+      });
+
+      // Unset must stay unset: cursor-agent picks its own model, and a Claude id
+      // here would be invalid for it.
+      expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+        'cursor',
+        expect.objectContaining({ model: undefined }),
+      );
+      expect(modelContractMocks.resolveClaudeWorkerModel).not.toHaveBeenCalled();
+    } finally {
+      if (originalCursorModel === undefined) delete process.env.OMC_CURSOR_DEFAULT_MODEL;
+      else process.env.OMC_CURSOR_DEFAULT_MODEL = originalCursorModel;
+      if (originalCursorExternal === undefined) delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+      else process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL = originalCursorExternal;
+    }
+  });
+
   it('direct grok launch passes OMC_GROK_DEFAULT_MODEL through to buildWorkerArgv', async () => {
     cwd = await mkdtempFixture('omc-runtime-v2-grok-model-');
     const originalGrokModel = process.env.OMC_GROK_DEFAULT_MODEL;

--- a/src/team/__tests__/runtime-v2.dispatch.test.ts
+++ b/src/team/__tests__/runtime-v2.dispatch.test.ts
@@ -1926,6 +1926,38 @@ describe('runtime v2 startup inbox dispatch', () => {
     }
   });
 
+  it('direct cursor launch resolves the configured cursor default when env is unset', async () => {
+    cwd = await mkdtempFixture('omc-runtime-v2-cursor-config-');
+    const originalCursorModel = process.env.OMC_CURSOR_DEFAULT_MODEL;
+    const originalCursorExternal = process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    delete process.env.OMC_CURSOR_DEFAULT_MODEL;
+    delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+    try {
+      const { startTeamV2 } = await import('../runtime-v2.js');
+
+      await startTeamV2({
+        teamName: 'dispatch-team',
+        workerCount: 1,
+        agentTypes: ['cursor'],
+        tasks: [{ subject: 'Cursor dispatch', description: 'Verify configured cursor model passthrough' }],
+        pluginConfig: {
+          externalModels: { defaults: { cursorModel: 'composer-2.5' } },
+        },
+        cwd,
+      });
+
+      expect(modelContractMocks.buildWorkerArgv).toHaveBeenCalledWith(
+        'cursor',
+        expect.objectContaining({ model: 'composer-2.5' }),
+      );
+    } finally {
+      if (originalCursorModel === undefined) delete process.env.OMC_CURSOR_DEFAULT_MODEL;
+      else process.env.OMC_CURSOR_DEFAULT_MODEL = originalCursorModel;
+      if (originalCursorExternal === undefined) delete process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL;
+      else process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL = originalCursorExternal;
+    }
+  });
+
   it('direct cursor launch falls back to the legacy OMC_CURSOR_DEFAULT_MODEL', async () => {
     cwd = await mkdtempFixture('omc-runtime-v2-cursor-legacy-env-');
     const originalCursorModel = process.env.OMC_CURSOR_DEFAULT_MODEL;

--- a/src/team/__tests__/stage-router.test.ts
+++ b/src/team/__tests__/stage-router.test.ts
@@ -146,6 +146,41 @@ describe('stage-router resolveRoleAssignment', () => {
       expect(out.model).toBe('grok-code-fast-1');
     });
 
+    it('cursor resolves configured externalModels.defaults.cursorModel when model omitted', () => {
+      const cfg: PluginConfig = {
+        externalModels: { defaults: { cursorModel: 'cursor-grok-4.6-high' } },
+        team: { roleRouting: { 'code-reviewer': { provider: 'cursor' } } },
+      };
+      const out = resolveRoleAssignment('code-reviewer', cfg);
+      expect(out.provider).toBe('cursor');
+      expect(out.model).toBe('cursor-grok-4.6-high');
+    });
+
+    it('tier name on cursor provider falls back to configured cursorModel', () => {
+      // Previously a tier resolved to '' with no diagnostic, so a user asking
+      // for HIGH silently got whatever cursor-agent defaults to.
+      const cfg: PluginConfig = {
+        externalModels: { defaults: { cursorModel: 'cursor-grok-4.6-high' } },
+        team: { roleRouting: { executor: { provider: 'cursor', model: 'HIGH' } } },
+      };
+      expect(resolveRoleAssignment('executor', cfg).model).toBe('cursor-grok-4.6-high');
+    });
+
+    it('explicit cursor model id outranks the configured default', () => {
+      const cfg: PluginConfig = {
+        externalModels: { defaults: { cursorModel: 'composer-2.5' } },
+        team: { roleRouting: { executor: { provider: 'cursor', model: 'cursor-grok-4.6-xhigh' } } },
+      };
+      expect(resolveRoleAssignment('executor', cfg).model).toBe('cursor-grok-4.6-xhigh');
+    });
+
+    it('unconfigured cursor stays empty so cursor-agent picks its own model', () => {
+      const cfg: PluginConfig = {
+        team: { roleRouting: { executor: { provider: 'cursor' } } },
+      };
+      expect(resolveRoleAssignment('executor', cfg).model).toBe('');
+    });
+
     it('tier name on grok provider falls back to provider default (tiers are claude-centric)', () => {
       const cfg: PluginConfig = {
         team: { roleRouting: { executor: { provider: 'grok', model: 'HIGH' } } },

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -3337,7 +3337,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     if (agentType === 'gemini') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL || process.env.OMC_GEMINI_DEFAULT_MODEL || undefined;
     if (agentType === 'antigravity') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_ANTIGRAVITY_MODEL || process.env.OMC_ANTIGRAVITY_DEFAULT_MODEL || undefined;
     if (agentType === 'grok') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL || process.env.OMC_GROK_DEFAULT_MODEL || undefined;
-    if (agentType === 'cursor') return undefined;
+    if (agentType === 'cursor') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL || process.env.OMC_CURSOR_DEFAULT_MODEL || undefined;
     return resolveClaudeWorkerModel();
   };
   for (let i = 0; i < workerNames.length; i++) {

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -3337,7 +3337,10 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     if (agentType === 'gemini') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GEMINI_MODEL || process.env.OMC_GEMINI_DEFAULT_MODEL || undefined;
     if (agentType === 'antigravity') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_ANTIGRAVITY_MODEL || process.env.OMC_ANTIGRAVITY_DEFAULT_MODEL || undefined;
     if (agentType === 'grok') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_GROK_MODEL || process.env.OMC_GROK_DEFAULT_MODEL || undefined;
-    if (agentType === 'cursor') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL || process.env.OMC_CURSOR_DEFAULT_MODEL || undefined;
+    if (agentType === 'cursor') return process.env.OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL
+      || process.env.OMC_CURSOR_DEFAULT_MODEL
+      || pluginCfg.externalModels?.defaults?.cursorModel
+      || undefined;
     return resolveClaudeWorkerModel();
   };
   for (let i = 0; i < workerNames.length; i++) {

--- a/src/team/stage-router.ts
+++ b/src/team/stage-router.ts
@@ -147,7 +147,11 @@ function resolveExternalModel(
     return defaults?.grokModel ?? '';
   }
   if (provider === 'cursor') {
-    return '';
+    // No builtin default: cursor-agent picks its own model when `--model` is
+    // omitted, and pinning one here would override that for every user. The
+    // config hook still has to exist, or `externalModels.defaults.cursorModel`
+    // and a tier name both resolve to nothing with no diagnostic.
+    return defaults?.cursorModel ?? '';
   }
   if (provider === 'antigravity') {
     return defaults?.antigravityModel ?? BUILTIN_EXTERNAL_MODEL_DEFAULTS.antigravityModel;


### PR DESCRIPTION
Closes the last two follow-ups from #3880: a silently-ignored config path, and the one remaining doc that still described cursor as executor-only.

## The silent failure

`resolveExternalModel` returned a hardcoded `''` for cursor with no override:

```
codex        defaults.codexModel        ?? builtin
gemini       defaults.geminiModel       ?? builtin
antigravity  defaults.antigravityModel  ?? builtin
grok         defaults.grokModel         ?? ''
cursor       ''                          ← no hook at all
```

`externalModels.defaults.cursorModel` existed in neither the type, the JSON schema, nor the env loader, so writing it in `omc.jsonc` did nothing and reported nothing.

**Where a user actually hits it: a tier name.** Tiers are claude-centric, so every external provider collapses `HIGH`/`MEDIUM`/`LOW` onto its configured default. Measured on `dev` before the change:

```
codex        HIGH  -> 'gpt-5.3-codex'
gemini       HIGH  -> 'gemini-3.1-pro-preview'
antigravity  HIGH  -> 'Gemini 3.1 Pro (High)'
grok         HIGH  -> ''          (but defaults.grokModel works)
cursor       HIGH  -> ''          (and nothing can fix it)
```

So:

```jsonc
{ "team": { "roleRouting": { "executor": { "provider": "cursor", "model": "HIGH" } } } }
```

passes config validation, warns about nothing, and runs cursor-agent on whatever it defaults to. That collapse is shared with grok, but grok has an escape hatch and cursor had none. It matters more now that #3881 made `--model` actually reach the launch args.

## Change

Adds `cursorModel` to the type, the JSON schema, and the env loader (`OMC_EXTERNAL_MODELS_DEFAULT_CURSOR_MODEL`, legacy `OMC_CURSOR_DEFAULT_MODEL`) — mirroring the grok wiring exactly.

**No builtin default.** cursor-agent picks its own model when `--model` is omitted; pinning one here would silently override that for every existing user. Unconfigured cursor still resolves to `''`. The change is only that configuring it now works:

```
cursorModel + tier HIGH        -> "cursor-grok-4.6-high"
unconfigured                   -> ""
explicit id vs cursorModel     -> "cursor-grok-4.6-xhigh"   (explicit still wins)
```

## Docs

I re-checked every location flagged as Phase 4. `AGENTS.md`, `skills/team/SKILL.md`, and `skills/autopilot/SKILL.md` were already corrected in the #3886 follow-ups. Only `README.md` was still stale, in two places:

- worker table: "Executor-style implementation tasks" → implementation and reviewer-style
- autopilot section: still said reviewer/critic/security-review/verdict roles "remain native Claude/OMC reviewer roles"

Both now match the shipped behaviour, plus a short note on pinning a model via `cursorModel`.

`externalModels` is not documented in `docs/REFERENCE.md` at all, so I did not add a lone entry there.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint` (5 changed files) | clean |
| `stage-router` + `loader` suites | 101 passed |
| `inventory-graph-drift` | 11 passed |
| `team/` + `config/` suites | 1870 passed / 18 failed |

Clean `origin/dev` measured the same way: **1865 passed / 18 failed**. Same count; the file list shuffles between runs because these are load-dependent. The two files unique to my run (`recovery-pane-rollback`, `merge-orchestrator`) pass in isolation — 85 passed / 4 skipped alongside `worker-launch-ack`, which failed on the `dev` baseline run instead.
