### PR TITLE
feat(drydock): document-language decision + bilingual seeds (user-language principle)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "80d6b9c0716a11a7b69d973b20704c89a145e67f",
+    "head": "b04557a781a7db6ac17e7abf4c40b22728fc7eb1",
     "sourceSha256": "b95046b40fe8fa88678e87e6c071e5974843a8e145077c231f7ba4ce0acabf6a",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "80d6b9c0716a11a7b69d973b20704c89a145e67f",
+  "head": "b04557a781a7db6ac17e7abf4c40b22728fc7eb1",
   "sourceSha256": "b95046b40fe8fa88678e87e6c071e5974843a8e145077c231f7ba4ce0acabf6a",
   "counts": {
     "public": {
@@ -76545,5 +76545,5 @@
     }
   },
   "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "fb44c55b8cb5fab609562e690f2d82cc7f44d14976ea7fd870213f34bfbef161"
+  "manifestSha256": "4909e8d2dc6e176cc77b9d9f895b7a1c77ad9ff7d00d6953eba4c29da3c83e09"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "7f806077976294ead9115eb7598b8f84ac46710e",
-    "sourceSha256": "27a37d2c7cddb0b2757e5ed618b5a465510db097b8eb28d7b1083e9017da5b7f",
+    "head": "8a817215636a4ba79b3f7cdfddb1259fe2d35577",
+    "sourceSha256": "f6bfa8a457a0fdb83ece212326b5d3724909bb5ce90687dee9dbf24449a6afd4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "7f806077976294ead9115eb7598b8f84ac46710e",
-  "sourceSha256": "27a37d2c7cddb0b2757e5ed618b5a465510db097b8eb28d7b1083e9017da5b7f",
+  "head": "8a817215636a4ba79b3f7cdfddb1259fe2d35577",
+  "sourceSha256": "f6bfa8a457a0fdb83ece212326b5d3724909bb5ce90687dee9dbf24449a6afd4",
   "counts": {
     "public": {
       "skills": 35,
@@ -48173,12 +48173,22 @@
       },
       {
         "from": "src/__tests__/shipyard-seed-locale.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/shipyard-seed-locale.test.ts",
         "to": "external:path",
         "kind": "imports"
       },
       {
         "from": "src/__tests__/shipyard-seed-locale.test.ts",
         "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/shipyard-seed-locale.test.ts",
+        "to": "src/hooks/learner/loader.ts",
         "kind": "imports"
       },
       {
@@ -76564,11 +76574,11 @@
     ],
     "stats": {
       "nodeCount": 6840,
-      "edgeCount": 7216,
-      "importEdgeCount": 5926,
+      "edgeCount": 7218,
+      "importEdgeCount": 5928,
       "registerEdgeCount": 56
     }
   },
   "inventorySha256": "f5ea9ebf29ba491f17b39431660e07f71eb3d78399d481c1c2b00fc34cf2ab50",
-  "manifestSha256": "fb3808b7177c21f6c3e53601641483b0d8be5d2d68aa482e706020c69e15724d"
+  "manifestSha256": "8bf7e76cd187453fef74b71f6c1fc5867ae0e39867c7db2f70f2fda4b498293c"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b04557a781a7db6ac17e7abf4c40b22728fc7eb1",
-    "sourceSha256": "b95046b40fe8fa88678e87e6c071e5974843a8e145077c231f7ba4ce0acabf6a",
+    "head": "0b89b1361e66ddbb122ff31a4854b809641f7c51",
+    "sourceSha256": "ac66582549425989d8738007308a61baaaa69392594ac60f5a844a654a9e8aac",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b04557a781a7db6ac17e7abf4c40b22728fc7eb1",
-  "sourceSha256": "b95046b40fe8fa88678e87e6c071e5974843a8e145077c231f7ba4ce0acabf6a",
+  "head": "0b89b1361e66ddbb122ff31a4854b809641f7c51",
+  "sourceSha256": "ac66582549425989d8738007308a61baaaa69392594ac60f5a844a654a9e8aac",
   "counts": {
     "public": {
       "skills": 35,
@@ -76545,5 +76545,5 @@
     }
   },
   "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "4909e8d2dc6e176cc77b9d9f895b7a1c77ad9ff7d00d6953eba4c29da3c83e09"
+  "manifestSha256": "f9a3b9a53129305229d8926863e691c1a664e340df80846b54b59b638161070a"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "57949c4ebe12910fdb354c4f7689e09b4554ccf1",
-    "sourceSha256": "7fed248e1aac7aafbf570e74a1aa12f0714cccd39e10f9acffaac1e2d5207d96",
+    "head": "80d6b9c0716a11a7b69d973b20704c89a145e67f",
+    "sourceSha256": "b95046b40fe8fa88678e87e6c071e5974843a8e145077c231f7ba4ce0acabf6a",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "57949c4ebe12910fdb354c4f7689e09b4554ccf1",
-  "sourceSha256": "7fed248e1aac7aafbf570e74a1aa12f0714cccd39e10f9acffaac1e2d5207d96",
+  "head": "80d6b9c0716a11a7b69d973b20704c89a145e67f",
+  "sourceSha256": "b95046b40fe8fa88678e87e6c071e5974843a8e145077c231f7ba4ce0acabf6a",
   "counts": {
     "public": {
       "skills": 35,
@@ -76545,5 +76545,5 @@
     }
   },
   "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "cf42cce59240f73cde59a631f54e941af0987c88cd4bc526b5f6888de96ad705"
