### PR TITLE
fix(release): stage notes outside checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
         run: |
           git cat-file -e HEAD:.github/release-body.md
           test -s .github/release-body.md
-          cp .github/release-body.md release-notes.md
+          cp .github/release-body.md "$RUNNER_TEMP/release-notes.md"
 
       - name: Verify plugin shipping surface
         run: npm run plugin:shipping:verify
@@ -480,10 +480,9 @@ jobs:
 
       - name: Assert clean deterministic tracked tree before archive
         run: |
-          # Build/test/package preparation may regenerate ignored or tracked
-          # projections. Restore only generated build products and the known
-          # test-mutated hook projection, then fail closed on any remaining
-          # tracked drift before archive or publish.
+          # Build/test preparation may regenerate the known tracked build
+          # closure and the hook projection. Restore only those known paths;
+          # the release-notes copy lives outside the checkout.
           git restore --worktree dist bridge hooks/hooks.json
           git clean -fdX dist
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
@@ -598,7 +597,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          body_path: release-notes.md
+          body_path: ${{ runner.temp }}/release-notes.md
           draft: false
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
         env:

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "d10a0eaa93d17c279146a2d0824704633fbc0a00",
-    "sourceSha256": "62befd852df6b1ad3edbec820c228093a8a37e5eb835a37cfba2a43fe45ba227",
+    "head": "03976673d6d1009919ae73bb8e231972a759a852",
+    "sourceSha256": "3fa7d7ad59c0d5c3fe107b55338737bdf5ad99d32583351e95ffd640efd9f6ff",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "d10a0eaa93d17c279146a2d0824704633fbc0a00",
-  "sourceSha256": "62befd852df6b1ad3edbec820c228093a8a37e5eb835a37cfba2a43fe45ba227",
+  "head": "03976673d6d1009919ae73bb8e231972a759a852",
+  "sourceSha256": "3fa7d7ad59c0d5c3fe107b55338737bdf5ad99d32583351e95ffd640efd9f6ff",
   "counts": {
     "public": {
       "skills": 32,
@@ -76550,5 +76550,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "bda85757dd83cda833dd5415c02a1fd44b9656453300adab2f1f8fa8ef66f30f"
+  "manifestSha256": "105f7412474aed6844971d7e6ac06768b526b2b7a7a8c97fa554b7257165fce9"
 }

--- a/src/__tests__/trusted-publishing-contract.test.ts
+++ b/src/__tests__/trusted-publishing-contract.test.ts
@@ -141,7 +141,7 @@ describe('npm trusted publishing contract', () => {
       'node scripts/release-boundary.mjs assert-npm-absent --package oh-my-claude-sisyphus --version "$VERSION"',
     );
     expect(releaseJob).toContain('git cat-file -e HEAD:.github/release-body.md');
-    expect(releaseJob).toContain('cp .github/release-body.md release-notes.md');
+    expect(releaseJob).toContain('cp .github/release-body.md "$RUNNER_TEMP/release-notes.md"');
     expect(releaseJob).toContain(
       'node scripts/release-boundary.mjs prepare-stage --seed-tarball "$SEED_TARBALL" --stage "$STAGE" --git-head "$GITHUB_SHA"',
     );
@@ -156,7 +156,7 @@ describe('npm trusted publishing contract', () => {
     expect(releaseJob).toContain(
       'node scripts/release-boundary.mjs verify-registry --package oh-my-claude-sisyphus --version "$VERSION" --tag "$GITHUB_REF_NAME" --sha "$GITHUB_SHA" --evidence "$EVIDENCE_JSON" --tarball "$FINAL_TARBALL" --provenance required --audit "$AUDIT_JSON"',
     );
-    expect(releaseJob).toContain('body_path: release-notes.md');
+    expect(releaseJob).toContain('body_path: ${{ runner.temp }}/release-notes.md');
     expect(releaseJob).toContain('Assert clean deterministic tracked tree before archive');
     expect(releaseJob).toContain('git restore --worktree dist bridge hooks/hooks.json');
     expect(releaseJob).toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}');


### PR DESCRIPTION
The v5.0.2 tag workflow failed because Validate release notes created an untracked release-notes.md in the checkout. Stage the body under RUNNER_TEMP and point the release action there; retain the existing deterministic cleanup and clean-tree assertion. Contract coverage verifies the path.