### PR TITLE
fix(lsp): bound directory diagnostics lifecycle

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "83bf9f31dcbcc226853905e440cad09747783722",
-    "sourceSha256": "fdcb56a6aeba88cdb84df3ee91e5c43d9d7f5a5e2ed4f4c5803acd7e0b1090fa",
+    "head": "7a16db651f5f1d1e2e8d6cb298b079a917d807a4",
+    "sourceSha256": "265cce00d1dc89466fcf5ae8d2cc857b8532a324ab00767e3e8a5f2ee98f0dc1",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "83bf9f31dcbcc226853905e440cad09747783722",
-  "sourceSha256": "fdcb56a6aeba88cdb84df3ee91e5c43d9d7f5a5e2ed4f4c5803acd7e0b1090fa",
+  "head": "7a16db651f5f1d1e2e8d6cb298b079a917d807a4",
+  "sourceSha256": "265cce00d1dc89466fcf5ae8d2cc857b8532a324ab00767e3e8a5f2ee98f0dc1",
   "counts": {
     "public": {
       "skills": 35,
@@ -76824,5 +76824,5 @@
     }
   },
   "inventorySha256": "09828ef29aafe8920279970c90a291d2281be31074ba85d6224727ec4c0f6cc5",
-  "manifestSha256": "e67c4649d11d3319cb24287a0294dca4d7c61b379a48f45a06c89f01f4d2d095"
+  "manifestSha256": "b008d2f6de9a0dd50df38b1955a930069b934147ca2a67aec2603f6d1c708388"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "e836deb017c20ad94134bdcdc1bc953b873ca39a",
-    "sourceSha256": "98ff4f88215fda9ee3001d79453043907ef04620b50dc804189eb2264a7940ca",
+    "head": "83bf9f31dcbcc226853905e440cad09747783722",
+    "sourceSha256": "fdcb56a6aeba88cdb84df3ee91e5c43d9d7f5a5e2ed4f4c5803acd7e0b1090fa",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "e836deb017c20ad94134bdcdc1bc953b873ca39a",
-  "sourceSha256": "98ff4f88215fda9ee3001d79453043907ef04620b50dc804189eb2264a7940ca",
+  "head": "83bf9f31dcbcc226853905e440cad09747783722",
+  "sourceSha256": "fdcb56a6aeba88cdb84df3ee91e5c43d9d7f5a5e2ed4f4c5803acd7e0b1090fa",
   "counts": {
     "public": {
       "skills": 35,
@@ -25,11 +25,11 @@
     "internal": {
       "hookFiles": 295,
       "featureFiles": 69,
-      "toolFiles": 60,
+      "toolFiles": 61,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1318,
-      "total": 1339
+      "srcFiles": 1319,
+      "total": 1340
     },
     "generated": {
       "distFiles": 4955,
@@ -532,6 +532,7 @@
       "src/tools/lsp-tools.ts",
       "src/tools/lsp/AGENTS.md",
       "src/tools/lsp/__tests__/client-devcontainer.test.ts",
+      "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
       "src/tools/lsp/__tests__/client-eviction.test.ts",
       "src/tools/lsp/__tests__/client-handle-data.test.ts",
       "src/tools/lsp/__tests__/client-python-boundary.test.ts",
@@ -6239,6 +6240,7 @@
       "src/tools/lsp-tools.ts",
       "src/tools/lsp/AGENTS.md",
       "src/tools/lsp/__tests__/client-devcontainer.test.ts",
+      "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
       "src/tools/lsp/__tests__/client-eviction.test.ts",
       "src/tools/lsp/__tests__/client-handle-data.test.ts",
       "src/tools/lsp/__tests__/client-python-boundary.test.ts",
@@ -39850,6 +39852,11 @@
         "id": "src/tools/lsp/__tests__/client-devcontainer.test.ts",
         "kind": "tool",
         "path": "src/tools/lsp/__tests__/client-devcontainer.test.ts"
+      },
+      {
+        "id": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "kind": "tool",
+        "path": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts"
       },
       {
         "id": "src/tools/lsp/__tests__/client-eviction.test.ts",
@@ -74284,6 +74291,36 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "to": "external:node:events",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/tools/lsp/__tests__/client-document-lifecycle.test.ts",
+        "to": "src/tools/lsp/client.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/tools/lsp/__tests__/client-eviction.test.ts",
         "to": "external:vitest",
         "kind": "imports"
@@ -76780,12 +76817,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6848,
-      "edgeCount": 7251,
-      "importEdgeCount": 5960,
+      "nodeCount": 6849,
+      "edgeCount": 7257,
+      "importEdgeCount": 5966,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "c1d8aa2e942388c4a0bf6b0db08b31577d36245fcfe3368dc8ab48695904619f",
-  "manifestSha256": "29d700a8f40d3bf501e731b66ce2a77f7a95165f9989dfcbb5c571156c23951c"
+  "inventorySha256": "09828ef29aafe8920279970c90a291d2281be31074ba85d6224727ec4c0f6cc5",
+  "manifestSha256": "e67c4649d11d3319cb24287a0294dca4d7c61b379a48f45a06c89f01f4d2d095"
 }

--- a/src/tools/diagnostics/__tests__/lsp-aggregator.test.ts
+++ b/src/tools/diagnostics/__tests__/lsp-aggregator.test.ts
@@ -24,8 +24,170 @@ beforeEach(() => {
 });
 
 describe('runLspAggregatedDiagnostics', () => {
+  it('bounds concurrent files while processing more than one at a time', async () => {
+    mockGetServerForFile.mockReturnValue({
+      command: 'test-lsp',
+      installHint: 'install test-lsp',
+    });
+
+    let active = 0;
+    let maxActive = 0;
+    mockRunWithClientLease.mockImplementation(async (_file, callback) => {
+      const openDocument = vi.fn();
+      const closeDocument = vi.fn().mockResolvedValue(undefined);
+      return callback({
+        supportsPullDiagnostics: false,
+        openDocument,
+        closeDocument,
+        withOpenDocument: async (file: string, operation: () => Promise<unknown>) => {
+          await openDocument(file);
+          try {
+            return await operation();
+          } finally {
+            await closeDocument(file);
+          }
+        },
+        waitForDiagnostics: vi.fn(async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          active--;
+        }),
+        getDiagnostics: vi.fn(() => []),
+      });
+    });
+
+    const tmp = mkdtempSync(join(tmpdir(), 'lsp-agg-test-'));
+    try {
+      for (let index = 0; index < 12; index++) {
+        writeFileSync(join(tmp, `${index.toString().padStart(2, '0')}.ts`), '');
+      }
+
+      const startedAt = performance.now();
+      const result = await runLspAggregatedDiagnostics(tmp);
+      const elapsedMs = performance.now() - startedAt;
+      console.info(JSON.stringify({ files: 12, delayPerFileMs: 25, elapsedMs, maxActive }));
+      expect(maxActive).toBeGreaterThan(1);
+      expect(maxActive).toBeLessThanOrEqual(8);
+      expect(result.filesChecked).toBe(12);
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('closes every document it opens, including when diagnostics waiting fails', async () => {
+    mockGetServerForFile.mockReturnValue({
+      command: 'test-lsp',
+      installHint: 'install test-lsp',
+    });
+    const openDocument = vi.fn();
+    const closeDocument = vi.fn().mockResolvedValue(undefined);
+    const waitForDiagnostics = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('cancelled'));
+    mockRunWithClientLease.mockImplementation(async (_file, callback) =>
+      callback({
+        supportsPullDiagnostics: false,
+        openDocument,
+        closeDocument,
+        withOpenDocument: async (file: string, operation: () => Promise<unknown>) => {
+          await openDocument(file);
+          try {
+            return await operation();
+          } finally {
+            await closeDocument(file);
+          }
+        },
+        waitForDiagnostics,
+        getDiagnostics: vi.fn(() => []),
+      })
+    );
+
+    const tmp = mkdtempSync(join(tmpdir(), 'lsp-agg-test-'));
+    try {
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'b.ts'), '');
+
+      const result = await runLspAggregatedDiagnostics(tmp);
+
+      console.info(JSON.stringify({ opened: openDocument.mock.calls.length, closed: closeDocument.mock.calls.length }));
+      expect(openDocument).toHaveBeenCalledTimes(2);
+      expect(closeDocument).toHaveBeenCalledTimes(2);
+      expect(closeDocument.mock.calls).toEqual(openDocument.mock.calls);
+      expect(result.filesChecked).toBe(1);
+      expect(result.skippedFiles).toHaveLength(1);
+      expect(result.skippedFiles[0].reason).toBe('cancelled');
+      expect(result.success).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('uses pull diagnostics when the server advertises support', async () => {
+    mockGetServerForFile.mockReturnValue({ command: 'test-lsp', installHint: 'install test-lsp' });
+    const pullDiagnostics = vi.fn().mockResolvedValue([{
+      range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+      message: 'pulled diagnostic',
+      severity: 1,
+    }]);
+    const waitForDiagnostics = vi.fn();
+    mockRunWithClientLease.mockImplementation(async (_file, callback) => callback({
+      supportsPullDiagnostics: true,
+      withOpenDocument: async (_file: string, operation: () => Promise<unknown>) => operation(),
+      pullDiagnostics,
+      waitForDiagnostics,
+      getDiagnostics: vi.fn(() => []),
+    }));
+
+    const tmp = mkdtempSync(join(tmpdir(), 'lsp-agg-test-'));
+    try {
+      writeFileSync(join(tmp, 'a.ts'), '');
+
+      const result = await runLspAggregatedDiagnostics(tmp);
+
+      expect(pullDiagnostics).toHaveBeenCalledOnce();
+      expect(waitForDiagnostics).not.toHaveBeenCalled();
+      expect(result.diagnostics.map(item => item.diagnostic.message)).toEqual(['pulled diagnostic']);
+      expect(result.success).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('preserves file order without losing or duplicating diagnostics', async () => {
+    mockGetServerForFile.mockReturnValue({ command: 'test-lsp', installHint: 'install test-lsp' });
+    mockRunWithClientLease.mockImplementation(async (file, callback) => callback({
+      supportsPullDiagnostics: false,
+      withOpenDocument: async (_file: string, operation: () => Promise<unknown>) => operation(),
+      waitForDiagnostics: vi.fn(async () => {
+        const delay = file.endsWith('a.ts') ? 20 : file.endsWith('b.ts') ? 10 : 0;
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }),
+      getDiagnostics: vi.fn(() => [{
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+        message: file.slice(-4),
+        severity: 1,
+      }]),
+    }));
+
+    const tmp = mkdtempSync(join(tmpdir(), 'lsp-agg-test-'));
+    try {
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'b.ts'), '');
+      writeFileSync(join(tmp, 'c.ts'), '');
+
+      const result = await runLspAggregatedDiagnostics(tmp);
+
+      expect(result.diagnostics.map(item => item.diagnostic.message)).toEqual(['a.ts', 'b.ts', 'c.ts']);
+      expect(new Set(result.diagnostics.map(item => item.file)).size).toBe(3);
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
   it('surfaces install hints when language server is missing', async () => {
-    mockGetServerForFile.mockReturnValue({ command: 'ty', installHint: 'Install ty from https://github.com/astral-sh/ty' });
+    mockGetServerForFile.mockReturnValue({
+      command: 'ty',
+      installHint: 'Install ty from https://github.com/astral-sh/ty',
+    });
     mockRunWithClientLease.mockRejectedValue(
       new Error("Language server 'ty' not found.\nInstall with: Install ty from https://github.com/astral-sh/ty")
     );
@@ -50,7 +212,7 @@ describe('runLspAggregatedDiagnostics', () => {
   it('surfaces the selected basedpyright install hint without ty fallback', async () => {
     mockGetServerForFile.mockReturnValue({
       command: 'basedpyright-langserver',
-      installHint: 'uv tool install basedpyright'
+      installHint: 'uv tool install basedpyright',
     });
     mockRunWithClientLease.mockRejectedValue(
       new Error("Language server 'basedpyright-langserver' not found.\nInstall with: uv tool install basedpyright")
@@ -72,10 +234,15 @@ describe('runLspAggregatedDiagnostics', () => {
   });
 
   it('pre-check skips files with no registered language server', async () => {
-    mockGetServerForFile
-      .mockReturnValueOnce(null)
-      .mockReturnValue({ command: 'ty', installHint: 'pip install ty' });
-    mockRunWithClientLease.mockResolvedValue(undefined);
+    mockGetServerForFile.mockReturnValueOnce(null).mockReturnValue({ command: 'ty', installHint: 'pip install ty' });
+    mockRunWithClientLease.mockImplementation(async (_file, callback) =>
+      callback({
+        supportsPullDiagnostics: false,
+        withOpenDocument: async (_file: string, operation: () => Promise<unknown>) => operation(),
+        waitForDiagnostics: vi.fn(),
+        getDiagnostics: vi.fn(() => []),
+      })
+    );
 
     const tmp = mkdtempSync(join(tmpdir(), 'lsp-agg-test-'));
     try {

--- a/src/tools/diagnostics/lsp-aggregator.ts
+++ b/src/tools/diagnostics/lsp-aggregator.ts
@@ -26,6 +26,28 @@ export interface LspAggregationResult {
   installHints: string[]; // deduplicated, insertion order preserved
 }
 
+export const LSP_DIAGNOSTICS_CONCURRENCY = 8;
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 /**
  * Recursively find files with given extensions
  */
@@ -35,7 +57,7 @@ function findFiles(directory: string, extensions: string[], ignoreDirs: string[]
 
   function walk(dir: string) {
     try {
-      const entries = readdirSync(dir);
+      const entries = readdirSync(dir).sort();
 
       for (const entry of entries) {
         const fullPath = join(dir, entry);
@@ -83,51 +105,63 @@ export async function runLspAggregatedDiagnostics(
   const files = findFiles(directory, extensions, ['node_modules', 'dist', 'build', '.git']);
 
   const allDiagnostics: LspDiagnosticWithFile[] = [];
-  let filesChecked = 0;
   const skippedFiles: Array<{ file: string; reason: string }> = [];
   const installHintSet = new Set<string>();
 
-  for (const file of files) {
+  const fileResults = await mapWithConcurrency(files, LSP_DIAGNOSTICS_CONCURRENCY, async (file) => {
     // Guards future callers passing custom extensions with no registered LSP; redundant under default extension list.
     if (!getServerForFile(file)) {
-      skippedFiles.push({ file, reason: 'no language server registered for extension' });
-      continue;
+      return {
+        file,
+        skippedReason: 'no language server registered for extension',
+      };
     }
 
     try {
-      await lspClientManager.runWithClientLease(file, async (client) => {
-        // Open document to trigger diagnostics
-        await client.openDocument(file);
+      const diagnostics = await lspClientManager.runWithClientLease(file, async (client) => {
+        return client.withOpenDocument(file, async () => {
+          if (client.supportsPullDiagnostics) {
+            return client.pullDiagnostics(file);
+          }
 
-        // Wait for the server to publish diagnostics via textDocument/publishDiagnostics
-        // notification instead of using a fixed delay. Falls back to LSP_DIAGNOSTICS_WAIT_MS
-        // as a timeout so we don't hang forever on servers that omit the notification.
-        await client.waitForDiagnostics(file, LSP_DIAGNOSTICS_WAIT_MS);
-
-        // Get diagnostics for this file
-        const diagnostics = client.getDiagnostics(file);
-
-        // Add to aggregated results
-        for (const diagnostic of diagnostics) {
-          allDiagnostics.push({
-            file,
-            diagnostic
-          });
-        }
-
-        // Must remain the last statement in the lease callback to preserve filesChecked + skippedFiles.length === files.length.
-        filesChecked++;
+          // Wait for the server to publish diagnostics via textDocument/publishDiagnostics.
+          // The timeout prevents a server that omits the notification from blocking a worker.
+          await client.waitForDiagnostics(file, LSP_DIAGNOSTICS_WAIT_MS);
+          return client.getDiagnostics(file);
+        });
       });
+
+      return { file, diagnostics };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      // Regex pinned to throw at src/tools/lsp/client.ts:186 — keep header literal in formatLspResult in sync.
-      const match = message.match(/^Language server '([^']+)' not found\.\nInstall with: (.+)$/s);
-      if (match) {
-        installHintSet.add(match[2].trim());
-        skippedFiles.push({ file, reason: `missing language server: ${match[1]}` });
-      } else {
-        skippedFiles.push({ file, reason: message });
+      return { file, skippedReason: message };
+    }
+  });
+
+  let filesChecked = 0;
+  for (const result of fileResults) {
+    if (result.diagnostics) {
+      filesChecked++;
+      for (const diagnostic of result.diagnostics) {
+        allDiagnostics.push({
+          file: result.file,
+          diagnostic
+        });
       }
+      continue;
+    }
+
+    const message = result.skippedReason ?? 'unknown LSP diagnostics failure';
+    // Keep the missing-server header literal in formatLspResult in sync.
+    const match = message.match(/^Language server '([^']+)' not found\.\nInstall with: (.+)$/s);
+    if (match) {
+      installHintSet.add(match[2].trim());
+      skippedFiles.push({
+        file: result.file,
+        reason: `missing language server: ${match[1]}`
+      });
+    } else {
+      skippedFiles.push({ file: result.file, reason: message });
     }
   }
 
@@ -138,7 +172,7 @@ export async function runLspAggregatedDiagnostics(
   const allFilesSkipped = filesChecked === 0 && files.length > 0;
 
   return {
-    success: errorCount === 0 && !allFilesSkipped,
+    success: errorCount === 0 && skippedFiles.length === 0 && !allFilesSkipped,
     diagnostics: allDiagnostics,
     errorCount,
     warningCount,

--- a/src/tools/lsp/__tests__/client-document-lifecycle.test.ts
+++ b/src/tools/lsp/__tests__/client-document-lifecycle.test.ts
@@ -510,12 +510,12 @@ describe('LspClient.withOpenDocument', () => {
     state.terminalError = null;
     state.openDocuments.add('file:///tmp/a.ts');
     state.persistentDocuments.add('file:///tmp/a.ts');
-    operationGate.resolve();
 
-    await active;
     await staleRejection;
     expect(state.openDocuments.has('file:///tmp/a.ts')).toBe(true);
     expect(state.persistentDocuments.has('file:///tmp/a.ts')).toBe(true);
+    operationGate.resolve();
+    await active;
   });
 });
 

--- a/src/tools/lsp/__tests__/client-document-lifecycle.test.ts
+++ b/src/tools/lsp/__tests__/client-document-lifecycle.test.ts
@@ -1,0 +1,708 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { EventEmitter } from 'node:events';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LspClient, LspClientManager } from '../client.js';
+
+const SERVER_CONFIG = {
+  name: 'test-server',
+  command: 'test-lsp',
+  args: [],
+  extensions: ['.ts'],
+  installHint: 'install test-lsp',
+};
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('LspClient.withOpenDocument', () => {
+  it('sends didClose for a didOpen when the operation rejects', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-lifecycle-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    const child = {};
+    const state = client as unknown as { process: typeof child; connectionGeneration: number };
+    state.process = child;
+    state.connectionGeneration = 1;
+    const notify = vi
+      .spyOn(client as unknown as { notify: (method: string, params: unknown) => void }, 'notify')
+      .mockImplementation(() => undefined);
+
+    try {
+      const operation = client.withOpenDocument(file, async () => {
+        throw new Error('cancelled');
+      });
+      const rejection = expect(operation).rejects.toThrow('cancelled');
+      await vi.advanceTimersByTimeAsync(100);
+      await rejection;
+
+      expect(notify.mock.calls.map(([method]) => method)).toEqual([
+        'textDocument/didOpen',
+        'textDocument/didClose',
+      ]);
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('serializes overlapping operations for the same document', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const ensureDocumentOpen = vi
+      .spyOn(client as unknown as { ensureDocumentOpen: (file: string) => Promise<void> }, 'ensureDocumentOpen')
+      .mockResolvedValue();
+    const closeTransientDocument = vi
+      .spyOn(client as unknown as { closeTransientDocument: (file: string) => Promise<void> }, 'closeTransientDocument')
+      .mockResolvedValue();
+    const firstGate = deferred();
+    const events: string[] = [];
+
+    const first = client.withOpenDocument('/tmp/a.ts', async () => {
+      events.push('first:start');
+      await firstGate.promise;
+      events.push('first:end');
+    });
+    const second = client.withOpenDocument('/tmp/a.ts', async () => {
+      events.push('second:start');
+      events.push('second:end');
+    });
+
+    await vi.waitFor(() => expect(events).toEqual(['first:start']));
+    firstGate.resolve();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual(['first:start', 'first:end', 'second:start', 'second:end']);
+    expect(ensureDocumentOpen).toHaveBeenCalledTimes(2);
+    expect(closeTransientDocument).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not close a document that was already open before the operation', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const hostUri = 'file:///tmp/a.ts';
+    const state = client as unknown as { openDocuments: Set<string>; persistentDocuments: Set<string> };
+    state.openDocuments.add(hostUri);
+    state.persistentDocuments.add(hostUri);
+    const closeTransientDocument = vi
+      .spyOn(client as unknown as { closeTransientDocument: (file: string) => Promise<void> }, 'closeTransientDocument')
+      .mockResolvedValue();
+
+    await client.withOpenDocument('/tmp/a.ts', async () => undefined);
+
+    expect(closeTransientDocument).not.toHaveBeenCalled();
+  });
+
+  it('closes transient ownership before a queued direct open takes ownership', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const ensureDocumentOpen = vi
+      .spyOn(client as unknown as { ensureDocumentOpen: (file: string) => Promise<void> }, 'ensureDocumentOpen')
+      .mockResolvedValue();
+    const closeTransientDocument = vi
+      .spyOn(client as unknown as { closeTransientDocument: (file: string) => Promise<void> }, 'closeTransientDocument')
+      .mockResolvedValue();
+    const operationGate = deferred();
+    let operationStarted = false;
+
+    const transient = client.withOpenDocument('/tmp/a.ts', async () => {
+      operationStarted = true;
+      await operationGate.promise;
+    });
+    await vi.waitFor(() => expect(operationStarted).toBe(true));
+
+    const directOpen = client.openDocument('/tmp/a.ts');
+    operationGate.resolve();
+    await Promise.all([transient, directOpen]);
+
+    expect(ensureDocumentOpen).toHaveBeenCalledTimes(2);
+    expect(closeTransientDocument).toHaveBeenCalledOnce();
+  });
+
+  it('defers a direct close until an active transient operation finishes', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    vi.spyOn(
+      client as unknown as { ensureDocumentOpen: (file: string) => Promise<void> },
+      'ensureDocumentOpen'
+    ).mockResolvedValue();
+    const closeTransientDocument = vi
+      .spyOn(
+        client as unknown as { closeTransientDocument: (file: string) => Promise<void> },
+        'closeTransientDocument'
+      )
+      .mockResolvedValue();
+    const operationGate = deferred();
+    let operationStarted = false;
+
+    const transient = client.withOpenDocument('/tmp/a.ts', async () => {
+      operationStarted = true;
+      await operationGate.promise;
+    });
+    await vi.waitFor(() => expect(operationStarted).toBe(true));
+
+    const directClose = client.closeDocument('/tmp/a.ts');
+    await Promise.resolve();
+    expect(closeTransientDocument).not.toHaveBeenCalled();
+
+    operationGate.resolve();
+    await Promise.all([transient, directClose]);
+    expect(closeTransientDocument).toHaveBeenCalled();
+  });
+
+  it('waits for stdin drain before starting a transient operation', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-backpressure-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+    let operationStarted = false;
+
+    try {
+      const operation = client.withOpenDocument(file, async () => {
+        operationStarted = true;
+      });
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+      expect(operationStarted).toBe(false);
+      expect(stdin.listenerCount('drain')).toBe(1);
+
+      stdin.emit('drain');
+      await vi.advanceTimersByTimeAsync(100);
+      await operation;
+
+      expect(operationStarted).toBe(true);
+      expect(stdin.write).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('serializes transient close before a direct reopen during backpressure', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-open-singleflight-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+
+    try {
+      const transient = client.withOpenDocument(file, async () => undefined);
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+      const direct = client.openDocument(file);
+
+      stdin.emit('drain');
+      await vi.advanceTimersByTimeAsync(200);
+      await Promise.all([transient, direct]);
+
+      const methods = stdin.write.mock.calls.map(([message]) => String(message));
+      expect(methods.filter(message => message.includes('textDocument/didOpen'))).toHaveLength(2);
+      expect(methods.filter(message => message.includes('textDocument/didClose'))).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('does not write another document notification before stdin drains', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-notification-queue-'));
+    const firstFile = join(workspace, 'a.ts');
+    const secondFile = join(workspace, 'b.ts');
+    writeFileSync(firstFile, 'const first = 1;');
+    writeFileSync(secondFile, 'const second = 2;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+
+    try {
+      const first = client.withOpenDocument(firstFile, async () => undefined);
+      const second = client.withOpenDocument(secondFile, async () => undefined);
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+      expect(stdin.write).toHaveBeenCalledOnce();
+
+      stdin.emit('drain');
+      await vi.advanceTimersByTimeAsync(100);
+      await Promise.all([first, second]);
+
+      expect(stdin.write).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('does not write a request while a document notification waits for drain', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-request-queue-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+
+    try {
+      const open = client.openDocument(file);
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+      const request = (client as unknown as {
+        request: (method: string, params: unknown, timeout: number) => Promise<unknown>;
+      }).request('workspace/symbol', { query: 'queued' }, 1_000);
+      const rejection = expect(request).rejects.toThrow('force-killed');
+
+      await Promise.resolve();
+      expect(stdin.write).toHaveBeenCalledOnce();
+      stdin.emit('drain');
+      await vi.advanceTimersByTimeAsync(100);
+      expect(stdin.write).toHaveBeenCalledTimes(2);
+
+      client.forceKill();
+      await rejection;
+      await expect(open).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('rejects a pending request when stdin fails after accepting the write', async () => {
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValue(true),
+    });
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+    stdin.on('error', (error: Error) => {
+      (client as unknown as { handleTransportFailure: (failure: Error) => void }).handleTransportFailure(error);
+    });
+
+    const request = (client as unknown as {
+      request: (method: string, params: unknown, timeout: number) => Promise<unknown>;
+    }).request('workspace/symbol', { query: 'accepted' }, 1_000);
+    const rejection = expect(request).rejects.toThrow('broken pipe');
+    await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledOnce());
+
+    stdin.emit('error', new Error('broken pipe'));
+    await rejection;
+  });
+
+  it('does not transmit a queued request after its timeout expires', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-request-timeout-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+
+    try {
+      const open = client.openDocument(file);
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+      const request = (client as unknown as {
+        request: (method: string, params: unknown, timeout: number) => Promise<unknown>;
+      }).request('workspace/symbol', { query: 'expired' }, 10);
+      const rejection = expect(request).rejects.toThrow("timed out after 10ms");
+
+      await vi.advanceTimersByTimeAsync(10);
+      await rejection;
+      stdin.emit('drain');
+      await vi.advanceTimersByTimeAsync(100);
+      await open;
+
+      expect(stdin.write.mock.calls.some(([message]) => String(message).includes('workspace/symbol'))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('preserves a direct close requested while a direct open waits for drain', async () => {
+    vi.useFakeTimers();
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-open-close-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+
+    try {
+      const open = client.openDocument(file);
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+      const close = client.closeDocument(file);
+
+      stdin.emit('drain');
+      await vi.advanceTimersByTimeAsync(100);
+      await Promise.all([open, close]);
+
+      expect(stdin.write).toHaveBeenCalledTimes(2);
+      expect(String(stdin.write.mock.calls[0][0])).toContain('textDocument/didOpen');
+      expect(String(stdin.write.mock.calls[1][0])).toContain('textDocument/didClose');
+    } finally {
+      vi.useRealTimers();
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('rejects a drain-blocked document operation when the client is force-killed', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-drain-cancel-'));
+    const file = join(workspace, 'a.ts');
+    writeFileSync(file, 'const value = 1;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValue(false),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+
+    try {
+      const operation = client.withOpenDocument(file, async () => undefined);
+      const rejection = expect(operation).rejects.toThrow('force-killed');
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+
+      client.forceKill();
+      await rejection;
+      expect(stdin.listenerCount('drain')).toBe(0);
+    } finally {
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('rejects notifications queued behind a force-killed drain waiter', async () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'lsp-client-queued-cancel-'));
+    const firstFile = join(workspace, 'a.ts');
+    const secondFile = join(workspace, 'b.ts');
+    writeFileSync(firstFile, 'const first = 1;');
+    writeFileSync(secondFile, 'const second = 2;');
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn().mockReturnValue(false),
+    });
+    const client = new LspClient(workspace, SERVER_CONFIG);
+    (client as unknown as { process: { stdin: typeof stdin } }).process = { stdin };
+    let firstStarted = false;
+    let secondStarted = false;
+
+    try {
+      const first = client.withOpenDocument(firstFile, async () => {
+        firstStarted = true;
+      });
+      const second = client.withOpenDocument(secondFile, async () => {
+        secondStarted = true;
+      });
+      for (let turn = 0; turn < 10 && stdin.listenerCount('drain') === 0; turn++) {
+        await Promise.resolve();
+      }
+
+      client.forceKill();
+      const results = await Promise.allSettled([first, second]);
+
+      expect(results.map(result => result.status)).toEqual(['rejected', 'rejected']);
+      expect(firstStarted).toBe(false);
+      expect(secondStarted).toBe(false);
+      expect(stdin.write).toHaveBeenCalledOnce();
+    } finally {
+      rmSync(workspace, { recursive: true });
+    }
+  });
+
+  it('releases the document queue when didClose throws', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    vi.spyOn(
+      client as unknown as { ensureDocumentOpen: (file: string) => Promise<void> },
+      'ensureDocumentOpen'
+    ).mockResolvedValue();
+    const closeTransientDocument = vi.spyOn(
+      client as unknown as { closeTransientDocument: (file: string) => Promise<void> },
+      'closeTransientDocument'
+    );
+    closeTransientDocument.mockRejectedValueOnce(new Error('write failed')).mockResolvedValue();
+
+    const first = client.withOpenDocument('/tmp/a.ts', async () => undefined);
+    const second = client.withOpenDocument('/tmp/a.ts', async () => 'second completed');
+
+    await expect(first).rejects.toThrow('write failed');
+    await expect(second).resolves.toBe('second completed');
+  });
+
+  it('does not let a stale disconnect finalizer kill a replacement child', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const shutdownGate = deferred();
+    const oldChild = { kill: vi.fn() };
+    const newChild = { kill: vi.fn() };
+    const state = client as unknown as {
+      process: typeof oldChild | null;
+      connectionGeneration: number;
+      disconnected: boolean;
+      request: (method: string, params: unknown, timeout: number) => Promise<unknown>;
+    };
+    state.process = oldChild;
+    state.connectionGeneration = 1;
+    vi.spyOn(state, 'request').mockImplementation(() => shutdownGate.promise);
+
+    const staleDisconnect = client.disconnect();
+    await Promise.resolve();
+    state.process = newChild;
+    state.connectionGeneration = 2;
+    state.disconnected = false;
+    shutdownGate.resolve();
+    await staleDisconnect;
+
+    expect(oldChild.kill).toHaveBeenCalledOnce();
+    expect(newChild.kill).not.toHaveBeenCalled();
+    expect(state.process).toBe(newChild);
+  });
+
+  it('rejects document operations queued by a retired connection generation', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const operationGate = deferred();
+    const state = client as unknown as {
+      connectionGeneration: number;
+      disconnected: boolean;
+      terminalError: Error | null;
+      openDocuments: Set<string>;
+      persistentDocuments: Set<string>;
+      ensureDocumentOpen: (file: string) => Promise<void>;
+    };
+    state.connectionGeneration = 1;
+    vi.spyOn(state, 'ensureDocumentOpen').mockResolvedValue();
+    let operationStarted = false;
+
+    const active = client.withOpenDocument('/tmp/a.ts', async () => {
+      operationStarted = true;
+      await operationGate.promise;
+    });
+    await vi.waitFor(() => expect(operationStarted).toBe(true));
+    const staleClose = client.closeDocument('/tmp/a.ts');
+    const staleRejection = expect(staleClose).rejects.toThrow('connection was replaced');
+
+    client.forceKill();
+    state.connectionGeneration++;
+    state.disconnected = false;
+    state.terminalError = null;
+    state.openDocuments.add('file:///tmp/a.ts');
+    state.persistentDocuments.add('file:///tmp/a.ts');
+    operationGate.resolve();
+
+    await active;
+    await staleRejection;
+    expect(state.openDocuments.has('file:///tmp/a.ts')).toBe(true);
+    expect(state.persistentDocuments.has('file:///tmp/a.ts')).toBe(true);
+  });
+});
+
+describe('LspClientManager concurrent startup', () => {
+  it('shares one client connection across concurrent leases', async () => {
+    const manager = new LspClientManager();
+    const connectGate = deferred();
+    const connect = vi.spyOn(LspClient.prototype, 'connect').mockImplementation(() => connectGate.promise);
+    vi.spyOn(LspClient.prototype, 'disconnect').mockResolvedValue();
+    const leasedClients: LspClient[] = [];
+
+    const first = manager.runWithClientLease('/tmp/a.ts', async (client) => {
+      leasedClients.push(client);
+    });
+    const second = manager.runWithClientLease('/tmp/b.ts', async (client) => {
+      leasedClients.push(client);
+    });
+
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce());
+    connectGate.resolve();
+    await Promise.all([first, second]);
+
+    expect(leasedClients).toHaveLength(2);
+    expect(leasedClients[0]).toBe(leasedClients[1]);
+    expect(manager.clientCount).toBe(1);
+    await manager.disconnectAll();
+  });
+
+  it('does not resurrect a client that finishes connecting after shutdown', async () => {
+    const manager = new LspClientManager();
+    const connectGate = deferred();
+    const connect = vi.spyOn(LspClient.prototype, 'connect').mockImplementation(() => connectGate.promise);
+    const forceKill = vi.spyOn(LspClient.prototype, 'forceKill').mockImplementation(() => undefined);
+    connect.mockClear();
+    forceKill.mockClear();
+
+    const lease = manager.runWithClientLease('/tmp/a.ts', async () => undefined);
+    const rejection = expect(lease).rejects.toThrow('shut down during connection');
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce());
+
+    await manager.disconnectAll();
+    connectGate.resolve();
+    await rejection;
+
+    expect(forceKill).toHaveBeenCalled();
+    expect(manager.clientCount).toBe(0);
+  });
+
+  it('replaces a cached client after its server exits', async () => {
+    const manager = new LspClientManager();
+    const connect = vi.spyOn(LspClient.prototype, 'connect').mockResolvedValue();
+    vi.spyOn(LspClient.prototype, 'disconnect').mockResolvedValue();
+    connect.mockClear();
+
+    const first = await manager.getClientForFile('/tmp/a.ts');
+    (first as unknown as { disconnected: boolean }).disconnected = true;
+    const second = await manager.getClientForFile('/tmp/b.ts');
+
+    expect(second).not.toBe(first);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(manager.clientCount).toBe(1);
+    await manager.disconnectAll();
+  });
+
+  it('waits for disconnectAll before acquiring a replacement client', async () => {
+    const manager = new LspClientManager();
+    const disconnectGate = deferred();
+    const connect = vi.spyOn(LspClient.prototype, 'connect').mockResolvedValue();
+    const disconnect = vi.spyOn(LspClient.prototype, 'disconnect').mockImplementation(() => disconnectGate.promise);
+    connect.mockClear();
+    disconnect.mockClear();
+
+    const first = await manager.getClientForFile('/tmp/a.ts');
+    const teardown = manager.disconnectAll();
+    const acquisition = manager.getClientForFile('/tmp/b.ts');
+
+    await vi.waitFor(() => expect(disconnect).toHaveBeenCalledOnce());
+    expect(connect).toHaveBeenCalledOnce();
+
+    disconnectGate.resolve();
+    await teardown;
+    const second = await acquisition;
+
+    expect(second).not.toBe(first);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(manager.clientCount).toBe(1);
+    vi.mocked(LspClient.prototype.disconnect).mockResolvedValue();
+    await manager.disconnectAll();
+  });
+
+  it('retries a raw acquisition when the selected client is replaced before handoff', async () => {
+    const manager = new LspClientManager();
+    const first = new LspClient('/tmp', SERVER_CONFIG);
+    const second = new LspClient('/tmp', SERVER_CONFIG);
+    const key = '/tmp:typescript-language-server:host';
+    const state = manager as unknown as {
+      clients: Map<string, LspClient>;
+      acquireClient: (...args: unknown[]) => Promise<LspClient>;
+    };
+    state.clients.set(key, second);
+    const acquire = vi.spyOn(state, 'acquireClient')
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+
+    const acquired = await manager.getClientForFile('/tmp/a.ts');
+
+    expect(acquired).toBe(second);
+    expect(acquire).toHaveBeenCalledTimes(2);
+  });
+
+  it('disconnects an active lease without waiting for its callback to finish', async () => {
+    const manager = new LspClientManager();
+    const leaseGate = deferred();
+    vi.spyOn(LspClient.prototype, 'connect').mockResolvedValue();
+    const disconnect = vi.spyOn(LspClient.prototype, 'disconnect').mockResolvedValue();
+    disconnect.mockClear();
+    let leaseStarted = false;
+
+    const lease = manager.runWithClientLease('/tmp/a.ts', async () => {
+      leaseStarted = true;
+      await leaseGate.promise;
+    });
+    await vi.waitFor(() => expect(leaseStarted).toBe(true));
+
+    const teardown = manager.disconnectAll();
+    await teardown;
+    expect(disconnect).toHaveBeenCalledOnce();
+
+    leaseGate.resolve();
+    await lease;
+  });
+});
+
+describe('LspClient diagnostic waiters', () => {
+  it('keeps later waiters registered when an earlier waiter times out', async () => {
+    vi.useFakeTimers();
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const waiters = (client as unknown as {
+      diagnosticWaiters: Map<string, Array<() => void>>;
+    }).diagnosticWaiters;
+
+    try {
+      const first = client.waitForDiagnostics('/tmp/a.ts', 10);
+      const second = client.waitForDiagnostics('/tmp/a.ts', 100);
+
+      await vi.advanceTimersByTimeAsync(10);
+      await first;
+      expect(Array.from(waiters.values())[0]).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(90);
+      await second;
+      expect(waiters.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects waiters when the transport fails', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const waiting = client.waitForDiagnostics('/tmp/a.ts', 1_000);
+    const rejection = expect(waiting).rejects.toThrow('transport failed');
+
+    (client as unknown as { handleTransportFailure: (error: Error) => void })
+      .handleTransportFailure(new Error('transport failed'));
+
+    await rejection;
+  });
+
+  it('rejects diagnostic waits started after terminal transport failure', async () => {
+    const client = new LspClient('/tmp', SERVER_CONFIG);
+    const state = client as unknown as {
+      documentOpenPromises: Map<string, Promise<void>>;
+      documentOperationTails: Map<string, Promise<void>>;
+      diagnostics: Map<string, unknown[]>;
+      buffer: Buffer;
+      handleTransportFailure: (error: Error) => void;
+    };
+    state.documentOpenPromises.set('file:///tmp/a.ts', Promise.resolve());
+    state.documentOperationTails.set('file:///tmp/a.ts', Promise.resolve());
+    state.diagnostics.set('file:///tmp/a.ts', []);
+    state.buffer = Buffer.from('partial frame');
+    state.handleTransportFailure(new Error('terminal transport failure'));
+
+    await expect(client.waitForDiagnostics('/tmp/a.ts', 10)).rejects.toThrow('terminal transport failure');
+    expect(state.documentOpenPromises.size).toBe(0);
+    expect(state.documentOperationTails.size).toBe(0);
+    expect(state.diagnostics.size).toBe(0);
+    expect(state.buffer).toHaveLength(0);
+  });
+});

--- a/src/tools/lsp/__tests__/client-handle-data.test.ts
+++ b/src/tools/lsp/__tests__/client-handle-data.test.ts
@@ -192,7 +192,7 @@ describe('LspClient handleData byte-length fix (#1026)', () => {
     expect(resolve).toHaveBeenCalledWith('recovered');
   });
 
-  it('replies to registration requests with the exact error and preserves string, zero, and empty IDs', () => {
+  it('replies to registration requests with the exact error and preserves string, zero, and empty IDs', async () => {
     const client = new LspClient('/tmp/ws', SERVER_CONFIG);
     const writes = setupWritableClient(client);
 
@@ -203,6 +203,8 @@ describe('LspClient handleData byte-length fix (#1026)', () => {
         method: 'client/registerCapability',
       })));
     }
+
+    await vi.waitFor(() => expect(writes).toHaveLength(3));
 
     expect(writes.map(decodeLspMessage)).toEqual([
       {
@@ -223,7 +225,7 @@ describe('LspClient handleData byte-length fix (#1026)', () => {
     ]);
   });
 
-  it('replies to unknown server requests with Method not found', () => {
+  it('replies to unknown server requests with Method not found', async () => {
     const client = new LspClient('/tmp/ws', SERVER_CONFIG);
     const writes = setupWritableClient(client);
 
@@ -233,6 +235,7 @@ describe('LspClient handleData byte-length fix (#1026)', () => {
       method: 'window/showMessageRequest',
     })));
 
+    await vi.waitFor(() => expect(writes).toHaveLength(1));
     expect(writes).toHaveLength(1);
     expect(decodeLspMessage(writes[0])).toEqual({
       jsonrpc: '2.0',
@@ -363,6 +366,7 @@ describe('LspClient handleData byte-length fix (#1026)', () => {
     let resolved = false;
     request.then(() => { resolved = true; });
 
+    await vi.waitFor(() => expect(writes).toHaveLength(4));
     expect(writes).toHaveLength(4);
     expect(decodeLspMessage(writes[2])).toEqual({
       jsonrpc: '2.0',

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -169,13 +169,22 @@ export class LspClient {
     timeout: NodeJS.Timeout;
   }>();
   private buffer = Buffer.alloc(0);
+  private notificationTail: Promise<void> = Promise.resolve();
+  private notificationGeneration = 0;
+  private notificationWaiterRejectors = new Set<(error: Error) => void>();
   private openDocuments = new Set<string>();
+  private persistentDocuments = new Set<string>();
+  private documentOpenPromises = new Map<string, Promise<void>>();
+  private documentOperationTails = new Map<string, Promise<void>>();
   private diagnostics = new Map<string, Diagnostic[]>();
-  private diagnosticWaiters = new Map<string, Array<() => void>>();
+  private diagnosticWaiters = new Map<string, Array<(error?: Error) => void>>();
   private workspaceRoot: string;
   private serverConfig: LspServerConfig;
   private devContainerContext: DevContainerContext | null;
   private initialized = false;
+  private disconnected = false;
+  private connectionGeneration = 0;
+  private terminalError: Error | null = null;
   private _serverCapabilities: Record<string, unknown> | null = null;
   private _supportsPullDiagnostics = false;
 
@@ -192,6 +201,18 @@ export class LspClient {
     if (this.process) {
       return; // Already connected
     }
+    this.disconnected = false;
+    this.terminalError = null;
+    const connectionGeneration = ++this.connectionGeneration;
+    this.buffer = Buffer.alloc(0);
+    this.openDocuments.clear();
+    this.persistentDocuments.clear();
+    this.documentOpenPromises.clear();
+    this.documentOperationTails.clear();
+    this.diagnostics.clear();
+    this.buffer = Buffer.alloc(0);
+    this.documentOperationTails.clear();
+    this.diagnostics.clear();
 
     const spawnCommand = this.devContainerContext ? 'docker' : this.serverConfig.command;
 
@@ -218,37 +239,69 @@ export class LspClient {
         stdio: ['pipe', 'pipe', 'pipe'],
         shell: !this.devContainerContext && process.platform === 'win32'
       });
+      const child = this.process;
 
-      this.process.stdout?.on('data', (data: Buffer) => {
+      child.stdout?.on('data', (data: Buffer) => {
+        if (this.process !== child || this.connectionGeneration !== connectionGeneration) return;
         this.handleData(data);
       });
 
-      this.process.stderr?.on('data', (data: Buffer) => {
+      child.stderr?.on('data', (data: Buffer) => {
+        if (this.process !== child || this.connectionGeneration !== connectionGeneration) return;
         // Log stderr for debugging but don't fail
         console.error(`LSP stderr: ${data.toString()}`);
       });
 
-      this.process.on('error', (error) => {
+      const stdin = child.stdin;
+      if (stdin && typeof stdin.on === 'function') {
+        stdin.on('error', (error: Error) => {
+          if (this.process !== child || this.connectionGeneration !== connectionGeneration) return;
+          this.handleTransportFailure(error);
+        });
+        stdin.on('close', () => {
+          if (this.process === child && this.connectionGeneration === connectionGeneration && !this.disconnected) {
+            this.handleTransportFailure(new Error('LSP stdin closed'));
+          }
+        });
+      }
+
+      child.on('error', (error) => {
+        if (this.process !== child || this.connectionGeneration !== connectionGeneration) return;
+        this.handleTransportFailure(error);
         reject(new Error(`Failed to start LSP server: ${error.message}`));
       });
 
-      this.process.on('exit', (code) => {
+      child.on('exit', (code) => {
+        if (this.process !== child || this.connectionGeneration !== connectionGeneration) return;
         this.process = null;
-        this.initialized = false;
+        this.handleTransportFailure(new Error(`LSP server exited (code ${code})`));
         if (code !== 0) {
           console.error(`LSP server exited with code ${code}`);
         }
-        // Reject all pending requests to avoid unresolved promises
-        this.rejectPendingRequests(new Error(`LSP server exited (code ${code})`));
       });
 
       // Send initialize request
       this.initialize()
         .then(() => {
+          if (this.process !== child || this.connectionGeneration !== connectionGeneration) {
+            reject(new Error('LSP server was replaced during initialization'));
+            return;
+          }
           this.initialized = true;
           resolve();
         })
-        .catch(reject);
+        .catch(error => {
+          if (this.process === child && this.connectionGeneration === connectionGeneration) {
+            this.forceKill();
+          } else {
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              // Ignore cleanup failures for a retired child.
+            }
+          }
+          reject(error);
+        });
     });
   }
 
@@ -257,6 +310,12 @@ export class LspClient {
    * Used in process exit handlers where async operations are not possible.
    */
   forceKill(): void {
+    const error = new Error('LSP client force-killed');
+    this.connectionGeneration++;
+    this.terminalError = error;
+    this.cancelPendingNotificationWrites(error);
+    this.rejectPendingRequests(error);
+    this.disconnected = true;
     if (this.process) {
       try {
         this.process.kill('SIGKILL');
@@ -265,41 +324,65 @@ export class LspClient {
       }
       this.process = null;
       this.initialized = false;
-      // Wake diagnostic waiters to prevent resource leaks
-      for (const waiters of this.diagnosticWaiters.values()) {
-        for (const wake of waiters) wake();
-      }
-      this.diagnosticWaiters.clear();
     }
+    this.cancelDiagnosticWaiters(error);
+    this.openDocuments.clear();
+    this.persistentDocuments.clear();
+    this.documentOpenPromises.clear();
+    this.documentOperationTails.clear();
+    this.diagnostics.clear();
+    this.buffer = Buffer.alloc(0);
   }
 
   /**
    * Disconnect from the LSP server
    */
   async disconnect(): Promise<void> {
-    if (!this.process) return;
-
+    const child = this.process;
+    const connectionGeneration = this.connectionGeneration;
     try {
-      // Short timeout for graceful shutdown — don't block forever
-      await this.request('shutdown', null, 3000);
-      this.notify('exit', null);
+      if (child && this.process === child && this.connectionGeneration === connectionGeneration) {
+        // Short timeout for graceful shutdown — don't block forever
+        await this.request('shutdown', null, 3000);
+        if (this.process === child && this.connectionGeneration === connectionGeneration) {
+          await Promise.race([
+            this.notifyWithBackpressure('exit', null),
+            new Promise<void>(resolveTimeout => setTimeout(resolveTimeout, 250))
+          ]);
+        }
+      }
     } catch {
       // Ignore errors during shutdown
     } finally {
-      // Always kill the process regardless of shutdown success
-      if (this.process) {
-        this.process.kill();
-        this.process = null;
+      if (this.process !== child || this.connectionGeneration !== connectionGeneration) {
+        if (child) {
+          try {
+            child.kill();
+          } catch {
+            // Ignore cleanup failures for a retired child.
+          }
+        }
+      } else {
+        const error = new Error('LSP client disconnected');
+        this.connectionGeneration++;
+        this.terminalError = error;
+        this.cancelPendingNotificationWrites(error);
+        this.disconnected = true;
+        // Always kill the process regardless of shutdown success
+        if (child) {
+          child.kill();
+          this.process = null;
+        }
+        this.initialized = false;
+        this.rejectPendingRequests(new Error('Client disconnected'));
+        this.openDocuments.clear();
+        this.persistentDocuments.clear();
+        this.documentOpenPromises.clear();
+        this.documentOperationTails.clear();
+        this.diagnostics.clear();
+        this.buffer = Buffer.alloc(0);
+        this.cancelDiagnosticWaiters(new Error('LSP client disconnected'));
       }
-      this.initialized = false;
-      this.rejectPendingRequests(new Error('Client disconnected'));
-      this.openDocuments.clear();
-      this.diagnostics.clear();
-      // Wake all diagnostic waiters so their setTimeout closures can be GC'd
-      for (const waiters of this.diagnosticWaiters.values()) {
-        for (const wake of waiters) wake();
-      }
-      this.diagnosticWaiters.clear();
     }
   }
 
@@ -312,6 +395,60 @@ export class LspClient {
       clearTimeout(pending.timeout);
       pending.reject(error);
       this.pendingRequests.delete(id);
+    }
+  }
+
+  private handleTransportFailure(error: Error): void {
+    if (this.disconnected) return;
+    this.connectionGeneration++;
+    this.disconnected = true;
+    this.terminalError = error;
+    this.cancelPendingNotificationWrites(error);
+    this.rejectPendingRequests(error);
+    this.cancelDiagnosticWaiters(error);
+    if (this.process) {
+      try {
+        this.process.kill('SIGKILL');
+      } catch {
+        // Ignore failures while retiring a broken transport.
+      }
+      this.process = null;
+    }
+    this.initialized = false;
+    this.openDocuments.clear();
+    this.persistentDocuments.clear();
+    this.documentOpenPromises.clear();
+    this.documentOperationTails.clear();
+    this.diagnostics.clear();
+    this.buffer = Buffer.alloc(0);
+  }
+
+  private cancelDiagnosticWaiters(error: Error): void {
+    for (const waiters of this.diagnosticWaiters.values()) {
+      for (const wake of waiters) wake(error);
+    }
+    this.diagnosticWaiters.clear();
+  }
+
+  private throwIfTerminal(): void {
+    if (this.terminalError) {
+      throw this.terminalError;
+    }
+    if (this.disconnected) {
+      throw new Error('LSP client is disconnected');
+    }
+  }
+
+  private isCurrentConnection(child: ChildProcess | null, connectionGeneration: number): boolean {
+    return child !== null
+      && this.process === child
+      && this.connectionGeneration === connectionGeneration
+      && !this.disconnected;
+  }
+
+  private assertCurrentConnection(child: ChildProcess | null, connectionGeneration: number): void {
+    if (!this.isCurrentConnection(child, connectionGeneration)) {
+      throw this.terminalError ?? new Error('LSP connection was replaced');
     }
   }
 
@@ -407,7 +544,10 @@ export class LspClient {
       : { code: -32601, message: 'Method not found' };
     const response: JsonRpcErrorResponse = { jsonrpc: '2.0', id: request.id, error };
     const content = JSON.stringify(response);
-    this.process?.stdin?.write(`Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`);
+    const message = `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`;
+    void this.enqueueOutboundWrite(() => this.writeMessage(message)).catch(() => {
+      // The client teardown path already rejects pending work and closes stdin.
+    });
   }
 
   /**
@@ -460,16 +600,26 @@ export class LspClient {
         timeout: timeoutHandle
       });
 
-      this.process?.stdin?.write(message);
+      void this.enqueueOutboundWrite(() => {
+        if (!this.pendingRequests.has(id)) {
+          throw new Error(`LSP request '${method}' is no longer pending`);
+        }
+        return this.writeMessage(message);
+      }).catch(error => {
+        const pending = this.pendingRequests.get(id);
+        if (!pending) return;
+
+        clearTimeout(pending.timeout);
+        this.pendingRequests.delete(id);
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
     });
   }
 
   /**
    * Send a notification to the server (no response expected)
    */
-  private notify(method: string, params: unknown): void {
-    if (!this.process?.stdin) return;
-
+  private notify(method: string, params: unknown): boolean {
     const notification: JsonRpcNotification = {
       jsonrpc: '2.0',
       method,
@@ -478,13 +628,88 @@ export class LspClient {
 
     const content = JSON.stringify(notification);
     const message = `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`;
-    this.process.stdin.write(message);
+    return this.writeMessage(message);
+  }
+
+  private async notifyWithBackpressure(method: string, params: unknown): Promise<void> {
+    return this.enqueueOutboundWrite(() => this.notify(method, params));
+  }
+
+  private async enqueueOutboundWrite(write: () => boolean): Promise<void> {
+    const generation = this.notificationGeneration;
+    const notification = this.notificationTail.then(() => {
+      if (generation !== this.notificationGeneration) {
+        throw new Error('LSP notification cancelled before write');
+      }
+      return this.writeWithBackpressure(write);
+    });
+    this.notificationTail = notification.catch(() => undefined);
+    return notification;
+  }
+
+  private writeMessage(message: string): boolean {
+    if (!this.process?.stdin) {
+      throw new Error('LSP client is not connected');
+    }
+    try {
+      return this.process.stdin.write(message);
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      this.handleTransportFailure(failure);
+      throw failure;
+    }
+  }
+
+  private async writeWithBackpressure(write: () => boolean): Promise<void> {
+    const stdin = this.process?.stdin;
+    if (write() || !stdin) {
+      return;
+    }
+    if (typeof stdin.once !== 'function' || typeof stdin.off !== 'function') {
+      return;
+    }
+
+    await new Promise<void>((resolveDrain, rejectDrain) => {
+      const cleanup = () => {
+        stdin.off('drain', handleDrain);
+        stdin.off('error', handleError);
+        stdin.off('close', handleClose);
+        this.notificationWaiterRejectors.delete(handleCancel);
+      };
+      const handleDrain = () => {
+        cleanup();
+        resolveDrain();
+      };
+      const handleError = (error: Error) => {
+        cleanup();
+        rejectDrain(error);
+      };
+      const handleClose = () => {
+        handleError(new Error('LSP stdin closed before drain'));
+      };
+      const handleCancel = (error: Error) => {
+        handleError(error);
+      };
+      this.notificationWaiterRejectors.add(handleCancel);
+      stdin.once('drain', handleDrain);
+      stdin.once('error', handleError);
+      stdin.once('close', handleClose);
+    });
+  }
+
+  private cancelPendingNotificationWrites(error: Error): void {
+    this.notificationGeneration++;
+    for (const reject of Array.from(this.notificationWaiterRejectors)) {
+      reject(error);
+    }
   }
 
   /**
    * Initialize the LSP connection
    */
   private async initialize(): Promise<void> {
+    const child = this.process;
+    const connectionGeneration = this.connectionGeneration;
     const initResult = await this.request<{ capabilities?: Record<string, unknown> }>('initialize', {
       processId: process.pid,
       rootUri: this.getWorkspaceRootUri(),
@@ -510,10 +735,12 @@ export class LspClient {
       initializationOptions: this.serverConfig.initializationOptions || {}
     }, getLspRequestTimeout(this.serverConfig, 'initialize'));
 
+    this.assertCurrentConnection(child, connectionGeneration);
     this._serverCapabilities = initResult?.capabilities ?? null;
     this._supportsPullDiagnostics = !!this._serverCapabilities?.diagnosticProvider;
 
-    this.notify('initialized', {});
+    await this.notifyWithBackpressure('initialized', {});
+    this.assertCurrentConnection(child, connectionGeneration);
   }
 
   /**
@@ -521,9 +748,34 @@ export class LspClient {
    */
   async openDocument(filePath: string): Promise<void> {
     const hostUri = fileUri(filePath);
-    const uri = this.toServerUri(hostUri);
+    await this.queueDocumentOperation(hostUri, async () => {
+      await this.ensureDocumentOpen(filePath);
+      this.persistentDocuments.add(hostUri);
+    });
+  }
+
+  private async ensureDocumentOpen(filePath: string): Promise<void> {
+    const hostUri = fileUri(filePath);
 
     if (this.openDocuments.has(hostUri)) return;
+
+    const pending = this.documentOpenPromises.get(hostUri);
+    if (pending) return pending;
+
+    const opening = this.performDocumentOpen(filePath, hostUri).finally(() => {
+      if (this.documentOpenPromises.get(hostUri) === opening) {
+        this.documentOpenPromises.delete(hostUri);
+      }
+    });
+    this.documentOpenPromises.set(hostUri, opening);
+    return opening;
+  }
+
+  private async performDocumentOpen(filePath: string, hostUri: string): Promise<void> {
+    this.throwIfTerminal();
+    const child = this.process;
+    const connectionGeneration = this.connectionGeneration;
+    const uri = this.toServerUri(hostUri);
 
     if (!existsSync(filePath)) {
       throw new Error(`File not found: ${filePath}`);
@@ -532,7 +784,11 @@ export class LspClient {
     const content = readFileSync(filePath, 'utf-8');
     const languageId = this.getLanguageId(filePath);
 
-    this.notify('textDocument/didOpen', {
+    // A reopened document needs fresh diagnostics rather than a cached result
+    // from its previous didOpen/didClose lifecycle.
+    this.diagnostics.delete(hostUri);
+
+    await this.notifyWithBackpressure('textDocument/didOpen', {
       textDocument: {
         uri,
         languageId,
@@ -541,26 +797,89 @@ export class LspClient {
       }
     });
 
+    this.assertCurrentConnection(child, connectionGeneration);
     this.openDocuments.add(hostUri);
 
     // Wait a bit for the server to process the document
     await new Promise(resolve => setTimeout(resolve, 100));
+    this.assertCurrentConnection(child, connectionGeneration);
+    this.throwIfTerminal();
   }
 
   /**
    * Close a document
    */
-  closeDocument(filePath: string): void {
+  async closeDocument(filePath: string): Promise<void> {
+    const hostUri = fileUri(filePath);
+    await this.queueDocumentOperation(hostUri, async () => {
+      this.persistentDocuments.delete(hostUri);
+      await this.closeTransientDocument(filePath);
+    });
+  }
+
+  private async closeTransientDocument(filePath: string): Promise<void> {
     const hostUri = fileUri(filePath);
     const uri = this.toServerUri(hostUri);
+    const child = this.process;
+    const connectionGeneration = this.connectionGeneration;
 
     if (!this.openDocuments.has(hostUri)) return;
 
-    this.notify('textDocument/didClose', {
-      textDocument: { uri }
-    });
+    try {
+      await this.notifyWithBackpressure('textDocument/didClose', {
+        textDocument: { uri }
+      });
+    } finally {
+      if (this.isCurrentConnection(child, connectionGeneration)) {
+        this.openDocuments.delete(hostUri);
+      }
+    }
+  }
 
-    this.openDocuments.delete(hostUri);
+  /**
+   * Run an operation while a document is open, closing only documents opened
+   * by this operation. Calls for the same document are serialized so one
+   * operation cannot close the document while another is still using it.
+   */
+  async withOpenDocument<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+    const hostUri = fileUri(filePath);
+    const connectionGeneration = this.connectionGeneration;
+    return this.queueDocumentOperation(hostUri, async () => {
+      try {
+        await this.ensureDocumentOpen(filePath);
+        return await operation();
+      } finally {
+        if (this.connectionGeneration === connectionGeneration && !this.persistentDocuments.has(hostUri)) {
+          await this.closeTransientDocument(filePath);
+        }
+      }
+    });
+  }
+
+  private async queueDocumentOperation<T>(hostUri: string, operation: () => Promise<T>): Promise<T> {
+    const connectionGeneration = this.connectionGeneration;
+    const previous = this.documentOperationTails.get(hostUri) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolveCurrent) => {
+      release = resolveCurrent;
+    });
+    const tail = previous.catch(() => undefined).then(() => current);
+    this.documentOperationTails.set(hostUri, tail);
+
+    await previous.catch(() => undefined);
+
+    try {
+      if (this.connectionGeneration !== connectionGeneration) {
+        throw this.terminalError ?? new Error('LSP connection was replaced');
+      }
+      this.throwIfTerminal();
+      return await operation();
+    } finally {
+      release();
+      if (this.documentOperationTails.get(hostUri) === tail) {
+        this.documentOperationTails.delete(hostUri);
+      }
+    }
   }
 
   /**
@@ -693,6 +1012,10 @@ export class LspClient {
     return this._supportsPullDiagnostics;
   }
 
+  get isUsable(): boolean {
+    return !this.disconnected;
+  }
+
   /**
    * Request diagnostics via the LSP 3.17 pull model (textDocument/diagnostic).
    * Only call when supportsPullDiagnostics is true.
@@ -720,31 +1043,52 @@ export class LspClient {
    */
   waitForDiagnostics(filePath: string, timeoutMs = 2000): Promise<void> {
     const uri = fileUri(filePath);
+    try {
+      this.throwIfTerminal();
+    } catch (error) {
+      return Promise.reject(error);
+    }
 
     // If diagnostics are already present, resolve immediately.
     if (this.diagnostics.has(uri)) {
       return Promise.resolve();
     }
 
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       let resolved = false;
+      const removeWaiter = (waiter: (error?: Error) => void) => {
+        const waiters = this.diagnosticWaiters.get(uri);
+        if (!waiters) return;
+
+        const remaining = waiters.filter(candidate => candidate !== waiter);
+        if (remaining.length === 0) {
+          this.diagnosticWaiters.delete(uri);
+        } else {
+          this.diagnosticWaiters.set(uri, remaining);
+        }
+      };
+      const waiter = (error?: Error) => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timer);
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        }
+      };
       const timer = setTimeout(() => {
         if (!resolved) {
           resolved = true;
-          this.diagnosticWaiters.delete(uri);
+          removeWaiter(waiter);
           resolve();
         }
       }, timeoutMs);
 
       // Store the resolver so handleNotification can wake it up.
       const existing = this.diagnosticWaiters.get(uri) || [];
-      existing.push(() => {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timer);
-          resolve();
-        }
-      });
+      existing.push(waiter);
       this.diagnosticWaiters.set(uri, existing);
     });
   }
@@ -859,6 +1203,9 @@ export const IDLE_CHECK_INTERVAL_MS = readPositiveIntEnv('OMC_LSP_IDLE_CHECK_INT
  */
 export class LspClientManager {
   private clients = new Map<string, LspClient>();
+  private pendingClients = new Map<string, { client: LspClient; promise: Promise<LspClient> }>();
+  private clientGeneration = 0;
+  private disconnecting: Promise<void> | null = null;
   private lastUsed = new Map<string, number>();
   private inFlightCount = new Map<string, number>();
   private idleDeadlines = new Map<string, ReturnType<typeof setTimeout>>();
@@ -891,7 +1238,16 @@ export class LspClientManager {
           // Ignore errors during cleanup
         }
       }
+      for (const { client } of this.pendingClients.values()) {
+        try {
+          client.forceKill();
+        } catch {
+          // Ignore errors during cleanup
+        }
+      }
+      this.clientGeneration++;
       this.clients.clear();
+      this.pendingClients.clear();
       this.lastUsed.clear();
       this.inFlightCount.clear();
     };
@@ -919,20 +1275,12 @@ export class LspClientManager {
     const devContainerContext = resolveDevContainerContext(workspaceRoot);
     const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
 
-    let client = this.clients.get(key);
-    if (!client) {
-      client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
-      try {
-        await client.connect();
-        this.clients.set(key, client);
-      } catch (error) {
-        throw error;
+    while (true) {
+      const client = await this.acquireClient(key, workspaceRoot, serverConfig, devContainerContext);
+      if (this.clients.get(key) === client && client.isUsable && !this.disconnecting) {
+        return client;
       }
     }
-
-    this.touchClient(key);
-
-    return client;
   }
 
   /**
@@ -950,32 +1298,118 @@ export class LspClientManager {
     const devContainerContext = resolveDevContainerContext(workspaceRoot);
     const key = `${workspaceRoot}:${serverConfig.command}:${devContainerContext?.containerId ?? 'host'}`;
 
-    let client = this.clients.get(key);
-    if (!client) {
-      client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
-      try {
-        await client.connect();
-        this.clients.set(key, client);
-      } catch (error) {
-        throw error;
-      }
-    }
-
-    // Touch timestamp and increment in-flight counter
-    this.touchClient(key);
-    this.inFlightCount.set(key, (this.inFlightCount.get(key) || 0) + 1);
+    const client = await this.acquireClientLease(key, workspaceRoot, serverConfig, devContainerContext);
 
     try {
       return await fn(client);
     } finally {
-      // Decrement in-flight counter and refresh timestamp
-      const count = (this.inFlightCount.get(key) || 1) - 1;
-      if (count <= 0) {
-        this.inFlightCount.delete(key);
-      } else {
-        this.inFlightCount.set(key, count);
+      // A replaced or detached client must not mutate the replacement's lease count.
+      if (this.clients.get(key) === client) {
+        const count = (this.inFlightCount.get(key) || 1) - 1;
+        if (count <= 0) {
+          this.inFlightCount.delete(key);
+        } else {
+          this.inFlightCount.set(key, count);
+        }
+        this.touchClient(key);
       }
-      this.touchClient(key);
+    }
+  }
+
+  private async getOrCreateClient(
+    key: string,
+    workspaceRoot: string,
+    serverConfig: LspServerConfig,
+    devContainerContext: DevContainerContext | null
+  ): Promise<LspClient> {
+    const existing = this.clients.get(key);
+    if (existing?.isUsable) {
+      return existing;
+    }
+    if (existing) {
+      existing.forceKill();
+      this.clients.delete(key);
+      this.clearIdleDeadline(key);
+      this.lastUsed.delete(key);
+      this.inFlightCount.delete(key);
+    }
+
+    let pending = this.pendingClients.get(key);
+    if (!pending) {
+      const client = new LspClient(workspaceRoot, serverConfig, devContainerContext);
+      const generation = this.clientGeneration;
+      const promise = client.connect().then(() => {
+        if (generation !== this.clientGeneration) {
+          client.forceKill();
+          throw new Error('LSP client manager shut down during connection');
+        }
+        this.clients.set(key, client);
+        return client;
+      }).finally(() => {
+        if (this.pendingClients.get(key)?.client === client) {
+          this.pendingClients.delete(key);
+        }
+      });
+      pending = { client, promise };
+      this.pendingClients.set(key, pending);
+    }
+
+    return pending.promise;
+  }
+
+  private async acquireClient(
+    key: string,
+    workspaceRoot: string,
+    serverConfig: LspServerConfig,
+    devContainerContext: DevContainerContext | null
+  ): Promise<LspClient> {
+    while (true) {
+      const teardown = this.disconnecting;
+      if (teardown) {
+        await teardown;
+      }
+
+      const generation = this.clientGeneration;
+      this.startIdleCheck();
+      const existing = this.clients.get(key);
+      if (existing?.isUsable) {
+        this.touchClient(key);
+        return existing;
+      }
+      const client = await this.getOrCreateClient(key, workspaceRoot, serverConfig, devContainerContext);
+      if (generation === this.clientGeneration && !this.disconnecting && client.isUsable) {
+        this.touchClient(key);
+        return client;
+      }
+    }
+  }
+
+  private async acquireClientLease(
+    key: string,
+    workspaceRoot: string,
+    serverConfig: LspServerConfig,
+    devContainerContext: DevContainerContext | null
+  ): Promise<LspClient> {
+    while (true) {
+      const teardown = this.disconnecting;
+      if (teardown) {
+        await teardown;
+      }
+
+      const generation = this.clientGeneration;
+      this.startIdleCheck();
+      const existing = this.clients.get(key);
+      if (existing?.isUsable) {
+        this.touchClient(key);
+        this.inFlightCount.set(key, (this.inFlightCount.get(key) || 0) + 1);
+        return existing;
+      }
+      const client = await this.getOrCreateClient(key, workspaceRoot, serverConfig, devContainerContext);
+      if (generation === this.clientGeneration && !this.disconnecting && client.isUsable) {
+        this.touchClient(key);
+        this.inFlightCount.set(key, (this.inFlightCount.get(key) || 0) + 1);
+        return client;
+      }
     }
   }
 
@@ -1105,6 +1539,23 @@ export class LspClientManager {
    * Maps are always cleared regardless of individual disconnect failures.
    */
   async disconnectAll(): Promise<void> {
+    if (this.disconnecting) {
+      return this.disconnecting;
+    }
+
+    const teardown = Promise.resolve().then(() => this.performDisconnectAll());
+    this.disconnecting = teardown;
+    try {
+      await teardown;
+    } finally {
+      if (this.disconnecting === teardown) {
+        this.disconnecting = null;
+      }
+    }
+  }
+
+  private async performDisconnectAll(): Promise<void> {
+    this.clientGeneration++;
     if (this.idleTimer) {
       clearInterval(this.idleTimer);
       this.idleTimer = null;
@@ -1115,7 +1566,19 @@ export class LspClientManager {
     }
     this.idleDeadlines.clear();
 
+    for (const { client } of this.pendingClients.values()) {
+      try {
+        client.forceKill();
+      } catch {
+        // Ignore errors while stopping clients that are still connecting
+      }
+    }
+    this.pendingClients.clear();
+
     const entries = Array.from(this.clients.entries());
+    this.clients.clear();
+    this.lastUsed.clear();
+    this.inFlightCount.clear();
     const results = await Promise.allSettled(
       entries.map(([, client]) => client.disconnect())
     );
@@ -1129,10 +1592,8 @@ export class LspClientManager {
       }
     }
 
-    // Always clear maps regardless of individual failures
-    this.clients.clear();
-    this.lastUsed.clear();
-    this.inFlightCount.clear();
+    // Pending clients from the prior generation cannot publish.
+    this.pendingClients.clear();
   }
 
   /** Expose in-flight count for testing */

--- a/src/tools/lsp/client.ts
+++ b/src/tools/lsp/client.ts
@@ -50,6 +50,14 @@ function fileUri(filePath: string): string {
   return pathToFileURL(resolve(filePath)).href;
 }
 
+function createCancellationSignal(): { promise: Promise<void>; cancel: () => void } {
+  let cancel!: () => void;
+  const promise = new Promise<void>((resolveCancellation) => {
+    cancel = resolveCancellation;
+  });
+  return { promise, cancel };
+}
+
 // LSP Protocol Types
 export interface Position {
   line: number;
@@ -176,6 +184,7 @@ export class LspClient {
   private persistentDocuments = new Set<string>();
   private documentOpenPromises = new Map<string, Promise<void>>();
   private documentOperationTails = new Map<string, Promise<void>>();
+  private documentQueueCancellation = createCancellationSignal();
   private diagnostics = new Map<string, Diagnostic[]>();
   private diagnosticWaiters = new Map<string, Array<(error?: Error) => void>>();
   private workspaceRoot: string;
@@ -204,6 +213,8 @@ export class LspClient {
     this.disconnected = false;
     this.terminalError = null;
     const connectionGeneration = ++this.connectionGeneration;
+    this.documentQueueCancellation.cancel();
+    this.documentQueueCancellation = createCancellationSignal();
     this.buffer = Buffer.alloc(0);
     this.openDocuments.clear();
     this.persistentDocuments.clear();
@@ -312,6 +323,7 @@ export class LspClient {
   forceKill(): void {
     const error = new Error('LSP client force-killed');
     this.connectionGeneration++;
+    this.documentQueueCancellation.cancel();
     this.terminalError = error;
     this.cancelPendingNotificationWrites(error);
     this.rejectPendingRequests(error);
@@ -365,6 +377,7 @@ export class LspClient {
       } else {
         const error = new Error('LSP client disconnected');
         this.connectionGeneration++;
+        this.documentQueueCancellation.cancel();
         this.terminalError = error;
         this.cancelPendingNotificationWrites(error);
         this.disconnected = true;
@@ -401,6 +414,7 @@ export class LspClient {
   private handleTransportFailure(error: Error): void {
     if (this.disconnected) return;
     this.connectionGeneration++;
+    this.documentQueueCancellation.cancel();
     this.disconnected = true;
     this.terminalError = error;
     this.cancelPendingNotificationWrites(error);
@@ -858,6 +872,7 @@ export class LspClient {
 
   private async queueDocumentOperation<T>(hostUri: string, operation: () => Promise<T>): Promise<T> {
     const connectionGeneration = this.connectionGeneration;
+    const cancellation = this.documentQueueCancellation.promise;
     const previous = this.documentOperationTails.get(hostUri) ?? Promise.resolve();
     let release!: () => void;
     const current = new Promise<void>((resolveCurrent) => {
@@ -866,10 +881,13 @@ export class LspClient {
     const tail = previous.catch(() => undefined).then(() => current);
     this.documentOperationTails.set(hostUri, tail);
 
-    await previous.catch(() => undefined);
+    const predecessorCompleted = await Promise.race([
+      previous.then(() => true, () => true),
+      cancellation.then(() => false)
+    ]);
 
     try {
-      if (this.connectionGeneration !== connectionGeneration) {
+      if (!predecessorCompleted || this.connectionGeneration !== connectionGeneration) {
         throw this.terminalError ?? new Error('LSP connection was replaced');
       }
       this.throwIfTerminal();


### PR DESCRIPTION
Fixes #3924.

## What changed
- run directory LSP diagnostics through a fixed 8-worker pool while preserving input/result order
- pair transient `didOpen`/`didClose` lifecycles on success and rejection paths
- serialize same-document transient operations and preserve direct/persistent document ownership
- honor LSP stdin back-pressure for document opens
- singleflight concurrent client/document startup and prevent post-shutdown client resurrection
- isolate concurrent diagnostic waiters

## Deterministic evidence
Exact base: `369caf12f29ce9f15a5fcb77d32a8cdfa53f980d`
Exact head: `841f5fe95ed59cf8877bf40c8d5f4a78cc375eda`

Synthetic 12-file probe, 25 ms diagnostic delay per file:
- before: 306.50 ms total, 25.54 ms/file, max concurrency 1
- after: 53.38 ms total, 4.45 ms/file effective, max concurrency 8
- lifecycle probe after: 2 opens / 2 closes, including a rejected wait path

## Verification
- `npx vitest run src/tools/diagnostics src/tools/lsp/__tests__ --reporter=dot` — 11 files, 66 tests passed
- `npx tsc --noEmit --incremental false` — passed
- `npm run lint` — 0 errors; 28 pre-existing warnings outside the changed files
- `npm run generate:inventory && npm run generate:inventory:verify` — regenerated and verified
- full local suite: 13,601 passed; 17 unrelated failures in session-end timing/state and a Python 1s subprocess timeout while the live OMC lane was active; exact-head hosted CI is the release gate

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*