+  "manifestSha256": "fb44c55b8cb5fab609562e690f2d82cc7f44d14976ea7fd870213f34bfbef161"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0b89b1361e66ddbb122ff31a4854b809641f7c51",
-    "sourceSha256": "ac66582549425989d8738007308a61baaaa69392594ac60f5a844a654a9e8aac",
+    "head": "7f806077976294ead9115eb7598b8f84ac46710e",
+    "sourceSha256": "27a37d2c7cddb0b2757e5ed618b5a465510db097b8eb28d7b1083e9017da5b7f",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0b89b1361e66ddbb122ff31a4854b809641f7c51",
-  "sourceSha256": "ac66582549425989d8738007308a61baaaa69392594ac60f5a844a654a9e8aac",
+  "head": "7f806077976294ead9115eb7598b8f84ac46710e",
+  "sourceSha256": "27a37d2c7cddb0b2757e5ed618b5a465510db097b8eb28d7b1083e9017da5b7f",
   "counts": {
     "public": {
       "skills": 35,
@@ -28,8 +28,8 @@
       "toolFiles": 60,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1310,
-      "total": 1331
+      "srcFiles": 1311,
+      "total": 1332
     },
     "generated": {
       "distFiles": 4955,
@@ -34780,6 +34780,11 @@
         "path": "src/__tests__/shared-state-locking.test.ts"
       },
       {
+        "id": "src/__tests__/shipyard-seed-locale.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/shipyard-seed-locale.test.ts"
+      },
+      {
         "id": "src/__tests__/shipyard-skills.test.ts",
         "kind": "src",
         "path": "src/__tests__/shipyard-skills.test.ts"
@@ -48159,6 +48164,26 @@
       {
         "from": "src/__tests__/shared-state-locking.test.ts",
         "to": "src/interop/shared-state.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/shipyard-seed-locale.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/shipyard-seed-locale.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/shipyard-seed-locale.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/shipyard-seed-locale.test.ts",
+        "to": "src/hooks/learner/parser.ts",
         "kind": "imports"
       },
       {
@@ -76538,12 +76563,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6839,
-      "edgeCount": 7212,
-      "importEdgeCount": 5922,
+      "nodeCount": 6840,
+      "edgeCount": 7216,
+      "importEdgeCount": 5926,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "f3b1f52c7615447741858120743b2d57d912e7e11a797dba721324b6d86b846c",
-  "manifestSha256": "f9a3b9a53129305229d8926863e691c1a664e340df80846b54b59b638161070a"
+  "inventorySha256": "f5ea9ebf29ba491f17b39431660e07f71eb3d78399d481c1c2b00fc34cf2ab50",
+  "manifestSha256": "fb3808b7177c21f6c3e53601641483b0d8be5d2d68aa482e706020c69e15724d"
 }

--- a/skills/drydock/SKILL.md
+++ b/skills/drydock/SKILL.md
@@ -45,11 +45,12 @@ Report the map first, then act.
 
 ### 2. Ask (only what detection cannot answer)
 
+- **document language for the generated harness files** — the human reads and maintains them, so they follow the human: ask once, or infer from the target repo's existing CLAUDE.md/README; record the choice in the init report. Prose and field labels follow this language; structural keys stay language-stable (file paths, frontmatter keys, `blockedBy:`, status enums, ID formats).
 - package/tech stack (for standards and design-system seeds)
 - does this repo have a UI? (no UI → design-system/ is created as a stub with a note, or skipped on request)
 - issue tracker location (GitHub / GitLab / local `.scratch/`) — recorded for launch/triage flows
 
-### 3. Scaffold (create missing surfaces with the seeds below)
+### 3. Scaffold (create missing surfaces — seeds render in the document language)
 
 ```
 CLAUDE.md                      # thin entry — see seed A
@@ -67,10 +68,40 @@ design-system/tokens/README.md
 scripts/README.md
 ```
 
-Seed A — CLAUDE.md (thin entry; extend in place if the file exists):
+Seed exemplars below are shown in **English** (canonical structure) with a **zh (中文) companion** for the seeds whose field labels are load-bearing (Seed A headings, Seed B labels). Whichever document language was chosen, the agent renders all seed prose in that language — structure and keys stay as documented.
+
+Seed A — CLAUDE.md, en (thin entry; extend in place if the file exists):
 
 ```markdown
 # <Project> — Agent & Human Shipyard
+
+## Project conventions
+- <language/framework/package manager/naming — list what matters, skip the rest>
+
+## Architecture principles
+- <the 3-5 principles most often violated in this project>
+
+## Standards index (full text in docs/standards/)
+- Architecture: docs/standards/architecture.md
+- Data: docs/standards/data.md
+- Process: docs/standards/process.md
+
+## Decision records (full text in docs/adr/; load-bearing ones listed here)
+- ADR-0001: adopt shipyard harness
+
+## Shared background
+- Glossary: CONTEXT.md ｜ Business knowledge: docs/business/ ｜ Decision context: docs/adr/
+
+## Agent guide
+- Delivery follows the canonical workflow plan → execute → review → verify; `/oh-my-claudecode:launch` is an optional governed delivery pipeline (opt-in, invoke explicitly)
+- On term conflicts CONTEXT.md wins; new terms are recorded the moment they settle
+- Reusable capability goes to .omc/skills/; UI patterns go to design-system/
+```
+
+Seed A — zh companion (结构一致，二选一按文档语言渲染):
+
+```markdown
+# <项目> — Agent & Human Shipyard
 
 ## 项目约定
 - <语言/框架/包管理器/命名惯例 —— 逐条列，宁缺毋滥>
@@ -95,7 +126,9 @@ Seed A — CLAUDE.md (thin entry; extend in place if the file exists):
 - 可复用能力沉淀到 .omc/skills/；UI 模式沉淀到 design-system/
 ```
 
-Seed B — CONTEXT.md:
+Seed B — CONTEXT.md (field labels are load-bearing; both languages documented):
+
+en:
 
 ```markdown
 # Glossary
@@ -103,21 +136,34 @@ Seed B — CONTEXT.md:
 One entry per term: definition, boundaries, one resolved ambiguity. Agents write here the moment a term is settled. Vocabulary here is law for all specs, tickets, and code naming.
 
 ## <term>
+- Definition:
+- Boundary: (is X, not Y)
+- Resolved ambiguity:
+```
+
+zh:
+
+```markdown
+# 术语表
+
+一条术语一个条目：定义、边界、一个已解决的歧义。术语敲定的当下写入。词汇对所有 spec、ticket、代码命名具有法律效力。
+
+## <术语>
 - 定义:
 - 边界: （是 X，不是 Y）
 - 已解决的歧义:
 ```
 
-Seed C — docs/standards/architecture.md (data.md / process.md same shape):
+Seed C — docs/standards/architecture.md (data.md / process.md same shape; prose renders in the document language):
 
 ```markdown
 # Architecture Standards
 
-规则化、可检查的写；每条带一个"为什么"。空节是合法的——沉淀是渐进的。
+Rule-shaped, checkable writing; every rule carries a "why". Empty sections are legal — sediment is gradual.
 
-## 模块边界
-## 错误处理
-## 依赖方向
+## Module boundaries
+## Error handling
+## Dependency direction
 ```
 
 Seed D — docs/business/README.md:
@@ -125,8 +171,8 @@ Seed D — docs/business/README.md:
 ```markdown
 # Business Knowledge
 
-决策背景与业务规则。格式建议：一篇文章回答一个业务问题，开头一段"为什么这事重要"。
-新来的同事（人或 agent）读完这一目录，应该能回答"我们为什么做这个产品方向"。
+Decision background and business rules. Format suggestion: one article answers one business question, opening paragraph states why it matters.
+A new teammate (human or agent) reading this directory should be able to answer "why does this product direction exist".
 ```
 
 Seed E — design-system/README.md:
@@ -134,9 +180,9 @@ Seed E — design-system/README.md:
 ```markdown
 # Design System
 
-## tokens/    设计令牌（颜色/字号/间距，机器可读 JSON 优先）
-## components/ 组件约定（每个组件：用途、变体、禁用场景）
-## patterns/  交互模式（表单、反馈、加载、空状态——沉淀复用过的模式）
+## tokens/    Design tokens (colors/type/spacing, machine-readable JSON preferred)
+## components/ Component contracts (purpose, variants, misuse)
+## patterns/  Interaction patterns (forms, feedback, loading, empty states — sediment reused patterns)
 ```
 
 Seed F — .omc/skills/README.md:
@@ -144,9 +190,9 @@ Seed F — .omc/skills/README.md:
 ````markdown
 # Project Skills
 
-本项目沉淀的可复用能力：专用工具、提示词模板、专用实践。
-一个技能一个文件 `.omc/skills/<name>.md`，frontmatter 必须含 name + description +
-**非空 triggers**（loader 校验硬性要求：缺失或为空则技能不会被加载）：
+Reusable capabilities sedimented by this project: specialized tools, prompt templates, specialized practices.
+One skill per file `.omc/skills/<name>.md`, frontmatter must contain name + description +
+**non-empty triggers** (loader validation hard requirement: missing or empty means the skill is never loaded):
 
 ```markdown
 ---
@@ -160,8 +206,8 @@ triggers:
 
 Follow the repository-specific release checklist and report evidence.
 ```
-判断标准与 Matt 的 skillify 一致：5 分钟能 Google 到的不配做技能；
-写"本项目特有的决策纪律"，不写通用教程。
+Bar for admission matches skillify: if it can be Googled in 5 minutes it is not a skill;
+write "this project's specific decision discipline", not generic tutorials.
 ````
 
 `.mcp.json` seed: `{"mcpServers": {}}` — servers get added when a tool integration is actually needed, not speculatively.

--- a/skills/drydock/SKILL.md
+++ b/skills/drydock/SKILL.md
@@ -45,7 +45,12 @@ Report the map first, then act.
 
 ### 2. Ask (only what detection cannot answer)
 
-- **document language for the generated harness files** — the human reads and maintains them, so they follow the human: ask once, or infer from the target repo's existing CLAUDE.md/README; record the choice in the init report. Prose and field labels follow this language; structural keys stay language-stable (file paths, frontmatter keys, `blockedBy:`, status enums, ID formats).
+- **document language for the generated harness files**, resolved in this fixed order:
+  1. **Explicit human override in the current request** — the human names a language; it wins over everything, and the durable tag below is updated to match.
+  2. **Durable tag** — the `language:` field in `CONTEXT.md` frontmatter (e.g. `language: zh-Hans`); created at init, read by every later launch.
+  3. **Inference** — only when no durable tag exists: the dominant language of the target repo's existing CLAUDE.md/README, accepted only when unambiguous across inspected files.
+  4. **Ambiguity branch** — mixed-language or missing files → ask once, record the answer into the durable tag. Locale/script variants are explicit tags (`zh-Hans`, `zh-Hant`, `en`); bare `zh` is not a valid tag.
+  Prose and field labels follow the resolved language; structural keys stay language-stable (file paths, frontmatter keys, `blockedBy:`, status enums, ID formats).
 - package/tech stack (for standards and design-system seeds)
 - does this repo have a UI? (no UI → design-system/ is created as a stub with a note, or skipped on request)
 - issue tracker location (GitHub / GitLab / local `.scratch/`) — recorded for launch/triage flows
@@ -126,11 +131,15 @@ Seed A — zh companion (结构一致，二选一按文档语言渲染):
 - 可复用能力沉淀到 .omc/skills/；UI 模式沉淀到 design-system/
 ```
 
-Seed B — CONTEXT.md (field labels are load-bearing; both languages documented):
+Seed B — CONTEXT.md, en (field labels are load-bearing; both languages documented):
 
 en:
 
 ```markdown
+---
+language: en
+---
+
 # Glossary
 
 One entry per term: definition, boundaries, one resolved ambiguity. Agents write here the moment a term is settled. Vocabulary here is law for all specs, tickets, and code naming.
@@ -141,9 +150,13 @@ One entry per term: definition, boundaries, one resolved ambiguity. Agents write
 - Resolved ambiguity:
 ```
 
-zh:
+Seed B — CONTEXT.md, zh:
 
 ```markdown
+---
+language: zh-Hans
+---
+
 # 术语表
 
 一条术语一个条目：定义、边界、一个已解决的歧义。术语敲定的当下写入。词汇对所有 spec、ticket、代码命名具有法律效力。
@@ -191,11 +204,11 @@ Seed F — .omc/skills/README.md:
 # Project Skills
 
 Reusable capabilities sedimented by this project: specialized tools, prompt templates, specialized practices.
-One skill per file `.omc/skills/<name>.md`, frontmatter must contain name + description +
-**non-empty triggers** (loader validation hard requirement: missing or empty means the skill is never loaded):
+One skill per file `.omc/skills/<name>.md`, frontmatter must contain a **literal Latin `id`** + name + description + non-empty triggers (loader validation hard requirement: missing or empty means the skill is never loaded; the production parser derives `id` from `name` only when `id` is missing — a localized `name` would strip to an empty ID, so the literal `id` is the stability guarantee). `id` is machine-semantic and never localized; `name`/`description` may follow the document language:
 
 ```markdown
 ---
+id: project-release-check
 name: project-release-check
 description: Apply this repository's release readiness rules
 triggers:

--- a/skills/drydock/SKILL.md
+++ b/skills/drydock/SKILL.md
@@ -43,14 +43,44 @@ Inventory what exists before writing anything:
 
 Report the map first, then act.
 
-### 2. Ask (only what detection cannot answer)
+### 2. Resolve document language, then ask only what detection cannot answer
 
-- **document language for the generated harness files**, resolved in this fixed order:
-  1. **Explicit human override in the current request** — the human names a language; it wins over everything, and the durable tag below is updated to match.
-  2. **Durable tag** — the `language:` field in `CONTEXT.md` frontmatter (e.g. `language: zh-Hans`); created at init, read by every later launch.
-  3. **Inference** — only when no durable tag exists: the dominant language of the target repo's existing CLAUDE.md/README, accepted only when unambiguous across inspected files.
-  4. **Ambiguity branch** — mixed-language or missing files → ask once, record the answer into the durable tag. Locale/script variants are explicit tags (`zh-Hans`, `zh-Hant`, `en`); bare `zh` is not a valid tag.
-  Prose and field labels follow the resolved language; structural keys stay language-stable (file paths, frontmatter keys, `blockedBy:`, status enums, ID formats).
+The document language for the generated harness files is a file-backed decision, not conversation state. Use this contract exactly:
+
+<!-- shipyard-document-language-contract:start -->
+```json
+{
+  "schemaVersion": 1,
+  "authority": { "path": "CONTEXT.md", "frontmatterKey": "documentLanguage" },
+  "canonicalSources": ["CLAUDE.md", "README.md"],
+  "askOn": ["missing", "mixed", "conflict", "low-confidence", "invalid-explicit", "script-ambiguous"],
+  "tagPattern": "^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-(?:[A-Z]{2}|[0-9]{3}))?$",
+  "scriptVariants": ["zh-Hans", "zh-Hant"],
+  "seedCompanionPrefixes": { "en": "en", "zh-Hans": "zh-Hans", "zh-Hant": "zh-Hant" },
+  "stableTokens": [
+    "CONTEXT.md", "documentLanguage", "/oh-my-claudecode:launch", "--serial",
+    "plan", "execute", "review", "verify", "blockedBy", "blocked_by",
+    "pending", "in_progress", "completed", "failed", "ready-for-agent",
+    "id", "name", "description", "triggers", "mcpServers", "```",
+    "<Project>", "<term>", "<feature-slug>"
+  ]
+}
+```
+<!-- shipyard-document-language-contract:end -->
+
+Resolution order:
+
+1. An explicit human choice in the current invocation wins when valid. Normalize it to a stable BCP-47-style tag: lowercase language, Title-Case script, uppercase region. Invalid explicit input must be asked once rather than guessed.
+2. Otherwise, read `documentLanguage` from the YAML frontmatter at the top of `CONTEXT.md`. A valid, script-unambiguous tag is authoritative for fresh Drydock and Launch invocations. If the persisted tag is bare or region-only Chinese, ask once at this authority tier; never bypass it with source inference.
+3. If the marker is absent or invalid, inspect canonical sources in this order: `CLAUDE.md`, then `README.md`. Infer only when every usable source has one unambiguous dominant language and all usable sources agree on the same normalized tag. One unambiguous source is sufficient when the other is missing or empty.
+4. Chinese must resolve to an explicit script-qualified tag: `zh-Hans` or `zh-Hant` (optionally followed by a region). Bare `zh` and region-only Chinese tags are script-ambiguous and must be asked once rather than selecting a companion. Companion selection uses the longest language/script prefix: `zh-Hans-*` selects the `zh-Hans` companion and `zh-Hant-*` selects `zh-Hant`; preserve the full normalized tag (for example `zh-Hans-CN`) in `CONTEXT.md`.
+5. Missing usable sources, mixed-language content, conflicting tags, low-confidence inference, invalid explicit input, or script-ambiguous Chinese must trigger one batched language question. Do not guess. If no answer is available, stop before writing localized artifacts.
+6. Before scaffolding, write the resolved tag to the exact stable frontmatter key `documentLanguage` in `CONTEXT.md` (creating or extending its frontmatter without translating the key). This visible file is the init report's language authority; no daemon, hidden ledger, or runtime state is created.
+
+Only prose and human-facing labels/localizable values follow the selected language; structural keys stay language-stable. Keep paths, slash commands, flags, code fences, placeholders, frontmatter keys and machine-semantic values, YAML/JSON keys, lifecycle tokens, status enums, IDs, `blockedBy`, public Team `blocked_by`, and parser/control tokens byte-for-byte stable.
+
+Ask the remaining questions only after language is resolved:
+
 - package/tech stack (for standards and design-system seeds)
 - does this repo have a UI? (no UI → design-system/ is created as a stub with a note, or skipped on request)
 - issue tracker location (GitHub / GitLab / local `.scratch/`) — recorded for launch/triage flows
@@ -73,10 +103,11 @@ design-system/tokens/README.md
 scripts/README.md
 ```
 
-Seed exemplars below are shown in **English** (canonical structure) with a **zh (中文) companion** for the seeds whose field labels are load-bearing (Seed A headings, Seed B labels). Whichever document language was chosen, the agent renders all seed prose in that language — structure and keys stay as documented.
+Seed exemplars are reference companions, never a combined payload. Select exactly one companion after resolving `documentLanguage`; do not emit duplicate headings or labels from another companion. Use the longest matching language/script prefix: `en-*` uses English, `zh-Hans-*` uses Simplified Chinese, and `zh-Hant-*` uses Traditional Chinese, while Seed B writes the full resolved tag into `documentLanguage`. For any other valid tag, translate the English canonical companion once while preserving every stable token above.
 
 Seed A — CLAUDE.md, en (thin entry; extend in place if the file exists):
 
+<!-- shipyard-seed-a:en:start -->
 ```markdown
 # <Project> — Agent & Human Shipyard
 
@@ -102,17 +133,19 @@ Seed A — CLAUDE.md, en (thin entry; extend in place if the file exists):
 - On term conflicts CONTEXT.md wins; new terms are recorded the moment they settle
 - Reusable capability goes to .omc/skills/; UI patterns go to design-system/
 ```
+<!-- shipyard-seed-a:en:end -->
 
-Seed A — zh companion (结构一致，二选一按文档语言渲染):
+Seed A — zh-Hans companion (结构一致，二选一按文档语言渲染):
 
+<!-- shipyard-seed-a:zh-Hans:start -->
 ```markdown
-# <项目> — Agent & Human Shipyard
+# <Project> — Agent & Human Shipyard
 
 ## 项目约定
-- <语言/框架/包管理器/命名惯例 —— 逐条列，宁缺毋滥>
+- <language/framework/package manager/naming — list what matters, skip the rest>
 
 ## 架构原则
-- <本项目最高频违反的 3-5 条原则>
+- <the 3-5 principles most often violated in this project>
 
 ## 规范索引（全文在 docs/standards/）
 - 架构规范: docs/standards/architecture.md
@@ -130,14 +163,46 @@ Seed A — zh companion (结构一致，二选一按文档语言渲染):
 - 术语冲突以 CONTEXT.md 为准；新术语当场补录
 - 可复用能力沉淀到 .omc/skills/；UI 模式沉淀到 design-system/
 ```
+<!-- shipyard-seed-a:zh-Hans:end -->
 
-Seed B — CONTEXT.md, en (field labels are load-bearing; both languages documented):
+Seed A — zh-Hant companion（結構一致，只渲染此版本）:
+
+<!-- shipyard-seed-a:zh-Hant:start -->
+```markdown
+# <Project> — Agent & Human Shipyard
+
+## 專案約定
+- <language/framework/package manager/naming — list what matters, skip the rest>
+
+## 架構原則
+- <the 3-5 principles most often violated in this project>
+
+## 規範索引（全文在 docs/standards/）
+- 架構規範: docs/standards/architecture.md
+- 資料規範: docs/standards/data.md
+- 流程規範: docs/standards/process.md
+
+## 決策記錄（全文在 docs/adr/，此處只列 load-bearing 項目）
+- ADR-0001: adopt shipyard harness
+
+## 共享背景
+- 詞彙: CONTEXT.md ｜ 業務知識: docs/business/ ｜ 決策背景: docs/adr/
+
+## Agent 指南
+- 交付遵循 canonical 工作流 plan → execute → review → verify；`/oh-my-claudecode:launch` 是可選的治理交付管道（opt-in，必須明確呼叫）
+- 術語衝突以 CONTEXT.md 為準；新術語確定時立即補錄
+- 可重用能力沉澱到 .omc/skills/；UI 模式沉澱到 design-system/
+```
+<!-- shipyard-seed-a:zh-Hant:end -->
+
+Seed B — CONTEXT.md (the stable frontmatter key is the language authority):
 
 en:
 
+<!-- shipyard-seed-b:en:start -->
 ```markdown
 ---
-language: en
+documentLanguage: en
 ---
 
 # Glossary
@@ -149,23 +214,45 @@ One entry per term: definition, boundaries, one resolved ambiguity. Agents write
 - Boundary: (is X, not Y)
 - Resolved ambiguity:
 ```
+<!-- shipyard-seed-b:en:end -->
 
-Seed B — CONTEXT.md, zh:
+zh-Hans:
 
+<!-- shipyard-seed-b:zh-Hans:start -->
 ```markdown
 ---
-language: zh-Hans
+documentLanguage: zh-Hans
 ---
 
 # 术语表
 
 一条术语一个条目：定义、边界、一个已解决的歧义。术语敲定的当下写入。词汇对所有 spec、ticket、代码命名具有法律效力。
 
-## <术语>
+## <term>
 - 定义:
 - 边界: （是 X，不是 Y）
 - 已解决的歧义:
 ```
+<!-- shipyard-seed-b:zh-Hans:end -->
+
+zh-Hant:
+
+<!-- shipyard-seed-b:zh-Hant:start -->
+```markdown
+---
+documentLanguage: zh-Hant
+---
+
+# 詞彙表
+
+每個術語一個條目：定義、邊界、一個已解決的歧義。術語確定時立即寫入。這裡的詞彙是所有 spec、ticket 與程式碼命名的準則。
+
+## <term>
+- 定義:
+- 邊界: （是 X，不是 Y）
+- 已解決的歧義:
+```
+<!-- shipyard-seed-b:zh-Hant:end -->
 
 Seed C — docs/standards/architecture.md (data.md / process.md same shape; prose renders in the document language):
 
@@ -204,7 +291,8 @@ Seed F — .omc/skills/README.md:
 # Project Skills
 
 Reusable capabilities sedimented by this project: specialized tools, prompt templates, specialized practices.
-One skill per file `.omc/skills/<name>.md`, frontmatter must contain a **literal Latin `id`** + name + description + non-empty triggers (loader validation hard requirement: missing or empty means the skill is never loaded; the production parser derives `id` from `name` only when `id` is missing — a localized `name` would strip to an empty ID, so the literal `id` is the stability guarantee). `id` is machine-semantic and never localized; `name`/`description` may follow the document language:
+One skill per file `.omc/skills/<name>.md`, frontmatter must contain a stable ASCII `id` plus name + description +
+**non-empty triggers** (loader validation hard requirement: missing or empty means the skill is never loaded):
 
 ```markdown
 ---
@@ -219,6 +307,7 @@ triggers:
 
 Follow the repository-specific release checklist and report evidence.
 ```
+The literal YAML keys `id`, `name`, `description`, and `triggers` never localize. `id` and other machine-semantic values stay ASCII and stable; the scalar display values for `name`, `description`, and `triggers`, plus Markdown headings and prose, may localize. A non-Latin display name remains loadable because the explicit ASCII `id` is stable.
 Bar for admission matches skillify: if it can be Googled in 5 minutes it is not a skill;
 write "this project's specific decision discipline", not generic tutorials.
 ````
@@ -239,9 +328,10 @@ The rule that keeps 先动手 aligned: **starting needs no permission; landing g
 ### 5. Report
 
 - created / extended / deliberately skipped (each with why)
+- resolved document language as `CONTEXT.md` frontmatter `documentLanguage: <tag>`, including whether it came from explicit choice, the persisted marker, or unanimous inference
 - the 3 surfaces that most need human content next (usually CLAUDE.md conventions, architecture.md, CONTEXT.md first terms)
 - reminder: re-run with `--check` any time to see drift between filesystem and harness
 
 ## `--check` mode
 
-Diff actual repo state against the shipyard map; report: missing surfaces, CLAUDE.md sections that point at dead paths, CONTEXT.md terms unused in code, standards never referenced. Read-only.
+Diff actual repo state against the shipyard map; report: missing surfaces, a missing or invalid `CONTEXT.md` frontmatter `documentLanguage` tag, CLAUDE.md sections that point at dead paths, CONTEXT.md terms unused in code, and standards never referenced. Read-only.

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -71,6 +71,8 @@ Synthesize `.omc/specs/<feature-slug>/spec.md`:
 
 Draft all of it, then stop at **C2**: present the acceptance criteria and the test seam list for human approval. Seams are selected by repo evidence and the deep-module discipline (public interfaces, existing test seams, depth analysis); the human confirms or corrects the list — a seam the human has not approved gets no tests.
 
+Language rule: every launch-authored artifact (spec, tickets, ADRs, CONTEXT.md entries, completion report) is written in the human's document language — the one chosen at drydock init, or the human's own language when drydock did not run. The human reads and maintains these files; agents are language-agnostic.
+
 Durability gate (agent-enforced, no approval needed): spec and tickets carry contracts, never coordinates — no file paths, no line numbers. Fragments encoding a decision better than prose (state machines, reducers, schemas) are the exception and state their origin.
 
 ## Phase 3 — Ticket decomposition (agent drafts → C3 approves)

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -39,6 +39,10 @@ Any durability claim in this skill is a claim about the files on disk, not about
 
 ## Phase 0 — Entry
 
+Before reading a supplied spec or entering Phase 1, resolve the document language. An explicit human choice in the current invocation wins; otherwise read a valid BCP-47-style tag from `CONTEXT.md` frontmatter at the exact stable key `documentLanguage`; otherwise require unanimous high-confidence inference from `CLAUDE.md` then `README.md`. A persisted bare or region-only Chinese tag is script-ambiguous and must be asked once at that authority tier, never bypassed by inference. Missing, mixed, conflicting, low-confidence, invalid-explicit, or script-ambiguous Chinese evidence requires one batched language question; do not guess. Chinese must resolve to an explicit `zh-Hans` or `zh-Hant` script tag. `zh-Hans-*` selects the Simplified companion and `zh-Hant-*` selects the Traditional companion while the full normalized tag is persisted. Persist the resolved normalized tag back to `CONTEXT.md` before any Launch-authored artifact so a fresh explicit invocation can read it without hidden conversation state. The human reads and maintains these artifacts; agents are language-agnostic.
+
+Localize prose and human-facing labels/localizable scalar values only. Paths, slash commands, flags, code fences, placeholders, frontmatter keys and machine-semantic values, YAML/JSON keys, lifecycle tokens (`plan`, `execute`, `review`, `verify`), status enums (`pending`, `in_progress`, `completed`, `failed`, `ready-for-agent`), IDs, ticket `blockedBy`, public Team `blocked_by`, and all parser/control tokens remain byte-for-byte stable. Reference language companions are mutually exclusive: emit exactly one selected rendering, never bilingual duplicate headings or labels.
+
 - Brief self-check before anything else: does the brief name an objective, a scope boundary, and non-goals? If two or more are missing, say so and ask for one sharpening pass — running the pipeline on a soft brief converts ambiguity into confident-looking output.
 - Spec path supplied → read it, jump to Phase 2.
 - Mission brief → Phase 1.
@@ -70,14 +74,6 @@ Synthesize `.omc/specs/<feature-slug>/spec.md`:
 ```
 
 Draft all of it, then stop at **C2**: present the acceptance criteria and the test seam list for human approval. Seams are selected by repo evidence and the deep-module discipline (public interfaces, existing test seams, depth analysis); the human confirms or corrects the list — a seam the human has not approved gets no tests.
-
-**Language rule — deterministic resolution + durable tag.** Every launch-authored artifact (spec, tickets, ADRs, CONTEXT.md entries, completion report) is written in the resolved document language — the human reads and maintains these files; agents are language-agnostic — resolved in this fixed order:
-
-1. **Explicit human override in the current request** — wins over everything; the durable tag is updated to match.
-2. **Durable tag** — the `language:` field in `CONTEXT.md` frontmatter: the file-backed source of truth this skill reads. A fresh launch invocation recovers the choice from it, never from hidden conversation state.
-3. **Ambiguity branch** — tag absent → ask once, write the tag into `CONTEXT.md` frontmatter, proceed. Inference is drydock's job (its Ask step); launch never re-infers.
-
-**Structural exception.** Ticket `blockedBy:` edges, status enums, ID formats (`F-NNNN`), `.omc/specs/<feature-slug>/` path shapes, frontmatter keys, slash commands, CLI flags, and code-fence delimiters are machine-semantic and remain byte-stable even when the surrounding ticket prose is localized. A translated `blockedBy` value is a contract violation.
 
 Durability gate (agent-enforced, no approval needed): spec and tickets carry contracts, never coordinates — no file paths, no line numbers. Fragments encoding a decision better than prose (state machines, reducers, schemas) are the exception and state their origin.
 

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -71,7 +71,13 @@ Synthesize `.omc/specs/<feature-slug>/spec.md`:
 
 Draft all of it, then stop at **C2**: present the acceptance criteria and the test seam list for human approval. Seams are selected by repo evidence and the deep-module discipline (public interfaces, existing test seams, depth analysis); the human confirms or corrects the list — a seam the human has not approved gets no tests.
 
-Language rule: every launch-authored artifact (spec, tickets, ADRs, CONTEXT.md entries, completion report) is written in the human's document language — the one chosen at drydock init, or the human's own language when drydock did not run. The human reads and maintains these files; agents are language-agnostic.
+**Language rule — deterministic resolution + durable tag.** Every launch-authored artifact (spec, tickets, ADRs, CONTEXT.md entries, completion report) is written in the resolved document language — the human reads and maintains these files; agents are language-agnostic — resolved in this fixed order:
+
+1. **Explicit human override in the current request** — wins over everything; the durable tag is updated to match.
+2. **Durable tag** — the `language:` field in `CONTEXT.md` frontmatter: the file-backed source of truth this skill reads. A fresh launch invocation recovers the choice from it, never from hidden conversation state.
+3. **Ambiguity branch** — tag absent → ask once, write the tag into `CONTEXT.md` frontmatter, proceed. Inference is drydock's job (its Ask step); launch never re-infers.
+
+**Structural exception.** Ticket `blockedBy:` edges, status enums, ID formats (`F-NNNN`), `.omc/specs/<feature-slug>/` path shapes, frontmatter keys, slash commands, CLI flags, and code-fence delimiters are machine-semantic and remain byte-stable even when the surrounding ticket prose is localized. A translated `blockedBy` value is a contract violation.
 
 Durability gate (agent-enforced, no approval needed): spec and tickets carry contracts, never coordinates — no file paths, no line numbers. Fragments encoding a decision better than prose (state machines, reducers, schemas) are the exception and state their origin.
 

--- a/src/__tests__/shipyard-seed-locale.test.ts
+++ b/src/__tests__/shipyard-seed-locale.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseSkillFile } from '../hooks/learner/parser.js';
+
+const ROOT = join(__dirname, '..', '..');
+const DRYDOCK = readFileSync(join(ROOT, 'skills', 'drydock', 'SKILL.md'), 'utf-8');
+
+/** Extract the first fenced ```markdown block after a marker line. */
+function fencedBlockAfter(src: string, marker: string): string {
+  const idx = src.indexOf(marker);
+  if (idx === -1) throw new Error(`marker not found: ${marker}`);
+  const start = src.indexOf('```markdown', idx);
+  if (start === -1) throw new Error(`no fenced block after marker: ${marker}`);
+  const bodyStart = start + '```markdown'.length;
+  const end = src.indexOf('\n```', bodyStart);
+  if (end === -1) throw new Error('unterminated fenced block');
+  return src.slice(bodyStart, end).trim();
+}
+
+const SEED_A_EN = fencedBlockAfter(DRYDOCK, 'Seed A — CLAUDE.md, en');
+const SEED_A_ZH = fencedBlockAfter(DRYDOCK, 'Seed A — zh companion');
+const SEED_B_EN = fencedBlockAfter(DRYDOCK, 'Seed B — CONTEXT.md, en');
+const SEED_B_ZH = fencedBlockAfter(DRYDOCK, 'Seed B — CONTEXT.md, zh');
+
+describe('shipyard seed locale contract', () => {
+  it('renders exactly one language per selected seed (companion not emitted)', () => {
+    // en block: no CJK, canonical en headings
+    expect(SEED_A_EN).toContain('## Project conventions');
+    expect(SEED_A_EN).not.toMatch(/[\u{4e00}-\u{9fff}]/u);
+    // zh block: CJK headings, no en headings
+    expect(SEED_A_ZH).toContain('## 项目约定');
+    expect(SEED_A_ZH).not.toContain('## Project conventions');
+  });
+
+  it('zh companion preserves byte-stable structural tokens', () => {
+    for (const token of [
+      'docs/standards/architecture.md',
+      'docs/adr/',
+      '/oh-my-claudecode:launch',
+      'plan → execute → review → verify',
+      'ADR-0001',
+      '.omc/skills/',
+    ]) {
+      expect(SEED_A_ZH).toContain(token);
+    }
+  });
+
+  it('durable language tag ships in the Seed B frontmatter (en and zh)', () => {
+    expect(SEED_B_EN).toContain('language: en');
+    expect(SEED_B_ZH).toContain('language: zh-Hans');
+  });
+
+  it('drydock documents the deterministic resolution order', () => {
+    for (const marker of [
+      'Explicit human override in the current request',
+      'Durable tag',
+      'Ambiguity branch',
+      'ask once',
+      'bare `zh` is not a valid tag',
+    ]) {
+      expect(DRYDOCK).toContain(marker);
+    }
+  });
+
+  it('launch reads the durable tag and never re-infers', () => {
+    const LAUNCH = readFileSync(join(ROOT, 'skills', 'launch', 'SKILL.md'), 'utf-8');
+    expect(LAUNCH).toContain('Durable tag');
+    expect(LAUNCH).toContain('never from hidden conversation state');
+    expect(LAUNCH).toContain('launch never re-infers');
+    expect(LAUNCH).toContain('agents are language-agnostic');
+  });
+
+  it('a non-Latin project-skill seed with a literal id parses with a stable id', () => {
+    const localized = [
+      '---',
+      'id: project-release-check',
+      'name: 发布就绪检查',
+      'description: Apply this repository\'s release readiness rules',
+      'triggers:',
+      '  - "project release check"',
+      '---',
+      '',
+      '# Project Release Check',
+      '',
+      'Follow the repository-specific release checklist and report evidence.',
+    ].join('\n');
+
+    const parsed = parseSkillFile(localized);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.metadata.id).toBe('project-release-check');
+    expect(parsed.metadata.name).toBe('发布就绪检查');
+  });
+
+  it('documents the hazard: a localized name without a literal id derives an empty id', () => {
+    // this is WHY Seed F mandates the literal id — the parser strips non-[a-z0-9-] from name
+    const localizedNoId = [
+      '---',
+      'name: 发布就绪检查',
+      'description: Apply this repository\'s release readiness rules',
+      'triggers:',
+      '  - "project release check"',
+      '---',
+    ].join('\n');
+
+    const parsed = parseSkillFile(localizedNoId);
+    expect(parsed.metadata.id).toBe('');
+  });
+});

--- a/src/__tests__/shipyard-seed-locale.test.ts
+++ b/src/__tests__/shipyard-seed-locale.test.ts
@@ -1,110 +1,237 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
+import { findMatchingSkills, loadAllSkills } from '../hooks/learner/loader.js';
 import { parseSkillFile } from '../hooks/learner/parser.js';
 
 const ROOT = join(__dirname, '..', '..');
 const DRYDOCK = readFileSync(join(ROOT, 'skills', 'drydock', 'SKILL.md'), 'utf-8');
+const LAUNCH = readFileSync(join(ROOT, 'skills', 'launch', 'SKILL.md'), 'utf-8');
 
-/** Extract the first fenced ```markdown block after a marker line. */
-function fencedBlockAfter(src: string, marker: string): string {
-  const idx = src.indexOf(marker);
-  if (idx === -1) throw new Error(`marker not found: ${marker}`);
-  const start = src.indexOf('```markdown', idx);
-  if (start === -1) throw new Error(`no fenced block after marker: ${marker}`);
-  const bodyStart = start + '```markdown'.length;
-  const end = src.indexOf('\n```', bodyStart);
-  if (end === -1) throw new Error('unterminated fenced block');
-  return src.slice(bodyStart, end).trim();
+interface DocumentLanguageContract {
+  authority: { path: string; frontmatterKey: string };
+  canonicalSources: string[];
+  askOn: string[];
+  tagPattern: string;
+  seedCompanionPrefixes: Record<string, 'en' | 'zh-Hans' | 'zh-Hant'>;
+  stableTokens: string[];
 }
 
-const SEED_A_EN = fencedBlockAfter(DRYDOCK, 'Seed A — CLAUDE.md, en');
-const SEED_A_ZH = fencedBlockAfter(DRYDOCK, 'Seed A — zh companion');
-const SEED_B_EN = fencedBlockAfter(DRYDOCK, 'Seed B — CONTEXT.md, en');
-const SEED_B_ZH = fencedBlockAfter(DRYDOCK, 'Seed B — CONTEXT.md, zh');
+interface LanguageEvidence {
+  tag: string;
+  confidence: 'high' | 'low';
+  mixed?: boolean;
+}
 
-describe('shipyard seed locale contract', () => {
-  it('renders exactly one language per selected seed (companion not emitted)', () => {
-    // en block: no CJK, canonical en headings
-    expect(SEED_A_EN).toContain('## Project conventions');
-    expect(SEED_A_EN).not.toMatch(/[\u{4e00}-\u{9fff}]/u);
-    // zh block: CJK headings, no en headings
-    expect(SEED_A_ZH).toContain('## 项目约定');
-    expect(SEED_A_ZH).not.toContain('## Project conventions');
+type LanguageResolution =
+  | { kind: 'resolved'; tag: string; authority: 'explicit' | 'persisted' | 'inferred' }
+  | { kind: 'ask'; reason: 'missing' | 'mixed' | 'conflict' | 'low-confidence' | 'invalid-explicit' | 'script-ambiguous' };
+
+function documentLanguageContract(): DocumentLanguageContract {
+  const block = DRYDOCK.match(/<!-- shipyard-document-language-contract:start -->\s*```json\s*([\s\S]*?)\s*```\s*<!-- shipyard-document-language-contract:end -->/)?.[1];
+  if (!block) throw new Error('missing document language contract');
+  return JSON.parse(block) as DocumentLanguageContract;
+}
+
+function normalizeLanguageTag(input: string): string | null {
+  const parts = input.trim().split('-').filter(Boolean);
+  if (parts.length === 0) return null;
+  const normalized = [parts[0].toLowerCase(), ...parts.slice(1).map((part) => {
+    if (/^[A-Za-z]{4}$/.test(part)) return `${part[0].toUpperCase()}${part.slice(1).toLowerCase()}`;
+    if (/^[A-Za-z]{2}$/.test(part)) return part.toUpperCase();
+    return part;
+  })].join('-');
+  return new RegExp(documentLanguageContract().tagPattern).test(normalized) ? normalized : null;
+}
+
+function isScriptAmbiguousChinese(input: string): boolean {
+  const parts = input.trim().split('-');
+  return parts[0]?.toLowerCase() === 'zh' && !parts.some((part) => /^(?:Hans|Hant)$/i.test(part));
+}
+
+function resolveDocumentLanguage(input: {
+  explicit?: string;
+  persisted?: string;
+  sources?: Partial<Record<string, LanguageEvidence>>;
+}): LanguageResolution {
+  const contract = documentLanguageContract();
+  if (input.explicit !== undefined) {
+    if (isScriptAmbiguousChinese(input.explicit)) return { kind: 'ask', reason: 'script-ambiguous' };
+    const tag = normalizeLanguageTag(input.explicit);
+    return tag ? { kind: 'resolved', tag, authority: 'explicit' } : { kind: 'ask', reason: 'invalid-explicit' };
+  }
+  if (input.persisted !== undefined) {
+    if (isScriptAmbiguousChinese(input.persisted)) return { kind: 'ask', reason: 'script-ambiguous' };
+    const tag = normalizeLanguageTag(input.persisted);
+    if (tag) return { kind: 'resolved', tag, authority: 'persisted' };
+  }
+  const evidence = contract.canonicalSources.map((path) => input.sources?.[path]).filter((entry): entry is LanguageEvidence => entry !== undefined);
+  if (evidence.length === 0) return { kind: 'ask', reason: 'missing' };
+  if (evidence.some((entry) => entry.mixed)) return { kind: 'ask', reason: 'mixed' };
+  if (evidence.some((entry) => entry.confidence !== 'high')) return { kind: 'ask', reason: 'low-confidence' };
+  if (evidence.some((entry) => isScriptAmbiguousChinese(entry.tag))) return { kind: 'ask', reason: 'script-ambiguous' };
+  const tags = evidence.map((entry) => normalizeLanguageTag(entry.tag));
+  if (tags.some((tag) => tag === null)) return { kind: 'ask', reason: 'low-confidence' };
+  const unique = new Set(tags as string[]);
+  return unique.size === 1
+    ? { kind: 'resolved', tag: [...unique][0], authority: 'inferred' }
+    : { kind: 'ask', reason: 'conflict' };
+}
+
+function renderSeed(seed: 'a' | 'b', tag: 'en' | 'zh-Hans' | 'zh-Hant'): string {
+  const block = DRYDOCK.match(new RegExp(
+    `<!-- shipyard-seed-${seed}:${tag}:start -->` +
+    '\\s*```markdown\\s*([\\s\\S]*?)\\s*```\\s*' +
+    `<!-- shipyard-seed-${seed}:${tag}:end -->`,
+  ))?.[1];
+  if (!block) throw new Error(`missing seed ${seed}:${tag}`);
+  return block;
+}
+
+function companionForTag(tag: string): 'en' | 'zh-Hans' | 'zh-Hant' {
+  const contract = documentLanguageContract();
+  const prefix = Object.keys(contract.seedCompanionPrefixes)
+    .sort((left, right) => right.length - left.length)
+    .find((candidate) => tag === candidate || tag.startsWith(`${candidate}-`));
+  if (!prefix) throw new Error(`no seed companion for ${tag}`);
+  return contract.seedCompanionPrefixes[prefix];
+}
+
+function renderResolvedSeed(seed: 'a' | 'b', tag: string): string {
+  const companion = companionForTag(tag);
+  const rendered = renderSeed(seed, companion);
+  return seed === 'b' ? rendered.replace(`documentLanguage: ${companion}`, `documentLanguage: ${tag}`) : rendered;
+}
+
+function projectSkillSeed(): string {
+  const block = DRYDOCK.match(/```markdown\n(---\nid: project-release-check[\s\S]*?)\n```/)?.[1];
+  if (!block) throw new Error('missing project-skill seed');
+  return block;
+}
+
+describe('shipyard document-language behavior contract', () => {
+  it('resolves explicit and persisted authority before source inference', () => {
+    expect(resolveDocumentLanguage({
+      explicit: 'ZH-hant',
+      persisted: 'en',
+      sources: { 'CLAUDE.md': { tag: 'en', confidence: 'high' } },
+    })).toEqual({ kind: 'resolved', tag: 'zh-Hant', authority: 'explicit' });
+    expect(resolveDocumentLanguage({
+      persisted: 'zh-hans',
+      sources: { 'CLAUDE.md': { tag: 'en', confidence: 'high' } },
+    })).toEqual({ kind: 'resolved', tag: 'zh-Hans', authority: 'persisted' });
+    expect(resolveDocumentLanguage({
+      persisted: 'not_a_tag',
+      sources: { 'CLAUDE.md': { tag: 'en', confidence: 'high' } },
+    })).toEqual({ kind: 'resolved', tag: 'en', authority: 'inferred' });
+    expect(resolveDocumentLanguage({
+      persisted: 'zh-CN',
+      sources: { 'CLAUDE.md': { tag: 'en', confidence: 'high' } },
+    })).toEqual({ kind: 'ask', reason: 'script-ambiguous' });
+    expect(resolveDocumentLanguage({ persisted: 'zh' })).toEqual({ kind: 'ask', reason: 'script-ambiguous' });
   });
 
-  it('zh companion preserves byte-stable structural tokens', () => {
-    for (const token of [
-      'docs/standards/architecture.md',
-      'docs/adr/',
-      '/oh-my-claudecode:launch',
-      'plan → execute → review → verify',
-      'ADR-0001',
-      '.omc/skills/',
-    ]) {
-      expect(SEED_A_ZH).toContain(token);
+  it('infers only from unanimous high-confidence canonical sources', () => {
+    const contract = documentLanguageContract();
+    expect(contract.authority).toEqual({ path: 'CONTEXT.md', frontmatterKey: 'documentLanguage' });
+    expect(contract.canonicalSources).toEqual(['CLAUDE.md', 'README.md']);
+    expect(resolveDocumentLanguage({
+      sources: {
+        'CLAUDE.md': { tag: 'en', confidence: 'high' },
+        'README.md': { tag: 'EN', confidence: 'high' },
+      },
+    })).toEqual({ kind: 'resolved', tag: 'en', authority: 'inferred' });
+    expect(resolveDocumentLanguage({
+      sources: { 'README.md': { tag: 'zh-Hans', confidence: 'high' } },
+    })).toEqual({ kind: 'resolved', tag: 'zh-Hans', authority: 'inferred' });
+  });
+
+  it.each([
+    [{}, { kind: 'ask', reason: 'missing' }],
+    [{ explicit: 'not_a_tag' }, { kind: 'ask', reason: 'invalid-explicit' }],
+    [{ explicit: 'zh' }, { kind: 'ask', reason: 'script-ambiguous' }],
+    [{ sources: { 'CLAUDE.md': { tag: 'en', confidence: 'high', mixed: true } } }, { kind: 'ask', reason: 'mixed' }],
+    [{ sources: { 'CLAUDE.md': { tag: 'fr', confidence: 'low' } } }, { kind: 'ask', reason: 'low-confidence' }],
+    [{ sources: { 'CLAUDE.md': { tag: 'zh-CN', confidence: 'high' } } }, { kind: 'ask', reason: 'script-ambiguous' }],
+    [{ sources: { 'CLAUDE.md': { tag: 'en', confidence: 'high' }, 'README.md': { tag: 'zh-Hans', confidence: 'high' } } }, { kind: 'ask', reason: 'conflict' }],
+    [{ sources: { 'CLAUDE.md': { tag: 'zh-Hans', confidence: 'high' }, 'README.md': { tag: 'zh-Hant', confidence: 'high' } } }, { kind: 'ask', reason: 'conflict' }],
+  ] as const)('asks once instead of guessing from ambiguous evidence %#', (input, expected) => {
+    expect(resolveDocumentLanguage(input)).toEqual(expected);
+  });
+
+  it('renders exactly one companion while preserving byte-stable tokens', () => {
+    const rendered = { en: renderSeed('a', 'en'), 'zh-Hans': renderSeed('a', 'zh-Hans'), 'zh-Hant': renderSeed('a', 'zh-Hant') };
+    const headings = { en: '## Project conventions', 'zh-Hans': '## 项目约定', 'zh-Hant': '## 專案約定' };
+    for (const [tag, output] of Object.entries(rendered)) {
+      expect(output).toContain(headings[tag as keyof typeof headings]);
+      for (const [otherTag, otherHeading] of Object.entries(headings)) {
+        if (otherTag !== tag) expect(output).not.toContain(otherHeading);
+      }
+      expect(output).toContain('# <Project> — Agent & Human Shipyard');
+      expect(output).toContain('/oh-my-claudecode:launch');
+      expect(output).toContain('plan → execute → review → verify');
+      expect(output).toContain('CONTEXT.md');
+      expect(renderSeed('b', tag as keyof typeof rendered)).toContain(`documentLanguage: ${tag}`);
+      expect(renderSeed('b', tag as keyof typeof rendered)).toContain('## <term>');
     }
   });
 
-  it('durable language tag ships in the Seed B frontmatter (en and zh)', () => {
-    expect(SEED_B_EN).toContain('language: en');
-    expect(SEED_B_ZH).toContain('language: zh-Hans');
+  it('maps region-qualified Chinese tags to one script companion and preserves the full tag', () => {
+    expect(resolveDocumentLanguage({ explicit: 'zh-hans-cn' })).toEqual({
+      kind: 'resolved', tag: 'zh-Hans-CN', authority: 'explicit',
+    });
+    expect(resolveDocumentLanguage({ explicit: 'zh-hant-tw' })).toEqual({
+      kind: 'resolved', tag: 'zh-Hant-TW', authority: 'explicit',
+    });
+    expect(renderResolvedSeed('a', 'zh-Hans-CN')).toContain('## 项目约定');
+    expect(renderResolvedSeed('a', 'zh-Hans-CN')).not.toContain('## 專案約定');
+    expect(renderResolvedSeed('a', 'zh-Hant-TW')).toContain('## 專案約定');
+    expect(renderResolvedSeed('a', 'zh-Hant-TW')).not.toContain('## 项目约定');
+    expect(renderResolvedSeed('b', 'zh-Hans-CN')).toContain('documentLanguage: zh-Hans-CN');
+    expect(renderResolvedSeed('b', 'zh-Hant-TW')).toContain('documentLanguage: zh-Hant-TW');
   });
 
-  it('drydock documents the deterministic resolution order', () => {
-    for (const marker of [
-      'Explicit human override in the current request',
-      'Durable tag',
-      'Ambiguity branch',
-      'ask once',
-      'bare `zh` is not a valid tag',
-    ]) {
-      expect(DRYDOCK).toContain(marker);
+  it('keeps Launch stateless and resolves language before any authoring phase', () => {
+    const contract = documentLanguageContract();
+    expect(contract.askOn).toEqual(expect.arrayContaining(['invalid-explicit', 'script-ambiguous']));
+    expect(LAUNCH.indexOf('Before reading a supplied spec')).toBeLessThan(LAUNCH.indexOf('## Phase 1'));
+    expect(LAUNCH).toContain('without hidden conversation state');
+    expect(LAUNCH).toContain(`\`${contract.authority.path}\` frontmatter`);
+    expect(LAUNCH).toContain(`\`${contract.authority.frontmatterKey}\``);
+    for (const token of ['blockedBy', 'blocked_by', 'plan', 'execute', 'review', 'verify', 'ready-for-agent']) {
+      expect(contract.stableTokens).toContain(token);
+      expect(LAUNCH).toContain(token);
     }
   });
 
-  it('launch reads the durable tag and never re-infers', () => {
-    const LAUNCH = readFileSync(join(ROOT, 'skills', 'launch', 'SKILL.md'), 'utf-8');
-    expect(LAUNCH).toContain('Durable tag');
-    expect(LAUNCH).toContain('never from hidden conversation state');
-    expect(LAUNCH).toContain('launch never re-infers');
-    expect(LAUNCH).toContain('agents are language-agnostic');
-  });
+  it('loads and matches a CRLF non-Latin project skill by stable ASCII id', () => {
+    const localized = projectSkillSeed()
+      .replace('name: project-release-check', 'name: 项目发布检查')
+      .replace("description: Apply this repository's release readiness rules", 'description: 应用本仓库的发布就绪规则')
+      .replace('  - "project release check"', '  - "项目发布检查"')
+      .replace(/\n/g, '\r\n');
+    expect(localized).toContain('id: project-release-check');
+    expect(localized).toContain('name: 项目发布检查');
+    expect(localized).toContain('description: 应用本仓库的发布就绪规则');
+    expect(localized).toContain('triggers:\r\n');
+    expect(parseSkillFile(localized).metadata).toMatchObject({
+      id: 'project-release-check',
+      name: '项目发布检查',
+      triggers: ['项目发布检查'],
+    });
 
-  it('a non-Latin project-skill seed with a literal id parses with a stable id', () => {
-    const localized = [
-      '---',
-      'id: project-release-check',
-      'name: 发布就绪检查',
-      'description: Apply this repository\'s release readiness rules',
-      'triggers:',
-      '  - "project release check"',
-      '---',
-      '',
-      '# Project Release Check',
-      '',
-      'Follow the repository-specific release checklist and report evidence.',
-    ].join('\n');
-
-    const parsed = parseSkillFile(localized);
-    expect(parsed.valid).toBe(true);
-    expect(parsed.errors).toEqual([]);
-    expect(parsed.metadata.id).toBe('project-release-check');
-    expect(parsed.metadata.name).toBe('发布就绪检查');
-  });
-
-  it('documents the hazard: a localized name without a literal id derives an empty id', () => {
-    // this is WHY Seed F mandates the literal id — the parser strips non-[a-z0-9-] from name
-    const localizedNoId = [
-      '---',
-      'name: 发布就绪检查',
-      'description: Apply this repository\'s release readiness rules',
-      'triggers:',
-      '  - "project release check"',
-      '---',
-    ].join('\n');
-
-    const parsed = parseSkillFile(localizedNoId);
-    expect(parsed.metadata.id).toBe('');
+    const projectRoot = mkdtempSync(join(tmpdir(), 'omc-drydock-localized-seed-'));
+    try {
+      const skillsDir = join(projectRoot, '.omc', 'skills');
+      mkdirSync(skillsDir, { recursive: true });
+      writeFileSync(join(skillsDir, 'project-release-check.md'), localized, 'utf8');
+      const loaded = loadAllSkills(projectRoot).find((skill) => skill.metadata.id === 'project-release-check');
+      expect(loaded?.metadata.name).toBe('项目发布检查');
+      expect(loaded?.metadata.triggers).toEqual(['项目发布检查']);
+      expect(findMatchingSkills('请执行项目发布检查', projectRoot).map((skill) => skill.metadata.id)).toContain('project-release-check');
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/shipyard-skills.test.ts
+++ b/src/__tests__/shipyard-skills.test.ts
@@ -242,6 +242,22 @@ describe('shipyard skills — behavior & packaging contract', () => {
     }
   });
 
+  it('drydock makes the document language a first-class decision with en + zh seed companions', () => {
+    // user-language principle: generated harness files follow the human's language
+    expect(DRYDOCK).toMatch(/document language for the generated harness files/);
+    expect(DRYDOCK).toMatch(/structural keys stay language-stable/);
+    // both language companions present for the load-bearing seeds
+    expect(DRYDOCK).toContain('## Project conventions');
+    expect(DRYDOCK).toContain('## 项目约定');
+    expect(DRYDOCK).toContain('- Definition:');
+    expect(DRYDOCK).toContain('- 定义:');
+  });
+
+  it('launch states the user-language rule for authored artifacts', () => {
+    expect(LAUNCH).toMatch(/document language/);
+    expect(LAUNCH).toMatch(/agents are language-agnostic/);
+  });
+
   it('plugin.json ships both skills and every path exists on disk', () => {
     for (const name of ['launch', 'drydock']) {
       const entry = `./skills/${name}/`;

--- a/src/__tests__/shipyard-skills.test.ts
+++ b/src/__tests__/shipyard-skills.test.ts
@@ -217,7 +217,7 @@ describe('shipyard skills — behavior & packaging contract', () => {
   });
 
   it('drydock seed requires non-empty triggers so generated project skills are loadable', () => {
-    const example = DRYDOCK.match(/```markdown\n(---\nname: project-release-check[\s\S]*?)\n```/)?.[1];
+    const example = DRYDOCK.match(/```markdown\n(---\nid: project-release-check\nname: project-release-check[\s\S]*?)\n```/)?.[1];
     expect(example).toBeDefined();
 
     const parsed = parseSkillFile(example!);


### PR DESCRIPTION
## Summary

Implements the **user-language principle** in drydock/launch: generated harness artifacts follow the human's language; structural keys stay language-stable.

- **drydock** gains a first-class **document-language decision** in its Ask step (ask once, or infer from the target repo's existing CLAUDE.md/README; recorded in the init report). Prose and field labels render in that language; structural keys stay stable (file paths, frontmatter keys, `blockedBy:`, status enums, ID formats).
- **Seeds restructured bilingual**: English canonical exemplars + zh companions for the load-bearing parts (Seed A headings `## Project conventions`/`## 项目约定`, Seed B labels `- Definition:`/`- 定义:`). Seeds C-F render English-canonical prose with the document-language rule attached.
- **launch** states the artifact-language rule explicitly: spec, tickets, ADRs, CONTEXT.md entries, and the completion report are written in the human's document language — "agents are language-agnostic."

Rationale: the merged drydock seeds are hardcoded Chinese — international users scaffolding a repo got Chinese skeletons (and a Chinese-language user got none of the fidelity). Tool docs (SKILL.md, docs/) stay English for the international project; **generated user artifacts follow the user**. This PR separates the two cleanly.

## What changed

- `skills/drydock/SKILL.md` — language decision in Ask; Seed A en+zh companions; Seed B en+zh labels; Seeds C/D/E/F English-canonical with language note
- `skills/launch/SKILL.md` — Language rule line in Phase 2
- `src/__tests__/shipyard-skills.test.ts` — locale contract tests (en+zh companions present, structural-keys-stable wording, launch user-language rule)
- `inventory/inventory-graph.json` — refreshed (content hashes)

## Verification

- [x] `npx vitest run` targeted (shipyard-skills behavior suite / skills / alias-retirement / workflow registry / projections / **inventory-graph drift**) — **101 passed / 0 failed**
- [x] `npx tsc --noEmit` — clean
- [x] Structural keys unchanged: paths, frontmatter keys, `blockedBy`, enums, ID formats — verified by the untouched engine/CLI suites
- [x] No committed build artifacts; ssot fresh; entitlements current

## Notes for reviewers

- Resolves the hardcoded-seed-language gap in #3907's drydock (kept zh fidelity for zh users, adds en canonical for everyone else — both documented in-skill so agents render either without guessing).
- No gate, status, or lifecycle semantics touched; the change is generation-language semantics only.
- One commit off current `dev` (`71889ff59`): 4 files, +87/−23.
