### PR TITLE
docs: shipyard methodology map — vision, boundary, pillars/surfaces, feedback loop

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -16,6 +16,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [Goal Workflow UX: `/goal`, Ralph, Team, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultragoal)
 - [Skills (35 Total)](#skills-35-total)
 - [Slash Commands](#slash-commands)
+- [Shipyard Methodology](./shipyard.md) — governed delivery & shared harness map
 - [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
 - [Hooks System](#hooks-system)
 - [Magic Keywords](#magic-keywords)

--- a/docs/shipyard.md
+++ b/docs/shipyard.md
@@ -21,25 +21,25 @@ A repo that humans and agents both build on carries four pillars across five sur
 
 | Surface | Carries | Filled by |
 | --- | --- | --- |
-| `CLAUDE.md` | 薄入口：项目约定 / 架构原则 / 规范索引 / load-bearing 决策指针 | drydock seed; retro & reviews sediment |
-| `CONTEXT.md` | 术语词典（agent 当场落盘的格子；词汇即法律） | launch Phase 1; domain-modeling |
-| `docs/adr/` | 决策记录全文（航海日志） | launch C4; domain-modeling |
+| `CLAUDE.md` | Thin entry: project conventions / architecture principles / standards index / load-bearing decision pointers | drydock seed; retro & reviews sediment |
+| `CONTEXT.md` | Glossary (the slot agents write into the moment a term settles; vocabulary is law) | launch Phase 1; domain-modeling |
+| `docs/adr/` | Decision records in full (the logbook) | launch C4; domain-modeling |
 | `docs/standards/` | architecture.md / data.md / process.md | retro & code-review sediment |
-| `docs/business/` | 业务知识（一篇回答一个业务问题） | launch Phase 1 |
+| `docs/business/` | Business knowledge (one article answers one business question) | launch Phase 1 |
 | `design-system/` | tokens/ + components/ + patterns/ | frontend review sediment |
-| `.omc/skills/` | 项目技能：可复用能力 / 专用工具 / 提示词模板 / 专用实践 | anyone (skillify quality gate) |
-| `.mcp.json` + `scripts/` | MCP servers + CLI 工具链 / 自动化脚本 | PR |
+| `.omc/skills/` | Project skills: reusable capabilities / specialized tools / prompt templates / specialized practices | anyone (skillify quality gate) |
+| `.mcp.json` + `scripts/` | MCP servers + CLI toolchain / automation scripts | PR |
 
 ## The metaphor family (for teaching the system)
 
-| 隐喻 | 对应物 | 一句话 |
+| Metaphor | Maps to | In one line |
 | --- | --- | --- |
-| 船坞 shipyard | 整套 harness | 共享设施，人人来造船 |
-| 龙骨 keel | `CLAUDE.md` + `CONTEXT.md` | 先铺骨架，船体往上长 |
-| 船级社 classification society | `docs/standards/` + `design-system/` | 船要入级才能出海 = 变更要过标准才能合并 |
-| 海图 charts | specs + tickets | launch 的产物，照图施工 |
-| 航海日志 logbook | `docs/adr/` | 决策记录，事后可查 |
-| 下水 launch | `/oh-my-claudecode:launch` | 人人可以下水，船级社的检查一项不能少 |
+| The shipyard | The whole harness | A shared facility; everyone comes here to build |
+| The keel | `CLAUDE.md` + `CONTEXT.md` | Lay the skeleton first; the hull grows upward |
+| The classification society | `docs/standards/` + `design-system/` | A ship must pass class to sail = changes must pass standards to merge |
+| The charts | specs + tickets | Launch's output; build from the chart |
+| The logbook | `docs/adr/` | Decisions, auditable after the fact |
+| The launch | `/oh-my-claudecode:launch` | Everyone may launch — and not one class check may be skipped |
 
 ## The three skills compose
 

--- a/docs/shipyard.md
+++ b/docs/shipyard.md
@@ -1,0 +1,63 @@
+# Shipyard — Governed Delivery & Shared Harness
+
+Shipyard is the delivery methodology behind three opt-in skills: `drydock`, `launch`, and `minimal-code-discipline`. Its premise in one line:
+
+> **Everyone ships, and nobody ships randomly** — agents continuously run everything repeatable and acceptable-by-evidence; humans decide what cannot be judged by the system or what fails expensively.
+
+This page is the map of the methodology: the boundary principle, the four pillars, the surface layout, the working metaphor, and how the three skills compose. The skills themselves (`/oh-my-claudecode:drydock`, `/oh-my-claudecode:launch`, `/oh-my-claudecode:minimal-code-discipline`) are the executable form.
+
+## The verifiability boundary
+
+Every step in a launch run answers one test question: *if this is done wrong, can the system detect it? Can it redo or roll back automatically?*
+
+- **Both yes → agents run it continuously** (the repeatable ~80%): fact-finding, spec/ticket drafting, tdd implementation, builds, tests, code-review, verify, scheduling.
+- **Either no → the human decides it** (the critical ~20%): acceptance criteria, seam selection, ticket granularity, irreversible architecture decisions, final acceptance.
+
+It is not "let agents do as much as possible" — it is "delegate exactly what can be accepted, nothing more."
+
+## The four pillars → five surfaces
+
+A repo that humans and agents both build on carries four pillars across five surfaces. `/oh-my-claudecode:drydock` lays them; every later session inherits them by reading.
+
+| Surface | Carries | Filled by |
+| --- | --- | --- |
+| `CLAUDE.md` | 薄入口：项目约定 / 架构原则 / 规范索引 / load-bearing 决策指针 | drydock seed; retro & reviews sediment |
+| `CONTEXT.md` | 术语词典（agent 当场落盘的格子；词汇即法律） | launch Phase 1; domain-modeling |
+| `docs/adr/` | 决策记录全文（航海日志） | launch C4; domain-modeling |
+| `docs/standards/` | architecture.md / data.md / process.md | retro & code-review sediment |
+| `docs/business/` | 业务知识（一篇回答一个业务问题） | launch Phase 1 |
+| `design-system/` | tokens/ + components/ + patterns/ | frontend review sediment |
+| `.omc/skills/` | 项目技能：可复用能力 / 专用工具 / 提示词模板 / 专用实践 | anyone (skillify quality gate) |
+| `.mcp.json` + `scripts/` | MCP servers + CLI 工具链 / 自动化脚本 | PR |
+
+## The metaphor family (for teaching the system)
+
+| 隐喻 | 对应物 | 一句话 |
+| --- | --- | --- |
+| 船坞 shipyard | 整套 harness | 共享设施，人人来造船 |
+| 龙骨 keel | `CLAUDE.md` + `CONTEXT.md` | 先铺骨架，船体往上长 |
+| 船级社 classification society | `docs/standards/` + `design-system/` | 船要入级才能出海 = 变更要过标准才能合并 |
+| 海图 charts | specs + tickets | launch 的产物，照图施工 |
+| 航海日志 logbook | `docs/adr/` | 决策记录，事后可查 |
+| 下水 launch | `/oh-my-claudecode:launch` | 人人可以下水，船级社的检查一项不能少 |
+
+## The three skills compose
+
+- **`drydock`** lays the keel once per repo (surfaces + seeds + `--check` drift audit).
+- **`launch`** runs delivery per feature (C1 brief → C2 spec+seams → C3 tickets → C4 frontier execution → C5 closeout), with the human at exactly the checkpoints that fail expensively.
+- **`minimal-code-discipline`** governs how the code inside every ticket gets written (YAGNI ladder, smallest correct diff).
+
+They share one rule of thumb: **starting needs no permission; landing goes into a shipyard slot.** A change that cannot say which slot it lands in (or explicitly none) is the smell.
+
+## The feedback loop
+
+Shipyard corrects itself through evidence: friction observed during any run is recorded as a finding (phase-tagged), reviewed at closeout, and either fixed in the skill files or explicitly wontfixed with a reason. A fix is `shipped` only when a later run verifies it took effect. The ledger lives in each project's findings store; the audit is mechanical (`sy check`/`context-lint` style tools, or by hand).
+
+## When to reach for what
+
+- one-point fix → `execute` directly (no shipyard ceremony)
+- multi-step feature → `launch`
+- new repo, or a repo where knowledge lives in heads → `drydock` first
+- writing-time code discipline inside any of the above → `minimal-code-discipline`
+
+Shipyard adds no daemon, no mode, no always-on behavior: the surfaces are plain markdown, the skills are plain instructions, and the canonical `plan → execute → review → verify` spine remains the default path. Shipyard is opt-in at every door.

--- a/docs/shipyard.md
+++ b/docs/shipyard.md
@@ -17,25 +17,22 @@ It is not "let agents do as much as possible" — it is "delegate exactly what c
 
 ## The four pillars → five surfaces
 
-A repo that humans and agents both build on carries four pillars across five conceptual surfaces, represented by the concrete paths below. `/oh-my-claudecode:drydock` lays them; every later session inherits them by reading.
+A repo that humans and agents both build on carries four pillars across five conceptual surfaces. `/oh-my-claudecode:drydock` lays them; every later session inherits them by reading.
 
-| Surface | Carries | Filled by |
+| Conceptual surface | Concrete paths | Carries / filled by |
 | --- | --- | --- |
-| `CLAUDE.md` | Thin entry: project conventions / architecture principles / standards index / load-bearing decision pointers | drydock seed; retro & reviews sediment |
-| `CONTEXT.md` | Glossary (the slot agents write into the moment a term settles; vocabulary is law) | launch Phase 1; domain-modeling |
-| `docs/adr/` | Decision records in full (the logbook) | launch convergence and C4 follow-up; domain-modeling |
-| `docs/standards/` | architecture.md / data.md / process.md | retro & code-review sediment |
-| `docs/business/` | Business knowledge (one article answers one business question) | launch Phase 1 |
-| `design-system/` | tokens/ + components/ + patterns/ | frontend review sediment |
-| `.omc/skills/` | Project skills: reusable capabilities / specialized tools / prompt templates / specialized practices | anyone (skillify quality gate) |
-| `.mcp.json` + `scripts/` | MCP servers + CLI toolchain / automation scripts | PR |
+| Shared context | `CONTEXT.md` + `docs/business/` + `docs/adr/` + OMC wiki | Glossary, business knowledge, and decision records; launch writes the file-backed paper trail and wiki compounds session knowledge |
+| Rules | `CLAUDE.md` + `docs/standards/` | Thin conventions/principles/index plus architecture, data, and process standards; drydock seeds them and retros/reviews sediment recurring corrections |
+| Project skills | `.omc/skills/` | Reusable project capabilities and practices; contributors add them through the skillify quality gate |
+| Design system | `design-system/` | Tokens, components, and patterns; drydock seeds it for UI repos and may create a stub or skip it for non-UI repos |
+| MCP / CLI tools | `.mcp.json` + `scripts/` | MCP servers and repository automation; drydock seeds empty tool surfaces and integrations are added only when needed |
 
 ## The metaphor family (for teaching the system)
 
 | Metaphor | Maps to | In one line |
 | --- | --- | --- |
 | The shipyard | The whole harness | A shared facility; everyone comes here to build |
-| The keel | `CLAUDE.md` + `CONTEXT.md` | Lay the skeleton first; the hull grows upward |
+| The keel | Shared context + rules surfaces | Lay the skeleton first; the hull grows upward |
 | The classification society | `docs/standards/` + `design-system/` | A ship must pass class to sail = changes must pass standards to merge |
 | The charts | specs + tickets | Launch's output; build from the chart |
 | The logbook | `docs/adr/` | Decisions, auditable after the fact |
@@ -51,7 +48,7 @@ They share one rule of thumb: **starting needs no permission; landing goes into 
 
 ## The feedback loop
 
-Shipyard corrects itself through its plain-file paper trail: launch closeout reconciles the spec, `CONTEXT.md`, ADRs, and business docs, while recurring corrections can sediment into `CLAUDE.md` and `docs/standards/` through retros and reviews. `/oh-my-claudecode:drydock --check` audits harness drift. These skills do not add a separate findings store, shipped/wontfixed state machine, hidden ledger, or `sy check`/`context-lint` commands.
+Shipyard corrects itself through its file-backed paper trail: launch closeout reconciles the spec, `CONTEXT.md`, and ADRs, while recurring corrections can sediment into `CLAUDE.md` and `docs/standards/` through retros and reviews. `/oh-my-claudecode:drydock --check` audits harness drift. These skills do not add a separate findings store, shipped/wontfixed state machine, hidden ledger, or `sy check`/`context-lint` commands.
 
 ## When to reach for what
 
@@ -60,4 +57,4 @@ Shipyard corrects itself through its plain-file paper trail: launch closeout rec
 - new repo, or a repo where knowledge lives in heads → `drydock` first
 - writing-time code discipline inside any of the above → `minimal-code-discipline`
 
-Shipyard adds no daemon, no mode, no always-on behavior: the surfaces are plain markdown, the skills are plain instructions, and the canonical `plan → execute → review → verify` spine remains the default path. Shipyard is opt-in at every door.
+Shipyard adds no daemon, no mode, no always-on behavior: the surfaces are ordinary repository files, the skills are plain instructions, and the canonical `plan → execute → review → verify` spine remains the default path. Shipyard is opt-in at every door.

--- a/docs/shipyard.md
+++ b/docs/shipyard.md
@@ -17,13 +17,13 @@ It is not "let agents do as much as possible" — it is "delegate exactly what c
 
 ## The four pillars → five surfaces
 
-A repo that humans and agents both build on carries four pillars across five surfaces. `/oh-my-claudecode:drydock` lays them; every later session inherits them by reading.
+A repo that humans and agents both build on carries four pillars across five conceptual surfaces, represented by the concrete paths below. `/oh-my-claudecode:drydock` lays them; every later session inherits them by reading.
 
 | Surface | Carries | Filled by |
 | --- | --- | --- |
 | `CLAUDE.md` | Thin entry: project conventions / architecture principles / standards index / load-bearing decision pointers | drydock seed; retro & reviews sediment |
 | `CONTEXT.md` | Glossary (the slot agents write into the moment a term settles; vocabulary is law) | launch Phase 1; domain-modeling |
-| `docs/adr/` | Decision records in full (the logbook) | launch C4; domain-modeling |
+| `docs/adr/` | Decision records in full (the logbook) | launch convergence and C4 follow-up; domain-modeling |
 | `docs/standards/` | architecture.md / data.md / process.md | retro & code-review sediment |
 | `docs/business/` | Business knowledge (one article answers one business question) | launch Phase 1 |
 | `design-system/` | tokens/ + components/ + patterns/ | frontend review sediment |
@@ -44,14 +44,14 @@ A repo that humans and agents both build on carries four pillars across five sur
 ## The three skills compose
 
 - **`drydock`** lays the keel once per repo (surfaces + seeds + `--check` drift audit).
-- **`launch`** runs delivery per feature (C1 brief → C2 spec+seams → C3 tickets → C4 frontier execution → C5 closeout), with the human at exactly the checkpoints that fail expensively.
-- **`minimal-code-discipline`** governs how the code inside every ticket gets written (YAGNI ladder, smallest correct diff).
+- **`launch`** runs delivery per feature (C1 brief → C2 spec+seams → C3 tickets → frontier execution with C4 decision stops → C5 closeout), with the human at exactly the checkpoints that fail expensively.
+- **`minimal-code-discipline`** is an opt-in discipline for code written inside tickets (YAGNI ladder, smallest correct diff).
 
 They share one rule of thumb: **starting needs no permission; landing goes into a shipyard slot.** A change that cannot say which slot it lands in (or explicitly none) is the smell.
 
 ## The feedback loop
 
-Shipyard corrects itself through evidence: friction observed during any run is recorded as a finding (phase-tagged), reviewed at closeout, and either fixed in the skill files or explicitly wontfixed with a reason. A fix is `shipped` only when a later run verifies it took effect. The ledger lives in each project's findings store; the audit is mechanical (`sy check`/`context-lint` style tools, or by hand).
+Shipyard corrects itself through its plain-file paper trail: launch closeout reconciles the spec, `CONTEXT.md`, ADRs, and business docs, while recurring corrections can sediment into `CLAUDE.md` and `docs/standards/` through retros and reviews. `/oh-my-claudecode:drydock --check` audits harness drift. These skills do not add a separate findings store, shipped/wontfixed state machine, hidden ledger, or `sy check`/`context-lint` commands.
 
 ## When to reach for what
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "592ad024f8004cc3a9f58f5590ac1b6eefa2df54",
-    "sourceSha256": "2985112d6efe4f41cf15ac334f2536c5684138a41d9d2bbbd15c3c33e89045f2",
+    "head": "19a1ad113bad5d46a10d8172b27a1f734ec26002",
+    "sourceSha256": "b073bb7cf5941702657d7392459b07761ab842f2a08b6dd4b1d9cd16ef9b4bdc",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "592ad024f8004cc3a9f58f5590ac1b6eefa2df54",
-  "sourceSha256": "2985112d6efe4f41cf15ac334f2536c5684138a41d9d2bbbd15c3c33e89045f2",
+  "head": "19a1ad113bad5d46a10d8172b27a1f734ec26002",
+  "sourceSha256": "b073bb7cf5941702657d7392459b07761ab842f2a08b6dd4b1d9cd16ef9b4bdc",
   "counts": {
     "public": {
       "skills": 35,
@@ -76545,5 +76545,5 @@
     }
   },
   "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "230fa2643eec46ea98d41b4c4e7372746709df638d66a9cf017bec7e0ba1a923"
+  "manifestSha256": "f33b6eae9f4544621c925b58b3c6f6976bc15e6ae3b3918a9b6131fbf6712ff2"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "8953e3bae907dd5c414de54cc8986071144be4a3",
-    "sourceSha256": "e4469ab302e157ac24645935402fe615280ee6d182aa8b7d81734e66534bc5d1",
+    "head": "592ad024f8004cc3a9f58f5590ac1b6eefa2df54",
+    "sourceSha256": "2985112d6efe4f41cf15ac334f2536c5684138a41d9d2bbbd15c3c33e89045f2",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "8953e3bae907dd5c414de54cc8986071144be4a3",
-  "sourceSha256": "e4469ab302e157ac24645935402fe615280ee6d182aa8b7d81734e66534bc5d1",
+  "head": "592ad024f8004cc3a9f58f5590ac1b6eefa2df54",
+  "sourceSha256": "2985112d6efe4f41cf15ac334f2536c5684138a41d9d2bbbd15c3c33e89045f2",
   "counts": {
     "public": {
       "skills": 35,
@@ -76545,5 +76545,5 @@
     }
   },
   "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "e31aa8723dc52502e9f5c404ed723eb2dd90447d5552563f378e2fb20b62503f"
+  "manifestSha256": "230fa2643eec46ea98d41b4c4e7372746709df638d66a9cf017bec7e0ba1a923"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "71889ff5961c18b80e8263cb44ef547ce8c4a9b3",
-    "sourceSha256": "54fa634f73f3bee413c1d76e67675ed10a5ea17469aea350d2715e21352e48c8",
+    "head": "8953e3bae907dd5c414de54cc8986071144be4a3",
+    "sourceSha256": "e4469ab302e157ac24645935402fe615280ee6d182aa8b7d81734e66534bc5d1",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "71889ff5961c18b80e8263cb44ef547ce8c4a9b3",
-  "sourceSha256": "54fa634f73f3bee413c1d76e67675ed10a5ea17469aea350d2715e21352e48c8",
+  "head": "8953e3bae907dd5c414de54cc8986071144be4a3",
+  "sourceSha256": "e4469ab302e157ac24645935402fe615280ee6d182aa8b7d81734e66534bc5d1",
   "counts": {
     "public": {
       "skills": 35,
@@ -32173,6 +32173,11 @@
         "id": "docs/shared/verification-tiers.md",
         "kind": "other",
         "path": "docs/shared/verification-tiers.md"
+      },
+      {
+        "id": "docs/shipyard.md",
+        "kind": "other",
+        "path": "docs/shipyard.md"
       },
       {
         "id": "docs/ultragoal.md",
@@ -76533,12 +76538,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6838,
+      "nodeCount": 6839,
       "edgeCount": 7212,
       "importEdgeCount": 5922,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "c56f8abade4e2f50543755ab36df00439ddf6fb2b12d8d2388881a43e9d74e49",
-  "manifestSha256": "28fb027996710e4b0847ef61104ab9750fd4ff6ef39c7f8b72ca67c34c583ff9"
+  "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
+  "manifestSha256": "e31aa8723dc52502e9f5c404ed723eb2dd90447d5552563f378e2fb20b62503f"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "19a1ad113bad5d46a10d8172b27a1f734ec26002",
-    "sourceSha256": "b073bb7cf5941702657d7392459b07761ab842f2a08b6dd4b1d9cd16ef9b4bdc",
+    "head": "5dd86fff404b34b905d84f70b40285a4e817d147",
+    "sourceSha256": "7fed248e1aac7aafbf570e74a1aa12f0714cccd39e10f9acffaac1e2d5207d96",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "19a1ad113bad5d46a10d8172b27a1f734ec26002",
-  "sourceSha256": "b073bb7cf5941702657d7392459b07761ab842f2a08b6dd4b1d9cd16ef9b4bdc",
+  "head": "5dd86fff404b34b905d84f70b40285a4e817d147",
+  "sourceSha256": "7fed248e1aac7aafbf570e74a1aa12f0714cccd39e10f9acffaac1e2d5207d96",
   "counts": {
     "public": {
       "skills": 35,
@@ -76545,5 +76545,5 @@
     }
   },
   "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "f33b6eae9f4544621c925b58b3c6f6976bc15e6ae3b3918a9b6131fbf6712ff2"
+  "manifestSha256": "fb7c60782cc6cffb593d33af45e214fd703b93c4972bd2f1527b8ad3cc915ef9"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "9ea44cbf580dc7e9ae8859826a64619a495333b1",
-    "sourceSha256": "8dbae0c63f53897710eb55161fa889e27d1e44f63d46258370277b615f61b2ba",
+    "head": "71889ff5961c18b80e8263cb44ef547ce8c4a9b3",
+    "sourceSha256": "54fa634f73f3bee413c1d76e67675ed10a5ea17469aea350d2715e21352e48c8",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "9ea44cbf580dc7e9ae8859826a64619a495333b1",
-  "sourceSha256": "8dbae0c63f53897710eb55161fa889e27d1e44f63d46258370277b615f61b2ba",
+  "head": "71889ff5961c18b80e8263cb44ef547ce8c4a9b3",
+  "sourceSha256": "54fa634f73f3bee413c1d76e67675ed10a5ea17469aea350d2715e21352e48c8",
   "counts": {
     "public": {
       "skills": 35,
@@ -76540,5 +76540,5 @@
     }
   },
   "inventorySha256": "c56f8abade4e2f50543755ab36df00439ddf6fb2b12d8d2388881a43e9d74e49",
-  "manifestSha256": "38be0dc637f98f174194f3238687a09ae61ce8474d5d3e79d3bc9ec6bc0aa1ee"
+  "manifestSha256": "28fb027996710e4b0847ef61104ab9750fd4ff6ef39c7f8b72ca67c34c583ff9"
 }


### PR DESCRIPTION
## Summary

Docs-only addition: `docs/shipyard.md`, the methodology map for the three shipyard skills that shipped via #3907 (launch, drydock) and #3899 (minimal-code-discipline).

The merged skills carry the discipline as procedural text; this page carries the **map** a new contributor or teammate needs to see the whole at once:

- the premise in one line (everyone ships, nobody ships randomly)
- the **verifiability boundary** test that decides the human/agent split per step
- the four pillars and where they physically live (5 surfaces, with per-surface descriptions)
- the metaphor family used when teaching the system (keel / classification society / charts / logbook / launch)
- how the three skills compose, the feedback loop, and when to reach for what

Explicitly documents: shipyard adds no daemon, no mode, no always-on behavior — the canonical `plan → execute → review → verify` spine remains the default path, shipyard is opt-in at every door.

## What changed

- `docs/shipyard.md` (new, ~90 lines, markdown only)
- `docs/REFERENCE.md`: one TOC line linking the page

## Verification

- [x] Docs-only: no source, test, config, or inventory-behavior change (inventory graph refreshed for the new tracked file; verify green)
- [x] Zero behavior surface: nothing here can change any gate, test, or runtime path
- [x] Content reviewed against the merged skill texts (launch/drydock) — terminology matches (frontier, seams, paper trail, classification society)

## Notes for reviewers

- Follows #3907: the skills shipped as procedural documents; this page is the requested-and-missing methodology map, kept to one page and stripped of anything behavioral.
- Two commits off current `dev` (`71889ff59`).