### PR TITLE
perf(hooks): reduce per-tool-call state and process cost

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -128,6 +128,7 @@ Fires immediately before Claude uses a tool.
 
 Runs on all tool calls (`matcher: "*"`). Enforces agent permission restrictions (e.g., blocking Write/Edit for read-only agents).
 Denies Task/Agent calls whose `subagent_type` names a bundled skill (issue #3667): instead of Claude Code's generic native "Agent type not found", the hook returns a precise error naming the Skill tool and the correct identifier, and forbids closest-match agent substitution.
+The exact canonical shipped script runs in the trusted Worker path; untrusted paths, event mismatches, and extra arguments retain the isolated child-process fallback.
 
 ### PermissionRequest
 
@@ -147,8 +148,10 @@ Fires after a tool use completes.
 |--------|------|---------|
 | `post-tool-verifier.mjs` | Verifies tool results and injects additional context | 5s |
 | `project-memory-posttool.mjs` | Updates project memory | 3s |
+| `post-tool-rules-injector.mjs` | Injects matching project rules | 3s |
 
 Injects additional guidance based on Read, Write, Edit, and Bash results. For example, after reading a file it may hint "consider using parallel reads."
+These exact canonical shipped scripts use the trusted Worker path without changing their manifest timeout budgets. The verifier retains statistics for the current session and the 99 most recently updated historical sessions so per-tool writes stay bounded. Disable all three with `DISABLE_OMC=1` (or `DISABLE_OMC=true`) or `OMC_SKIP_HOOKS=post-tool-use`; `project-memory-posttool` also accepts its script-specific token.
 
 ### PostToolUseFailure
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -981,9 +981,9 @@ OMC registers 21 hook scripts across 11 Claude Code lifecycle events. For detail
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | **UserPromptSubmit**   | `keyword-detector.mjs`, `skill-injector.mjs`                                                                      | 30s outer fuse per command; 8s, 12s trusted Worker limits |
 | **SessionStart**       | `session-start.mjs`, `project-memory-session.mjs`, `setup-init.mjs` (init), `setup-maintenance.mjs` (maintenance) | 5s, 5s, 30s, 60s |
-| **PreToolUse**         | `pre-tool-enforcer.mjs`                                                                                           | 5s               |
+| **PreToolUse**         | `pre-tool-enforcer.mjs`                                                                                           | 5s trusted Worker |
 | **PermissionRequest**  | `permission-handler.mjs` (Bash only)                                                                              | 5s               |
-| **PostToolUse**        | `post-tool-verifier.mjs`, `project-memory-posttool.mjs`                                                           | 5s, 3s           |
+| **PostToolUse**        | `post-tool-verifier.mjs`, `project-memory-posttool.mjs`, `post-tool-rules-injector.mjs`                          | 5s, 3s, 3s trusted Workers |
 | **PostToolUseFailure** | `post-tool-use-failure.mjs`                                                                                       | 3s               |
 | **SubagentStart**      | `subagent-tracker.mjs start`                                                                                      | 3s               |
 | **SubagentStop**       | `subagent-tracker.mjs stop`, `verify-deliverables.mjs`                                                            | 5s, 5s           |
@@ -991,7 +991,7 @@ OMC registers 21 hook scripts across 11 Claude Code lifecycle events. For detail
 | **Stop**               | `context-guard-stop.mjs`, `workflow-drift-guard.mjs`, `persistent-mode.mjs`, `code-simplifier.mjs`                | 5s, 3s, 10s, 5s  |
 | **SessionEnd**         | `session-end.mjs`                                                                                                 | 30s              |
 
-For each UserPromptSubmit command, 30s is the outer host fuse, including any launcher delay before `run.cjs`. Only exact canonical targets in the trusted Worker branch receive the 8s keyword-detector or 12s skill-injector execution caps; generic, untrusted, and non-prompt child paths retain their existing timeout behavior. A command that never starts the runner can take the entire 30s per-command fuse, and host scheduling does not imply an aggregate latency.
+For each UserPromptSubmit command, 30s is the outer host fuse, including any launcher delay before `run.cjs`. Exact canonical targets use the trusted Worker branch only when their manifest event matches: the prompt hooks receive the 8s keyword-detector or 12s skill-injector execution caps, while the PreToolUse and PostToolUse hooks retain their manifest-derived inner budgets. Generic targets, untrusted paths, event mismatches, and invocations with extra arguments retain the isolated child-process path. A command that never starts the runner can take the entire 30s per-command fuse, and host scheduling does not imply an aggregate latency.
 
 The `workflow-drift-guard` blocks only supported source-associated local selection forks with a known minimum of two live alternatives—including exact binary questions and cardinality templates; explicit open input and every unsupported or ambiguous form fail open.
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "1b4fbd99fccd0332cd84db5b6231b26abed728b6",
-    "sourceSha256": "eaa8cf97e1e2a50f95ea17af6df92d78d585d31af11d354f48e859b15032e045",
+    "head": "41d1d38b3cb69d2a6f9460961fc1ff09c0e5bbf6",
+    "sourceSha256": "ed9dcbf0d058971bd1bbd14031c9d07ab6bc84d5723fad93dc8f4a8af3141499",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "1b4fbd99fccd0332cd84db5b6231b26abed728b6",
-  "sourceSha256": "eaa8cf97e1e2a50f95ea17af6df92d78d585d31af11d354f48e859b15032e045",
+  "head": "41d1d38b3cb69d2a6f9460961fc1ff09c0e5bbf6",
+  "sourceSha256": "ed9dcbf0d058971bd1bbd14031c9d07ab6bc84d5723fad93dc8f4a8af3141499",
   "counts": {
     "public": {
       "skills": 35,
@@ -76730,5 +76730,5 @@
     }
   },
   "inventorySha256": "5d85688387023c6ef6a52352cc780af75dd1f53e9549472fba7a37a6cd8ceb42",
-  "manifestSha256": "d310f9fc07654a41febe9da74c629fd9704dc0d669218aa51395d4d7f2d76836"
+  "manifestSha256": "5b2865d660f86fe360a9c10a3ba215e51a98a813133b5555ee15f48bf169a2ee"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "f0e392936fc8ed951ddee33397b0696a26c17a57",
-    "sourceSha256": "7c7a16173ac5ef57ff0e60a174a3979c3cdaf85f495626e9d9360fa88880630a",
+    "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
+    "sourceSha256": "90cad26b4b0d1ecfdc26c1366964c403916156f785aee719fa76c6409f311804",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "f0e392936fc8ed951ddee33397b0696a26c17a57",
-  "sourceSha256": "7c7a16173ac5ef57ff0e60a174a3979c3cdaf85f495626e9d9360fa88880630a",
+  "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
+  "sourceSha256": "90cad26b4b0d1ecfdc26c1366964c403916156f785aee719fa76c6409f311804",
   "counts": {
     "public": {
       "skills": 35,
@@ -76700,5 +76700,5 @@
     }
   },
   "inventorySha256": "bacabd73c39af38db89572e46515777aa7e76feff7c30ba4604cc3de0f3dbfdd",
-  "manifestSha256": "b0b51be657b65ff684f73fcb7a7548260f7a8b339367c931e75cea2bc51652aa"
+  "manifestSha256": "757ad1acb555ec8e265c4aa59bc81dfe12f844ab8a6180c467eedb8c3946ddf9"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "41d1d38b3cb69d2a6f9460961fc1ff09c0e5bbf6",
-    "sourceSha256": "ed9dcbf0d058971bd1bbd14031c9d07ab6bc84d5723fad93dc8f4a8af3141499",
+    "head": "afcdba5fc99a2f4fc77180a092a5419ab1b0b61a",
+    "sourceSha256": "fd659aab9e05e4aaae57e487905d9008193c362c3d7f8d840791815d43642637",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "41d1d38b3cb69d2a6f9460961fc1ff09c0e5bbf6",
-  "sourceSha256": "ed9dcbf0d058971bd1bbd14031c9d07ab6bc84d5723fad93dc8f4a8af3141499",
+  "head": "afcdba5fc99a2f4fc77180a092a5419ab1b0b61a",
+  "sourceSha256": "fd659aab9e05e4aaae57e487905d9008193c362c3d7f8d840791815d43642637",
   "counts": {
     "public": {
       "skills": 35,
@@ -76730,5 +76730,5 @@
     }
   },
   "inventorySha256": "5d85688387023c6ef6a52352cc780af75dd1f53e9549472fba7a37a6cd8ceb42",
-  "manifestSha256": "5b2865d660f86fe360a9c10a3ba215e51a98a813133b5555ee15f48bf169a2ee"
+  "manifestSha256": "921150bb7421644ebea00f30cc561cfdcc86ffd2fcb3285a6745dbed36f75fab"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
-    "sourceSha256": "90cad26b4b0d1ecfdc26c1366964c403916156f785aee719fa76c6409f311804",
+    "head": "1b4fbd99fccd0332cd84db5b6231b26abed728b6",
+    "sourceSha256": "eaa8cf97e1e2a50f95ea17af6df92d78d585d31af11d354f48e859b15032e045",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
-  "sourceSha256": "90cad26b4b0d1ecfdc26c1366964c403916156f785aee719fa76c6409f311804",
+  "head": "1b4fbd99fccd0332cd84db5b6231b26abed728b6",
+  "sourceSha256": "eaa8cf97e1e2a50f95ea17af6df92d78d585d31af11d354f48e859b15032e045",
   "counts": {
     "public": {
       "skills": 35,
@@ -28,8 +28,8 @@
       "toolFiles": 60,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1315,
-      "total": 1336
+      "srcFiles": 1316,
+      "total": 1337
     },
     "generated": {
       "distFiles": 4955,
@@ -34505,6 +34505,11 @@
         "path": "src/__tests__/project-memory-merge.test.ts"
       },
       {
+        "id": "src/__tests__/project-memory-posttool.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/project-memory-posttool.test.ts"
+      },
+      {
         "id": "src/__tests__/project-session-manager-review-worktree.test.ts",
         "kind": "src",
         "path": "src/__tests__/project-session-manager-review-worktree.test.ts"
@@ -46749,6 +46754,31 @@
       {
         "from": "src/__tests__/project-memory-merge.test.ts",
         "to": "src/lib/project-memory-merge.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:vitest",
         "kind": "imports"
       },
       {
@@ -76693,12 +76723,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6845,
-      "edgeCount": 7237,
-      "importEdgeCount": 5947,
+      "nodeCount": 6846,
+      "edgeCount": 7242,
+      "importEdgeCount": 5952,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "bacabd73c39af38db89572e46515777aa7e76feff7c30ba4604cc3de0f3dbfdd",
-  "manifestSha256": "757ad1acb555ec8e265c4aa59bc81dfe12f844ab8a6180c467eedb8c3946ddf9"
+  "inventorySha256": "5d85688387023c6ef6a52352cc780af75dd1f53e9549472fba7a37a6cd8ceb42",
+  "manifestSha256": "d310f9fc07654a41febe9da74c629fd9704dc0d669218aa51395d4d7f2d76836"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
-    "sourceSha256": "3cc0255d4da27ec6e3c84e8af7ee732ec5ba66ac97fda0c258b9b79071df396e",
+    "head": "ebca8465feb6ab22674900b14827eb83ddebc8e5",
+    "sourceSha256": "a10cd89145912171fd1391b28af8a572d29dfabf134bf388a89d15f023da3755",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "369caf12f29ce9f15a5fcb77d32a8cdfa53f980d",
-  "sourceSha256": "3cc0255d4da27ec6e3c84e8af7ee732ec5ba66ac97fda0c258b9b79071df396e",
+  "head": "ebca8465feb6ab22674900b14827eb83ddebc8e5",
+  "sourceSha256": "a10cd89145912171fd1391b28af8a572d29dfabf134bf388a89d15f023da3755",
   "counts": {
     "public": {
       "skills": 35,
@@ -28,8 +28,8 @@
       "toolFiles": 60,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1316,
-      "total": 1337
+      "srcFiles": 1317,
+      "total": 1338
     },
     "generated": {
       "distFiles": 4955,
@@ -34507,6 +34507,11 @@
         "path": "src/__tests__/project-memory-merge.test.ts"
       },
       {
+        "id": "src/__tests__/project-memory-posttool.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/project-memory-posttool.test.ts"
+      },
+      {
         "id": "src/__tests__/project-session-manager-review-worktree.test.ts",
         "kind": "src",
         "path": "src/__tests__/project-session-manager-review-worktree.test.ts"
@@ -46756,6 +46761,31 @@
       {
         "from": "src/__tests__/project-memory-merge.test.ts",
         "to": "src/lib/project-memory-merge.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/project-memory-posttool.test.ts",
+        "to": "external:vitest",
         "kind": "imports"
       },
       {
@@ -76710,12 +76740,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6846,
-      "edgeCount": 7239,
-      "importEdgeCount": 5949,
+      "nodeCount": 6847,
+      "edgeCount": 7244,
+      "importEdgeCount": 5954,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "8918d7975f1f220b0423a1191a32350db3a1f8565c3edf57c9d16bcbf438faca",
-  "manifestSha256": "11ee547966b94e3ba99cb517d869547e561371a1dc7e3d11192242dc55981bd2"
+  "inventorySha256": "4283f8f695d63821b3b3d94c9f54a71dd69a336e3944c8816a8c3a2f000e33ec",
+  "manifestSha256": "4d05086f86c8ec86bffe2aa8aea2394fd755a91db19f3b98598ec952abd8ab8b"
 }

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -132,6 +132,7 @@ const debugLog = (...args) => {
 // State file for session tracking
 const cfgDir = getClaudeConfigDir();
 const STATE_FILE = join(cfgDir, '.session-stats.json');
+const MAX_SESSION_STATS = 100;
 
 // Ensure state directory exists
 try {
@@ -183,6 +184,17 @@ function updateStats(toolName, sessionId) {
   session.last_tool = toolName;
   session.total_calls = (session.total_calls || 0) + 1;
   session.updated_at = Math.floor(Date.now() / 1000);
+
+  const sessionEntries = Object.entries(stats.sessions);
+  if (sessionEntries.length > MAX_SESSION_STATS) {
+    sessionEntries
+      .filter(([id]) => id !== sessionId)
+      .sort(([, left], [, right]) =>
+        (right.updated_at || right.started_at || 0) - (left.updated_at || left.started_at || 0)
+      )
+      .slice(MAX_SESSION_STATS - 1)
+      .forEach(([id]) => delete stats.sessions[id]);
+  }
 
   saveStats(stats);
   return session.tool_counts[toolName];
@@ -1014,7 +1026,11 @@ function combineMessages(...messages) {
 async function main() {
   // Skip guard: check OMC_SKIP_HOOKS env var (see issue #838)
   const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
-  if (process.env.DISABLE_OMC === '1' || _skipHooks.includes('post-tool-use')) {
+  if (
+    process.env.DISABLE_OMC === '1' ||
+    process.env.DISABLE_OMC === 'true' ||
+    _skipHooks.includes('post-tool-use')
+  ) {
     console.log(JSON.stringify({ continue: true }));
     return;
   }

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -19,6 +19,12 @@ import { readStdin } from './lib/stdin.mjs';
 import { resolveContextPercent } from './lib/context-usage.mjs';
 import { BOUNDED_GIT_TIMEOUT_MS } from './lib/bounded-git-timeout.mjs';
 
+const SKIP_HOOKS = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
+const HOOK_DISABLED =
+  process.env.DISABLE_OMC === '1' ||
+  process.env.DISABLE_OMC === 'true' ||
+  SKIP_HOOKS.includes('post-tool-use');
+
 const AGENT_OUTPUT_ANALYSIS_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_ANALYSIS_LIMIT || '12000', 10);
 const AGENT_OUTPUT_SUMMARY_LIMIT = parseInt(process.env.OMC_AGENT_OUTPUT_SUMMARY_LIMIT || '360', 10);
 const PREEMPTIVE_WARNING_THRESHOLD_PERCENT = parseInt(process.env.OMC_PREEMPTIVE_COMPACTION_WARNING_PERCENT || '70', 10);
@@ -116,12 +122,14 @@ const distDir = join(__dirname, '..', 'dist', 'hooks', 'notepad');
 // Try to import notepad functions (may fail if not built)
 let setPriorityContext = null;
 let addWorkingMemoryEntry = null;
-try {
-  const notepadModule = await import(pathToFileURL(join(distDir, 'index.js')).href);
-  setPriorityContext = notepadModule.setPriorityContext;
-  addWorkingMemoryEntry = notepadModule.addWorkingMemoryEntry;
-} catch {
-  // Notepad module not available - remember tags will be silently ignored
+if (!HOOK_DISABLED) {
+  try {
+    const notepadModule = await import(pathToFileURL(join(distDir, 'index.js')).href);
+    setPriorityContext = notepadModule.setPriorityContext;
+    addWorkingMemoryEntry = notepadModule.addWorkingMemoryEntry;
+  } catch {
+    // Notepad module not available - remember tags will be silently ignored
+  }
 }
 
 // Debug logging helper - gated behind OMC_DEBUG env var
@@ -135,12 +143,14 @@ const STATE_FILE = join(cfgDir, '.session-stats.json');
 const MAX_SESSION_STATS = 100;
 
 // Ensure state directory exists
-try {
-  const stateDir = cfgDir;
-  if (!existsSync(stateDir)) {
-    mkdirSync(stateDir, { recursive: true });
-  }
-} catch {}
+if (!HOOK_DISABLED) {
+  try {
+    const stateDir = cfgDir;
+    if (!existsSync(stateDir)) {
+      mkdirSync(stateDir, { recursive: true });
+    }
+  } catch {}
+}
 
 // Load session statistics
 function loadStats() {
@@ -1024,13 +1034,7 @@ function combineMessages(...messages) {
 }
 
 async function main() {
-  // Skip guard: check OMC_SKIP_HOOKS env var (see issue #838)
-  const _skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map(s => s.trim());
-  if (
-    process.env.DISABLE_OMC === '1' ||
-    process.env.DISABLE_OMC === 'true' ||
-    _skipHooks.includes('post-tool-use')
-  ) {
+  if (HOOK_DISABLED) {
     console.log(JSON.stringify({ continue: true }));
     return;
   }

--- a/scripts/project-memory-posttool.mjs
+++ b/scripts/project-memory-posttool.mjs
@@ -12,25 +12,27 @@ const debugLog = (...args) => {
   if (process.env.OMC_DEBUG) console.error('[omc:debug:project-memory]', ...args);
 };
 
-// Dynamic imports with graceful fallback (separate try-catch for partial availability)
 let learnFromToolOutput = null;
 let findProjectRoot = null;
-try {
-  learnFromToolOutput = (await import('../dist/hooks/project-memory/learner.js')).learnFromToolOutput;
-} catch (err) {
-  if (err?.code === 'ERR_MODULE_NOT_FOUND' && /dist\//.test(err?.message)) {
-    debugLog('dist/ learner module not found, skipping');
-  } else {
-    debugLog('Unexpected learner import error:', err?.code, err?.message);
+
+async function loadRuntimeModules() {
+  try {
+    learnFromToolOutput = (await import('../dist/hooks/project-memory/learner.js')).learnFromToolOutput;
+  } catch (err) {
+    if (err?.code === 'ERR_MODULE_NOT_FOUND' && /dist\//.test(err?.message)) {
+      debugLog('dist/ learner module not found, skipping');
+    } else {
+      debugLog('Unexpected learner import error:', err?.code, err?.message);
+    }
   }
-}
-try {
-  findProjectRoot = (await import('../dist/hooks/rules-injector/finder.js')).findProjectRoot;
-} catch (err) {
-  if (err?.code === 'ERR_MODULE_NOT_FOUND' && /dist\//.test(err?.message)) {
-    debugLog('dist/ finder module not found, skipping');
-  } else {
-    debugLog('Unexpected finder import error:', err?.code, err?.message);
+  try {
+    findProjectRoot = (await import('../dist/hooks/rules-injector/finder.js')).findProjectRoot;
+  } catch (err) {
+    if (err?.code === 'ERR_MODULE_NOT_FOUND' && /dist\//.test(err?.message)) {
+      debugLog('dist/ finder module not found, skipping');
+    } else {
+      debugLog('Unexpected finder import error:', err?.code, err?.message);
+    }
   }
 }
 
@@ -38,7 +40,19 @@ try {
  * Main hook execution
  */
 async function main() {
+  const skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map((hook) => hook.trim());
+  if (
+    process.env.DISABLE_OMC === '1' ||
+    process.env.DISABLE_OMC === 'true' ||
+    skipHooks.includes('project-memory-posttool') ||
+    skipHooks.includes('post-tool-use')
+  ) {
+    console.log(JSON.stringify({ continue: true }));
+    return;
+  }
+
   try {
+    await loadRuntimeModules();
     const input = await readStdin();
     const data = JSON.parse(input);
 

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -162,15 +162,19 @@ function resolveInnerTimeoutMs(manifestHook, platform = process.platform) {
   return Math.max(1, manifestHook.timeoutMs - resolveTimeoutCushionMs(manifestHook.timeoutMs, manifestHook.event, platform));
 }
 
-// Call only after resolveWorkerTarget has verified an exact canonical trusted prompt target.
-function resolveTrustedPromptWorkerTimeoutMs(targetPath, manifestHook, trustedPluginRoot) {
+// Call only after resolveWorkerTarget has verified an exact canonical trusted target.
+const TRUSTED_WORKER_HOOKS = new Map([
+  ['keyword-detector.mjs', { event: 'UserPromptSubmit', timeoutCapMs: 8000 }],
+  ['skill-injector.mjs', { event: 'UserPromptSubmit', timeoutCapMs: 12000 }],
+  ['pre-tool-enforcer.mjs', { event: 'PreToolUse' }],
+  ['post-tool-verifier.mjs', { event: 'PostToolUse' }],
+  ['project-memory-posttool.mjs', { event: 'PostToolUse' }],
+  ['post-tool-rules-injector.mjs', { event: 'PostToolUse' }],
+]);
+
+function resolveTrustedWorkerTimeoutMs(targetPath, manifestHook) {
   const calculatedTimeoutMs = resolveInnerTimeoutMs(manifestHook);
-  const canonicalTarget = normalizedComparisonPath(targetPath);
-  const capsByCanonicalTarget = new Map([
-    [normalizedComparisonPath(join(trustedPluginRoot, 'scripts', 'keyword-detector.mjs')), 8000],
-    [normalizedComparisonPath(join(trustedPluginRoot, 'scripts', 'skill-injector.mjs')), 12000],
-  ]);
-  const capMs = capsByCanonicalTarget.get(canonicalTarget);
+  const capMs = TRUSTED_WORKER_HOOKS.get(basename(targetPath))?.timeoutCapMs;
   return capMs ? Math.min(calculatedTimeoutMs, capMs) : calculatedTimeoutMs;
 }
 
@@ -234,12 +238,14 @@ function resolveWorkerTarget(resolution, extraArgs) {
     const canonicalTarget = normalizedComparisonPath(resolution.targetPath);
     if (!isContainedBy(canonicalRoot, canonicalTarget)) return null;
 
-    const expectedTargets = ['keyword-detector.mjs', 'skill-injector.mjs']
-      .map(script => normalizedComparisonPath(join(trustedRoot, 'scripts', script)));
-    if (!expectedTargets.includes(canonicalTarget)) return null;
+    const scriptName = basename(resolution.targetPath);
+    const trustedHook = TRUSTED_WORKER_HOOKS.get(scriptName);
+    if (!trustedHook) return null;
+    const expectedTarget = normalizedComparisonPath(join(trustedRoot, 'scripts', scriptName));
+    if (canonicalTarget !== expectedTarget) return null;
 
     const manifestHook = resolveHookTimeoutMsFromRoot(trustedRoot, resolution.targetPath, []);
-    if (manifestHook?.event !== 'UserPromptSubmit') return null;
+    if (manifestHook?.event !== trustedHook.event) return null;
     return manifestHook;
   } catch {
     return null;
@@ -896,7 +902,7 @@ if (require.main === module) {
       const extraArgs = process.argv.slice(3);
       const workerManifestHook = resolveWorkerTarget(resolution, extraArgs);
       if (workerManifestHook) {
-        const workerTimeoutMs = resolveTrustedPromptWorkerTimeoutMs(resolution.targetPath, workerManifestHook, resolution.trustedPluginRoot);
+        const workerTimeoutMs = resolveTrustedWorkerTimeoutMs(resolution.targetPath, workerManifestHook);
         runWorker(resolution.targetPath, workerManifestHook, workerTimeoutMs).then(status => {
           process.exitCode = status;
         });
@@ -921,7 +927,7 @@ if (require.main === module) {
 
 module.exports = {
   resolveInnerTimeoutMs,
-  resolveTrustedPromptWorkerTimeoutMs,
+  resolveTrustedWorkerTimeoutMs,
   resolveWorkerTarget,
   resolveHookTimeoutMs,
   resolveGenericTimeoutMs,

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -220,6 +220,18 @@ describe('session statistics retention', () => {
       expect(readFileSync(statePath, 'utf8')).toBe(original);
     });
   });
+
+  it('does not initialize the state directory when disabled', () => {
+    withTempDir((tempDir) => {
+      const configDir = join(tempDir, 'missing-config');
+
+      expect(runPostToolVerifier(
+        { session_id: 'disabled-session', cwd: tempDir, tool_name: 'Read' },
+        { CLAUDE_CONFIG_DIR: configDir, DISABLE_OMC: 'true' },
+      )).toEqual({ continue: true });
+      expect(existsSync(configDir)).toBe(false);
+    });
+  });
 });
 
 describe('detectBashFailure', () => {

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -144,6 +144,84 @@ function writeRalplanStateFixture(tempDir, sessionId, overrides = {}) {
   );
 }
 
+describe('session statistics retention', () => {
+  it('keeps the current session while pruning accumulated historical sessions', () => {
+    withTempDir((tempDir) => {
+      const configDir = join(tempDir, '.claude');
+      const statePath = join(configDir, '.session-stats.json');
+      mkdirSync(configDir, { recursive: true });
+      const sessions = Object.fromEntries(
+        Array.from({ length: 150 }, (_, index) => [
+          `historical-${index}`,
+          {
+            tool_counts: { Read: 1 },
+            last_tool: 'Read',
+            total_calls: 1,
+            started_at: index + 1,
+            updated_at: index + 1,
+          },
+        ]),
+      );
+      writeFileSync(statePath, JSON.stringify({ sessions }));
+
+      runPostToolVerifier(
+        {
+          session_id: 'current-session',
+          cwd: tempDir,
+          tool_name: 'Read',
+          tool_input: { file_path: join(tempDir, 'README.md') },
+          tool_response: 'ok',
+        },
+        {
+          HOME: tempDir,
+          USERPROFILE: tempDir,
+          CLAUDE_CONFIG_DIR: configDir,
+        },
+      );
+
+      const retained = JSON.parse(readFileSync(statePath, 'utf8')).sessions;
+      expect(Object.keys(retained)).toHaveLength(100);
+      expect(retained['current-session'].tool_counts.Read).toBe(1);
+      expect(retained['historical-149']).toBeDefined();
+      expect(retained['historical-0']).toBeUndefined();
+    });
+  });
+
+  it.each([
+    { DISABLE_OMC: 'true', OMC_SKIP_HOOKS: '' },
+    { DISABLE_OMC: '', OMC_SKIP_HOOKS: 'post-tool-use' },
+  ])('does not rewrite statistics when disabled by %j', (env) => {
+    withTempDir((tempDir) => {
+      const configDir = join(tempDir, '.claude');
+      const statePath = join(configDir, '.session-stats.json');
+      mkdirSync(configDir, { recursive: true });
+      const original = JSON.stringify({
+        sessions: {
+          existing: { tool_counts: { Read: 7 }, total_calls: 7, started_at: 1, updated_at: 2 },
+        },
+      });
+      writeFileSync(statePath, original);
+
+      expect(runPostToolVerifier(
+        {
+          session_id: 'current-session',
+          cwd: tempDir,
+          tool_name: 'Read',
+          tool_input: { file_path: join(tempDir, 'README.md') },
+          tool_response: 'ok',
+        },
+        {
+          HOME: tempDir,
+          USERPROFILE: tempDir,
+          CLAUDE_CONFIG_DIR: configDir,
+          ...env,
+        },
+      )).toEqual({ continue: true });
+      expect(readFileSync(statePath, 'utf8')).toBe(original);
+    });
+  });
+});
+
 describe('detectBashFailure', () => {
   describe('Claude Code temp CWD false positives (issue #696)', () => {
     it('should not flag macOS temp CWD permission error as a failure', () => {

--- a/src/__tests__/project-memory-posttool.test.ts
+++ b/src/__tests__/project-memory-posttool.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT_PATH = join(process.cwd(), 'scripts', 'project-memory-posttool.mjs');
+const tempDirs: string[] = [];
+const SKIP_ENVIRONMENTS: Record<string, string>[] = [
+  { DISABLE_OMC: '1' },
+  { DISABLE_OMC: 'true' },
+  { OMC_SKIP_HOOKS: 'project-memory-posttool' },
+  { OMC_SKIP_HOOKS: ' keyword-detector , post-tool-use ' },
+];
+
+function runHook(env: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'project-memory-posttool-'));
+  tempDirs.push(root);
+  mkdirSync(join(root, '.git'));
+  mkdirSync(join(root, '.omc'));
+  mkdirSync(join(root, 'scripts', 'lib'), { recursive: true });
+  const copiedScriptPath = join(root, 'scripts', 'project-memory-posttool.mjs');
+  writeFileSync(copiedScriptPath, readFileSync(SCRIPT_PATH));
+  writeFileSync(
+    join(root, 'scripts', 'lib', 'stdin.mjs'),
+    readFileSync(join(process.cwd(), 'scripts', 'lib', 'stdin.mjs')),
+  );
+  const memoryPath = join(root, '.omc', 'project-memory.json');
+  const memory = JSON.stringify({
+    version: '1.0.0',
+    lastScanned: Date.now(),
+    projectRoot: root,
+    techStack: { languages: [], frameworks: [], packageManager: null, runtime: null },
+    build: { buildCommand: null, testCommand: null, lintCommand: null, devCommand: null, scripts: {} },
+    conventions: { namingStyle: null, importStyle: null, testPattern: null, fileOrganization: null },
+    structure: { isMonorepo: false, workspaces: [], mainDirectories: [], gitBranches: null },
+    customNotes: [],
+    directoryMap: {},
+    hotPaths: [],
+    userDirectives: [],
+  });
+  writeFileSync(memoryPath, memory);
+  const result = spawnSync(process.execPath, [copiedScriptPath], {
+    cwd: root,
+    encoding: 'utf8',
+    input: JSON.stringify({
+      cwd: root,
+      tool_name: 'Read',
+      tool_input: { file_path: join(root, 'README.md') },
+      tool_response: 'ok',
+    }),
+    env: { ...process.env, DISABLE_OMC: '', OMC_SKIP_HOOKS: '', OMC_DEBUG: '1', ...env },
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return {
+    output: JSON.parse(result.stdout),
+    stderr: result.stderr,
+    memory: readFileSync(memoryPath, 'utf8'),
+    expectedMemory: memory,
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('project-memory-posttool skip guards', () => {
+  it.each(SKIP_ENVIRONMENTS)('does not touch project memory when disabled by %j', (env) => {
+    const result = runHook(env);
+    expect(result.output).toEqual({ continue: true });
+    expect(result.stderr).toBe('');
+    expect(result.memory).toBe(result.expectedMemory);
+  });
+});

--- a/src/__tests__/run-cjs-graceful-fallback.test.ts
+++ b/src/__tests__/run-cjs-graceful-fallback.test.ts
@@ -113,9 +113,9 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
       const outer = { event: 'UserPromptSubmit', timeoutMs: 30000 };
       const lower = { event: 'UserPromptSubmit', timeoutMs: 5000 };
       process.stdout.write(JSON.stringify([
-        runner.resolveTrustedPromptWorkerTimeoutMs(keyword, outer, root),
-        runner.resolveTrustedPromptWorkerTimeoutMs(skill, outer, root),
-        runner.resolveTrustedPromptWorkerTimeoutMs(keyword, lower, root),
+        runner.resolveTrustedWorkerTimeoutMs(keyword, outer),
+        runner.resolveTrustedWorkerTimeoutMs(skill, outer),
+        runner.resolveTrustedWorkerTimeoutMs(keyword, lower),
         runner.resolveGenericTimeoutMs(outer),
       ]));
     `;
@@ -478,7 +478,7 @@ describe('run.cjs — graceful fallback for stale plugin paths', () => {
   });
 });
 
-describe('run.cjs trusted UserPromptSubmit Worker selection', () => {
+describe('run.cjs trusted hook Worker selection', () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -494,7 +494,14 @@ describe('run.cjs trusted UserPromptSubmit Worker selection', () => {
     mkdirSync(join(root, 'hooks'), { recursive: true });
     writeFileSync(join(root, 'scripts', 'run.cjs'), '// plugin-root marker');
     for (const [name, contents] of Object.entries(scripts)) writeFileSync(join(root, 'scripts', name), contents);
-    for (const expectedScript of ['keyword-detector.mjs', 'skill-injector.mjs']) {
+    for (const expectedScript of [
+      'keyword-detector.mjs',
+      'skill-injector.mjs',
+      'pre-tool-enforcer.mjs',
+      'post-tool-verifier.mjs',
+      'project-memory-posttool.mjs',
+      'post-tool-rules-injector.mjs',
+    ]) {
       const expectedPath = join(root, 'scripts', expectedScript);
       if (!existsSync(expectedPath)) writeFileSync(expectedPath, 'process.exit(0);');
     }
@@ -530,6 +537,27 @@ describe('run.cjs trusted UserPromptSubmit Worker selection', () => {
     const result = run(target, { CLAUDE_PLUGIN_ROOT: root });
 
     expect(result).toMatchObject({ status: 0, stdout: 'worker' });
+  });
+
+  it.each([
+    ['pre-tool-enforcer.mjs', 'PreToolUse'],
+    ['post-tool-verifier.mjs', 'PostToolUse'],
+    ['project-memory-posttool.mjs', 'PostToolUse'],
+    ['post-tool-rules-injector.mjs', 'PostToolUse'],
+  ])('uses a Worker for exact trusted per-tool hook %s', (script, event) => {
+    const root = join(tmpDir, `${script}-root`);
+    const target = join(root, 'scripts', script);
+    createTrustedPlugin(root, { [script]: workerProbe }, event);
+
+    expect(run(target, { CLAUDE_PLUGIN_ROOT: root })).toMatchObject({ status: 0, stdout: 'worker' });
+  });
+
+  it('rejects a trusted per-tool pathname registered under the wrong event', () => {
+    const root = join(tmpDir, 'wrong-event-root');
+    const target = join(root, 'scripts', 'project-memory-posttool.mjs');
+    createTrustedPlugin(root, { 'project-memory-posttool.mjs': workerProbe }, 'PreToolUse');
+
+    expect(run(target, { CLAUDE_PLUGIN_ROOT: root })).toMatchObject({ status: 0, stdout: 'child' });
   });
 
   it('rejects same-basename outside-root, extra-argument, and nonprompt candidates to the generic child path', () => {
@@ -675,5 +703,24 @@ describe('run.cjs trusted UserPromptSubmit Worker selection', () => {
     expect(debug.stdout).toBe('');
     expect(debug.stderr).toContain('Hook keyword-detector.mjs timed out after 1000ms; exiting fail-open.');
     expect(readFileSync(startedMarker, 'utf-8')).toBe('async');
+  });
+
+  it('terminates a timed-out trusted per-tool Worker without late protocol output', () => {
+    const root = join(tmpDir, 'per-tool-timeout-root');
+    const target = join(root, 'scripts', 'pre-tool-enforcer.mjs');
+    createTrustedPlugin(
+      root,
+      {
+        'pre-tool-enforcer.mjs': "setTimeout(() => process.stdout.write('late'), 20); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);",
+      },
+      'PreToolUse',
+      1,
+    );
+
+    const result = run(target, { CLAUDE_PLUGIN_ROOT: root });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Hook pre-tool-enforcer.mjs timed out after 500ms; exiting fail-open.');
   });
 });

--- a/src/__tests__/run-cjs-graceful-fallback.test.ts
+++ b/src/__tests__/run-cjs-graceful-fallback.test.ts
@@ -516,11 +516,11 @@ describe('run.cjs trusted hook Worker selection', () => {
     }));
   }
 
-  function run(target: string, env: Record<string, string> = {}, args: string[] = []) {
+  function run(target: string, env: Record<string, string> = {}, args: string[] = [], input = '{}') {
     const result = spawnSync(NODE, [RUN_CJS_PATH, target, ...args], {
       encoding: 'utf-8',
       env: { ...process.env, ...env },
-      input: '{}',
+      input,
       timeout: 30000,
       maxBuffer: 10 * 1024 * 1024,
     });
@@ -550,6 +550,38 @@ describe('run.cjs trusted hook Worker selection', () => {
     createTrustedPlugin(root, { [script]: workerProbe }, event);
 
     expect(run(target, { CLAUDE_PLUGIN_ROOT: root })).toMatchObject({ status: 0, stdout: 'worker' });
+  });
+
+  it('executes the real post-tool verifier entrypoint inside its trusted Worker', () => {
+    const root = join(__dirname, '..', '..');
+    const target = join(root, 'scripts', 'post-tool-verifier.mjs');
+    const home = join(tmpDir, 'real-verifier-home');
+    const configDir = join(home, '.claude');
+    const input = JSON.stringify({
+      session_id: 'real-worker-session',
+      cwd: root,
+      tool_name: 'Read',
+      tool_input: { file_path: join(root, 'package.json') },
+      tool_response: 'ok',
+    });
+
+    const result = run(target, {
+      CLAUDE_PLUGIN_ROOT: root,
+      CLAUDE_CONFIG_DIR: configDir,
+      HOME: home,
+      USERPROFILE: home,
+      OMC_QUIET: '1',
+      DISABLE_OMC: '',
+      OMC_SKIP_HOOKS: '',
+    }, [], input);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({ continue: true });
+    const stats = JSON.parse(readFileSync(join(configDir, '.session-stats.json'), 'utf8'));
+    expect(stats.sessions['real-worker-session']).toMatchObject({
+      tool_counts: { Read: 1 },
+      total_calls: 1,
+    });
   });
 
   it('rejects a trusted per-tool pathname registered under the wrong event', () => {

--- a/src/__tests__/windows-prompt-hook-runner.test.ts
+++ b/src/__tests__/windows-prompt-hook-runner.test.ts
@@ -179,7 +179,7 @@ describe('Windows-safe prompt hook runner paths', () => {
     const cacheBase = mkdtempSync(join(tmpdir(), 'omc generic tree reap-'));
     tempDirs.push(cacheBase);
     const root = join(cacheBase, '4.6.0');
-    const target = join(root, 'scripts', 'post-tool-verifier.mjs');
+    const target = join(root, 'scripts', 'post-tool-use-failure.mjs');
     const pidfile = join(cacheBase, 'generic-grandchild.pid');
     let grandchildPid: number | undefined;
     mkdirSync(join(root, 'scripts'), { recursive: true });
@@ -193,9 +193,9 @@ describe('Windows-safe prompt hook runner paths', () => {
     `);
     writeFileSync(join(root, 'hooks', 'hooks.json'), JSON.stringify({
       hooks: {
-        PostToolUse: [{ matcher: '', hooks: [{
+        PostToolUseFailure: [{ matcher: '', hooks: [{
           type: 'command',
-          command: 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/post-tool-verifier.mjs',
+          command: 'node "$CLAUDE_PLUGIN_ROOT"/scripts/run.cjs "$CLAUDE_PLUGIN_ROOT"/scripts/post-tool-use-failure.mjs',
           timeout: 2,
         }] }],
       },
@@ -207,7 +207,7 @@ describe('Windows-safe prompt hook runner paths', () => {
       const elapsed = Date.now() - startedAt;
       expect(result.status).toBe(0);
       const declaredMs = 2000;
-      const innerMs = runCjs.resolveGenericTimeoutMs({ timeoutMs: declaredMs, event: 'PostToolUse' });
+      const innerMs = runCjs.resolveGenericTimeoutMs({ timeoutMs: declaredMs, event: 'PostToolUseFailure' });
       expect(elapsed).toBeGreaterThanOrEqual(innerMs >= 400 ? 400 : 0);
       expect(elapsed).toBeLessThan(declaredMs);
       const pidDeadline = Date.now() + 1000;


### PR DESCRIPTION
Closes #3923.

## What changed
- route the exact trusted `PreToolUse`/`PostToolUse` hook entrypoints through the existing Worker isolation path, while retaining canonical-root, exact-event, zero-extra-argument checks and generic child fallback
- cap `.session-stats.json` at the active session plus the 99 most recently updated historical sessions
- add the missing `DISABLE_OMC` / `OMC_SKIP_HOOKS` guard to `project-memory-posttool.mjs` before its runtime imports; align `DISABLE_OMC=true` for the verifier
- preserve project-memory locking and both atomic-write fsync durability steps unchanged
- add structural regression coverage for Worker eligibility/fallback, timeouts, bounded stats, early skip behavior, lock concurrency, and atomic publication
- regenerate the canonical inventory

## Measured evidence
Deterministic Linux/Node v25.1.0 fixture, 2,445 historical sessions, 1,232,302-byte initial stats file, one serial cycle of the four success-path hooks:

| Metric | `dev@369caf12` | this branch | Change |
|---|---:|---:|---:|
| median wall time (10 cycles) | 535.3 ms | 446.2 ms | -16.6% |
| Node hook processes | 8 | 4 | -50% |
| successful write bytes | 1,234,308 | 52,500 | -95.7% |
| stats file after cycle | ~1.23 MB / 2,445 sessions | 50,111 B / 100 sessions | bounded |
| fsync calls | 2 | 2 | unchanged |
| project-memory lock | acquired | acquired | unchanged |

The reporter's ~522 ms total and ~42 ms bare Node startup reproduced closely: 535.3 ms median and 43.7 ms median respectively. The two fsyncs and lock are real, but they remain because removing or failing open would weaken durability/race correctness. On this Linux host the Worker conversion alone was not the dominant wall-time win; the bounded global stats rewrite was the dominant safe recurring reduction.

## Verification
Exact local head `3f9b4ee040d78024033e67262e5f94c510b1ba9f`:
- 173 focused tests passed across Worker routing, verifier, project-memory guard, atomic write, and concurrent project-memory suites
- `npx tsc --noEmit` passed
- `npm run lint` passed with 0 errors (28 pre-existing warnings)
- `npm run generate:inventory:verify` passed
- full-suite run reached 13,600 passes but had unrelated shared-state/deadline failures under the local parallel harness; hosted exact-head CI is the release gate

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
