### PR TITLE
fix(notepad-wisdom): preserve dynamic regex escapes

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "f0e392936fc8ed951ddee33397b0696a26c17a57",
-    "sourceSha256": "7c7a16173ac5ef57ff0e60a174a3979c3cdaf85f495626e9d9360fa88880630a",
+    "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
+    "sourceSha256": "3cc0255d4da27ec6e3c84e8af7ee732ec5ba66ac97fda0c258b9b79071df396e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "f0e392936fc8ed951ddee33397b0696a26c17a57",
-  "sourceSha256": "7c7a16173ac5ef57ff0e60a174a3979c3cdaf85f495626e9d9360fa88880630a",
+  "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
+  "sourceSha256": "3cc0255d4da27ec6e3c84e8af7ee732ec5ba66ac97fda0c258b9b79071df396e",
   "counts": {
     "public": {
       "skills": 35,
@@ -24,12 +24,12 @@
     },
     "internal": {
       "hookFiles": 295,
-      "featureFiles": 68,
+      "featureFiles": 69,
       "toolFiles": 60,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1315,
-      "total": 1336
+      "srcFiles": 1316,
+      "total": 1337
     },
     "generated": {
       "distFiles": 4955,
@@ -486,6 +486,7 @@
       "src/features/model-routing/scorer.ts",
       "src/features/model-routing/signals.ts",
       "src/features/model-routing/types.ts",
+      "src/features/notepad-wisdom/__tests__/extractor.test.ts",
       "src/features/notepad-wisdom/extractor.ts",
       "src/features/notepad-wisdom/index.ts",
       "src/features/notepad-wisdom/types.ts",
@@ -6192,6 +6193,7 @@
       "src/features/model-routing/scorer.ts",
       "src/features/model-routing/signals.ts",
       "src/features/model-routing/types.ts",
+      "src/features/notepad-wisdom/__tests__/extractor.test.ts",
       "src/features/notepad-wisdom/extractor.ts",
       "src/features/notepad-wisdom/index.ts",
       "src/features/notepad-wisdom/types.ts",
@@ -35830,6 +35832,11 @@
         "path": "src/features/model-routing/types.ts"
       },
       {
+        "id": "src/features/notepad-wisdom/__tests__/extractor.test.ts",
+        "kind": "feature",
+        "path": "src/features/notepad-wisdom/__tests__/extractor.test.ts"
+      },
+      {
         "id": "src/features/notepad-wisdom/extractor.ts",
         "kind": "feature",
         "path": "src/features/notepad-wisdom/extractor.ts"
@@ -52805,6 +52812,16 @@
         "from": "src/features/model-routing/types.ts",
         "to": "src/shared/types.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/features/notepad-wisdom/__tests__/extractor.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/notepad-wisdom/__tests__/extractor.test.ts",
+        "to": "src/features/notepad-wisdom/extractor.ts",
+        "kind": "imports"
       },
       {
         "from": "src/features/notepad-wisdom/extractor.ts",
@@ -76693,12 +76710,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6845,
-      "edgeCount": 7237,
-      "importEdgeCount": 5947,
+      "nodeCount": 6846,
+      "edgeCount": 7239,
+      "importEdgeCount": 5949,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "bacabd73c39af38db89572e46515777aa7e76feff7c30ba4604cc3de0f3dbfdd",
-  "manifestSha256": "b0b51be657b65ff684f73fcb7a7548260f7a8b339367c931e75cea2bc51652aa"
+  "inventorySha256": "8918d7975f1f220b0423a1191a32350db3a1f8565c3edf57c9d16bcbf438faca",
+  "manifestSha256": "11ee547966b94e3ba99cb517d869547e561371a1dc7e3d11192242dc55981bd2"
 }

--- a/src/features/notepad-wisdom/__tests__/extractor.test.ts
+++ b/src/features/notepad-wisdom/__tests__/extractor.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { extractWisdomFromCompletion } from "../extractor.js";
+
+describe("extractWisdomFromCompletion", () => {
+  it("round-trips multi-line content from singular wisdom tags", () => {
+    const response = "<learning>line one\nline two</learning>";
+
+    expect(extractWisdomFromCompletion(response)).toEqual([
+      { category: "learnings", content: "line one\nline two" },
+    ]);
+  });
+
+  it("captures singular-tag content containing characters beyond s and S", () => {
+    const response = "<decision>adopt the stable parser</decision>";
+
+    expect(extractWisdomFromCompletion(response)).toEqual([
+      { category: "decisions", content: "adopt the stable parser" },
+    ]);
+  });
+});

--- a/src/features/notepad-wisdom/extractor.ts
+++ b/src/features/notepad-wisdom/extractor.ts
@@ -47,7 +47,7 @@ export function extractWisdomFromCompletion(response: string): ExtractedWisdom[]
   };
 
   for (const [singular, category] of Object.entries(singularMap)) {
-    const tagRegex = new RegExp(`<${singular}>([\s\S]*?)<\/${singular}>`, 'gi');
+    const tagRegex = new RegExp(String.raw`<${singular}>([\s\S]*?)</${singular}>`, 'gi');
 
     while ((match = tagRegex.exec(response)) !== null) {
       const content = match[1].trim();


### PR DESCRIPTION
## Summary
- build singular wisdom-tag regexes with `String.raw` so `\s\S` reaches `RegExp` unchanged
- add focused regression coverage for multi-line capture and non-`s`/`S` content
- regenerate the canonical inventory graph for the new test surface

## Independent verification
- reproduced exact-base compilation as `<learning>([sS]*?)<\\/learning>` with multi-line capture returning `null` and `sSs` still matching
- AST-audited 41 direct `new RegExp(\`...\`)` call sites under `src` on the exact base; this was the only single-backslash regex escape defect
- after the fix, 40 direct template call sites remain and zero have the same suspect escape form; the corrected call uses `String.raw`

## Local checks
- `npx vitest run src/features/notepad-wisdom/__tests__/extractor.test.ts` — 2 passed
- `npx eslint src/features/notepad-wisdom/extractor.ts src/features/notepad-wisdom/__tests__/extractor.test.ts` — passed
- `npx tsc --noEmit` — passed
- `npm run generate:inventory:verify` — passed
- repository-wide `npm run lint` — 0 errors, 28 pre-existing warnings

Closes #3926

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*