### PR TITLE
ci: bind terminal v5.1.0 release manifest

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -13520,8 +13520,8 @@
     {
       "pullNumber": 3912,
       "targetRef": "main",
-      "mergeBaseSha": "5efd21e099e9e71c6c942dcffb167af31ceaa09c",
-      "headSha": "8a3eef3730cb87b2d882c9d30c63ccca1c6746c9",
+      "mergeBaseSha": "8b6b9f23c1b53785a53ca156f6cc9c264a952306",
+      "headSha": "a7713974f56bdce63043afe1d3707626a54861df",
       "owner": "Yeachan-Heo",
       "expiresAt": "2026-09-29T00:00:00.000Z",
       "generatedDelta": {


### PR DESCRIPTION
## Terminal exact-head manifest update

Updates only the protected base-owned authorization tuple for release PR #3912:

- Exact reviewed head: `a7713974f56bdce63043afe1d3707626a54861df`
- GitHub signature: valid; author `Yeachan-Heo`; signer `web-flow`
- Merge base: `8b6b9f23c1b53785a53ca156f6cc9c264a952306`
- Generated closure: 36 files
- Generated SHA-256: `88e136fe03b321475946776b4e386429eca26d3c6158e67d9511383d849d88dd`

The tuple comes from the live fully enumerated PR file list and passes `validateAuthorizationManifest`. No product, generated, inventory, package, tag, release-body, or publication bytes change.

Owner authorization: Discord message `1543595574031290370`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
