### PR TITLE
ci: bind final verified v5.1.0 release head

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -13521,7 +13521,7 @@
       "pullNumber": 3912,
       "targetRef": "main",
       "mergeBaseSha": "adf4bf3280c8a8d7b932d5c11aef84ba22d6a11d",
-      "headSha": "826f47d95857d9345b1bf4418000d24d24e931a2",
+      "headSha": "4d637ae4dbe57841dba27c3308afa8bd1cf4657c",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-09-29T00:00:00.000Z",
       "generatedDelta": {

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "73643cfa63fdfea468b71ded0a5a63191bffa45c",
+    "head": "05b7682e0d946409859cb2fd375148fa879674c1",
     "sourceSha256": "0567a540fe1eb951722f0d28251b4f8aee456aca107b3f85828c68f8db4c5672",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "73643cfa63fdfea468b71ded0a5a63191bffa45c",
+  "head": "05b7682e0d946409859cb2fd375148fa879674c1",
   "sourceSha256": "0567a540fe1eb951722f0d28251b4f8aee456aca107b3f85828c68f8db4c5672",
   "counts": {
     "public": {
@@ -76550,5 +76550,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "ee922f54ed82d2bc0b59e4f744f2cdb9894247977e50b722c587cfe103ea7df4"
+  "manifestSha256": "ddea8570e0b08483ac3024e3a2a5619336e914ec5a754ad7bc64bb7113f250f8"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "05b7682e0d946409859cb2fd375148fa879674c1",
+    "head": "f34b8a90dcd81e5ff922cd729b87f3f9f96dada7",
     "sourceSha256": "0567a540fe1eb951722f0d28251b4f8aee456aca107b3f85828c68f8db4c5672",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "05b7682e0d946409859cb2fd375148fa879674c1",
+  "head": "f34b8a90dcd81e5ff922cd729b87f3f9f96dada7",
   "sourceSha256": "0567a540fe1eb951722f0d28251b4f8aee456aca107b3f85828c68f8db4c5672",
   "counts": {
     "public": {
@@ -76550,5 +76550,5 @@
     }
   },
   "inventorySha256": "105c63a2ed379d8c3bf6b66c30853f3dce437799afe24b2c22ca6a8d79503eb8",
-  "manifestSha256": "ddea8570e0b08483ac3024e3a2a5619336e914ec5a754ad7bc64bb7113f250f8"
+  "manifestSha256": "ef6559386eae26c9573ae8e753485cce701fa6365f082978b5e354bf58ae03b9"
 }


### PR DESCRIPTION
## Final exact authorization binding

Updates the existing base-owned PR #3912 tuple to the final protected-owner verified head:

- Head: `4d637ae4dbe57841dba27c3308afa8bd1cf4657c`
- GitHub REST verification: valid
- REST author: `Yeachan-Heo`
- GraphQL signature: valid, signer `web-flow`
- Target: `main`
- Compare merge base: `adf4bf3280c8a8d7b932d5c11aef84ba22d6a11d`
- Generated closure: 36 files
- Generated SHA-256: `070939e1e5594fb2594c6b2f35bc051afa93c654230784d511869d58c068de93`

No product, generated, package, tag, or release transaction bytes change here. `validateAuthorizationManifest` passes.

Owner authorization: Discord message `1543595574031290370` for the bounded v5.1.0 release transaction.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
