### PR TITLE
chore(inventory): rebind post-merge provenance

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "03976673d6d1009919ae73bb8e231972a759a852",
+    "head": "f3b9feb50d06f9e1019cbb5a0073f699b078926b",
     "sourceSha256": "3fa7d7ad59c0d5c3fe107b55338737bdf5ad99d32583351e95ffd640efd9f6ff",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "03976673d6d1009919ae73bb8e231972a759a852",
+  "head": "f3b9feb50d06f9e1019cbb5a0073f699b078926b",
   "sourceSha256": "3fa7d7ad59c0d5c3fe107b55338737bdf5ad99d32583351e95ffd640efd9f6ff",
   "counts": {
     "public": {
@@ -76550,5 +76550,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "105f7412474aed6844971d7e6ac06768b526b2b7a7a8c97fa554b7257165fce9"
+  "manifestSha256": "de1f8f9df14f4b251102abc530c958e06958f17a9dc43978532796e90caa8403"
 }


### PR DESCRIPTION
Refreshes the generated inventory after the squash merge so provenance.head is an ancestor of the actual main commit. No product files change.