### PR TITLE
perf(session-search): bound retained matches

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "ebca8465feb6ab22674900b14827eb83ddebc8e5",
-    "sourceSha256": "a10cd89145912171fd1391b28af8a572d29dfabf134bf388a89d15f023da3755",
+    "head": "afd7c36ab3b85fadd41568e44ede97b5721024d4",
+    "sourceSha256": "c459a96d8d6b1b5d95e97d89455e28a872c4aaeb6cff54aefbb28137a7856264",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "ebca8465feb6ab22674900b14827eb83ddebc8e5",
-  "sourceSha256": "a10cd89145912171fd1391b28af8a572d29dfabf134bf388a89d15f023da3755",
+  "head": "afd7c36ab3b85fadd41568e44ede97b5721024d4",
+  "sourceSha256": "c459a96d8d6b1b5d95e97d89455e28a872c4aaeb6cff54aefbb28137a7856264",
   "counts": {
     "public": {
       "skills": 35,
@@ -76747,5 +76747,5 @@
     }
   },
   "inventorySha256": "4283f8f695d63821b3b3d94c9f54a71dd69a336e3944c8816a8c3a2f000e33ec",
-  "manifestSha256": "4d05086f86c8ec86bffe2aa8aea2394fd755a91db19f3b98598ec952abd8ab8b"
+  "manifestSha256": "8411a1b2e6cc3685f69d114de58be280f394e35d29334aa7951e06acb50180b1"
 }

--- a/src/__tests__/session-history-search.test.ts
+++ b/src/__tests__/session-history-search.test.ts
@@ -3,11 +3,14 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { basename, join } from 'path';
 import {
+  __testingCreateMatchRetainer,
   __testingIsWithinProject,
   encodeProjectPath,
   parseSinceSpec,
   searchSessionHistory,
 } from '../features/session-history-search/index.js';
+
+type SessionHistoryMatch = Awaited<ReturnType<typeof searchSessionHistory>>['results'][number];
 
 function writeTranscript(filePath: string, entries: Array<Record<string, unknown>>): void {
   mkdirSync(join(filePath, '..'), { recursive: true });
@@ -16,6 +19,26 @@ function writeTranscript(filePath: string, entries: Array<Record<string, unknown
 
 function normalizePathForAssert(path: string): string {
   return path.replace(/\\/g, '/');
+}
+
+function syntheticMatch(id: string, timestamp: string | undefined, sourcePath: string): SessionHistoryMatch {
+  return {
+    sessionId: id,
+    timestamp,
+    sourcePath,
+    sourceType: 'project-transcript',
+    line: 1,
+    excerpt: id,
+  };
+}
+
+function compareExpectedMatches(a: SessionHistoryMatch, b: SessionHistoryMatch): number {
+  const parsedATime = a.timestamp ? Date.parse(a.timestamp) : 0;
+  const parsedBTime = b.timestamp ? Date.parse(b.timestamp) : 0;
+  const aTime = Number.isFinite(parsedATime) ? parsedATime : 0;
+  const bTime = Number.isFinite(parsedBTime) ? parsedBTime : 0;
+  if (aTime !== bTime) return bTime - aTime;
+  return a.sourcePath.localeCompare(b.sourcePath);
 }
 
 describe('session history search', () => {
@@ -164,6 +187,86 @@ describe('session history search', () => {
     expect(report.totalMatches).toBe(3);
     expect(report.results).toHaveLength(1);
     expect(report.results[0].sessionId).toBe('session-current');
+  });
+
+  it('bounds retained matches while counting every match', () => {
+    const limit = 10;
+    const matchCount = 80_000;
+    const retainer = __testingCreateMatchRetainer(limit);
+    let maxRetained = 0;
+
+    for (let index = 0; index < matchCount; index += 1) {
+      retainer.add(syntheticMatch(
+        `session-${index}`,
+        new Date(Date.UTC(2026, 0, 1) + index * 1_000).toISOString(),
+        '/synthetic/session.jsonl',
+      ));
+      maxRetained = Math.max(maxRetained, retainer.retained.length);
+    }
+
+    expect(maxRetained).toBe(limit);
+    expect(retainer.retained).toHaveLength(limit);
+    expect(retainer.totalMatches).toBe(matchCount);
+  });
+
+  it('matches the legacy sorted prefix for ties and cross-file timestamps', () => {
+    const limit = 5;
+    const matches = [
+      syntheticMatch('encounter-0', '2026-03-01T00:00:00.000Z', '/synthetic/z.jsonl'),
+      syntheticMatch('encounter-1', '2026-03-03T00:00:00.000Z', '/synthetic/b.jsonl'),
+      syntheticMatch('encounter-2', '2026-03-03T00:00:00.000Z', '/synthetic/a.jsonl'),
+      syntheticMatch('encounter-3', '2026-03-03T00:00:00.000Z', '/synthetic/a.jsonl'),
+      syntheticMatch('encounter-4', undefined, '/synthetic/c.jsonl'),
+      syntheticMatch('encounter-5', '2026-03-02T00:00:00.000Z', '/synthetic/c.jsonl'),
+      syntheticMatch('encounter-6', '2026-03-01T00:00:00.000Z', '/synthetic/a.jsonl'),
+    ];
+    const expected = [...matches].sort(compareExpectedMatches).slice(0, limit);
+    const retainer = __testingCreateMatchRetainer(limit);
+
+    for (const match of matches) {
+      retainer.add(match);
+    }
+
+    expect(retainer.retained).toEqual(expected);
+    expect(retainer.totalMatches).toBe(matches.length);
+  });
+
+  it('orders invalid timestamps with the existing missing-timestamp fallback', () => {
+    const matches = [
+      syntheticMatch('encounter-0', undefined, '/synthetic/a.jsonl'),
+      syntheticMatch('encounter-1', undefined, '/synthetic/b.jsonl'),
+      syntheticMatch('encounter-2', 'not-a-timestamp', '/synthetic/a.jsonl'),
+      syntheticMatch('encounter-3', undefined, '/synthetic/b.jsonl'),
+      syntheticMatch('encounter-4', undefined, '/synthetic/a.jsonl'),
+      syntheticMatch('encounter-5', undefined, '/synthetic/b.jsonl'),
+      syntheticMatch('encounter-6', undefined, '/synthetic/a.jsonl'),
+      syntheticMatch('encounter-7', undefined, '/synthetic/b.jsonl'),
+    ];
+    const expected = [...matches].sort(compareExpectedMatches).slice(0, 2);
+    const retainer = __testingCreateMatchRetainer(2);
+
+    for (const match of matches) {
+      retainer.add(match);
+    }
+
+    expect(retainer.retained).toEqual(expected);
+    expect(retainer.totalMatches).toBe(matches.length);
+  });
+
+  it('matches Array.slice limit coercion for direct fractional limits', () => {
+    const matches = [
+      syntheticMatch('newest', '2026-03-03T00:00:00.000Z', '/synthetic/a.jsonl'),
+      syntheticMatch('middle', '2026-03-02T00:00:00.000Z', '/synthetic/a.jsonl'),
+      syntheticMatch('oldest', '2026-03-01T00:00:00.000Z', '/synthetic/a.jsonl'),
+    ];
+    const retainer = __testingCreateMatchRetainer(2.9);
+
+    for (const match of matches) {
+      retainer.add(match);
+    }
+
+    expect(retainer.retained).toEqual([...matches].sort(compareExpectedMatches).slice(0, 2.9));
+    expect(retainer.totalMatches).toBe(matches.length);
   });
 
   it('uses a ~-prefixed CLAUDE_CONFIG_DIR for transcript discovery', async () => {

--- a/src/features/session-history-search/index.ts
+++ b/src/features/session-history-search/index.ts
@@ -395,6 +395,87 @@ function buildScopeMode(project: string | undefined): 'current' | 'project' | 'a
   return 'project';
 }
 
+function compareMatches(a: SessionHistoryMatch, b: SessionHistoryMatch): number {
+  const parsedATime = a.timestamp ? Date.parse(a.timestamp) : 0;
+  const parsedBTime = b.timestamp ? Date.parse(b.timestamp) : 0;
+  // Malformed non-timestamps are outside the timestamp ordering contract. Keep
+  // them searchable with the same deterministic epoch-zero fallback as missing values.
+  const aTime = Number.isFinite(parsedATime) ? parsedATime : 0;
+  const bTime = Number.isFinite(parsedBTime) ? parsedBTime : 0;
+  if (aTime !== bTime) return bTime - aTime;
+  return a.sourcePath.localeCompare(b.sourcePath);
+}
+
+interface RankedMatch {
+  match: SessionHistoryMatch;
+  encounterOrder: number;
+}
+
+function compareRankedMatches(a: RankedMatch, b: RankedMatch): number {
+  const comparison = compareMatches(a.match, b.match);
+  return comparison || a.encounterOrder - b.encounterOrder;
+}
+
+function addToWorstFirstHeap(heap: RankedMatch[], candidate: RankedMatch, capacity: number): void {
+  if (capacity <= 0) return;
+
+  if (heap.length >= capacity) {
+    if (compareRankedMatches(candidate, heap[0]) >= 0) return;
+    heap[0] = candidate;
+    let index = 0;
+    while (true) {
+      const left = index * 2 + 1;
+      const right = left + 1;
+      let worst = index;
+      if (left < heap.length && compareRankedMatches(heap[left], heap[worst]) > 0) worst = left;
+      if (right < heap.length && compareRankedMatches(heap[right], heap[worst]) > 0) worst = right;
+      if (worst === index) break;
+      [heap[index], heap[worst]] = [heap[worst], heap[index]];
+      index = worst;
+    }
+    return;
+  }
+
+  heap.push(candidate);
+  let index = heap.length - 1;
+  while (index > 0) {
+    const parent = Math.floor((index - 1) / 2);
+    if (compareRankedMatches(heap[parent], heap[index]) >= 0) break;
+    [heap[parent], heap[index]] = [heap[index], heap[parent]];
+    index = parent;
+  }
+}
+
+interface MatchRetainer {
+  add(match: SessionHistoryMatch): void;
+  readonly retained: SessionHistoryMatch[];
+  readonly totalMatches: number;
+}
+
+function createMatchRetainer(limit: number): MatchRetainer {
+  const maxMatches = Number.isNaN(limit) ? 0 : Math.max(0, Math.trunc(limit));
+  const heap: RankedMatch[] = [];
+  let totalMatches = 0;
+  let encounterOrder = 0;
+
+  return {
+    add(match) {
+      totalMatches += 1;
+      const rankedMatch = { match, encounterOrder };
+      encounterOrder += 1;
+      addToWorstFirstHeap(heap, rankedMatch, maxMatches);
+    },
+    get retained() {
+      return [...heap]
+        .sort(compareRankedMatches)
+        .map((rankedMatch) => rankedMatch.match);
+    },
+    get totalMatches() {
+      return totalMatches;
+    },
+  };
+}
+
 async function collectMatchesFromFile(
   target: SearchTarget,
   options: {
@@ -405,26 +486,26 @@ async function collectMatchesFromFile(
     sessionId?: string;
     projectFilter?: string;
     projectRoots?: string[];
+    onMatch: (match: SessionHistoryMatch) => void;
   },
-): Promise<SessionHistoryMatch[]> {
-  const matches: SessionHistoryMatch[] = [];
+): Promise<void> {
   const fileMtime = existsSync(target.filePath) ? statSync(target.filePath).mtimeMs : 0;
 
   if (target.sourceType === 'omc-session-summary' && target.filePath.endsWith('.json')) {
     try {
       const payload = JSON.parse(await import('fs/promises').then((fs) => fs.readFile(target.filePath, 'utf-8')));
       const entry = buildSearchableEntry(payload as Record<string, unknown>, target.sourceType);
-      if (!entry) return [];
-      if (options.sessionId && entry.sessionId !== options.sessionId) return [];
-      if (options.projectRoots && options.projectRoots.length > 0 && !isWithinProject(entry.projectPath, options.projectRoots)) return [];
-      if (!matchesProjectFilter(entry.projectPath, options.projectFilter)) return [];
+      if (!entry) return;
+      if (options.sessionId && entry.sessionId !== options.sessionId) return;
+      if (options.projectRoots && options.projectRoots.length > 0 && !isWithinProject(entry.projectPath, options.projectRoots)) return;
+      if (!matchesProjectFilter(entry.projectPath, options.projectFilter)) return;
       const entryEpoch = entry.timestamp ? Date.parse(entry.timestamp) : fileMtime;
-      if (options.sinceEpoch && Number.isFinite(entryEpoch) && entryEpoch < options.sinceEpoch) return [];
+      if (options.sinceEpoch && Number.isFinite(entryEpoch) && entryEpoch < options.sinceEpoch) return;
 
       for (const text of entry.texts) {
         const matchIndex = findMatchIndex(text, options.query, options.caseSensitive);
         if (matchIndex < 0) continue;
-        matches.push({
+        options.onMatch({
           sessionId: entry.sessionId,
           timestamp: entry.timestamp,
           projectPath: entry.projectPath,
@@ -438,9 +519,9 @@ async function collectMatchesFromFile(
         break;
       }
     } catch {
-      return [];
+      return;
     }
-    return matches;
+    return;
   }
 
   const stream = createReadStream(target.filePath, { encoding: 'utf-8' });
@@ -471,7 +552,7 @@ async function collectMatchesFromFile(
       for (const text of entry.texts) {
         const matchIndex = findMatchIndex(text, options.query, options.caseSensitive);
         if (matchIndex < 0) continue;
-        matches.push({
+        options.onMatch({
           sessionId: entry.sessionId,
           agentId: entry.agentId,
           timestamp: entry.timestamp,
@@ -490,8 +571,6 @@ async function collectMatchesFromFile(
     reader.close();
     stream.destroy();
   }
-
-  return matches;
 }
 
 export async function searchSessionHistory(
@@ -527,9 +606,9 @@ export async function searchSessionHistory(
     ? buildAllProjectTargets()
     : buildCurrentProjectTargets(currentProjectRoot, transcriptProjectRoots);
 
-  const allMatches: SessionHistoryMatch[] = [];
+  const matchRetainer = createMatchRetainer(limit);
   for (const target of targets) {
-    const fileMatches = await collectMatchesFromFile(target, {
+    await collectMatchesFromFile(target, {
       query,
       caseSensitive,
       contextChars,
@@ -537,16 +616,9 @@ export async function searchSessionHistory(
       sessionId: rawOptions.sessionId,
       projectFilter,
       projectRoots: scopeMode === 'current' ? currentProjectRoots : undefined,
+      onMatch: matchRetainer.add,
     });
-    allMatches.push(...fileMatches);
   }
-
-  allMatches.sort((a, b) => {
-    const aTime = a.timestamp ? Date.parse(a.timestamp) : 0;
-    const bTime = b.timestamp ? Date.parse(b.timestamp) : 0;
-    if (aTime !== bTime) return bTime - aTime;
-    return a.sourcePath.localeCompare(b.sourcePath);
-  });
 
   return {
     query,
@@ -558,12 +630,17 @@ export async function searchSessionHistory(
       caseSensitive,
     },
     searchedFiles: targets.length,
-    totalMatches: allMatches.length,
-    results: allMatches.slice(0, limit),
+    totalMatches: matchRetainer.totalMatches,
+    results: matchRetainer.retained,
   };
 }
 
-export { encodeProjectPath, isWithinProject as __testingIsWithinProject, parseSinceSpec };
+export {
+  encodeProjectPath,
+  isWithinProject as __testingIsWithinProject,
+  parseSinceSpec,
+  createMatchRetainer as __testingCreateMatchRetainer,
+};
 export type {
   SessionHistoryMatch,
   SessionHistorySearchOptions,


### PR DESCRIPTION
## Summary
- stream every session-history match through a bounded worst-first top-N heap
- retain O(limit) match objects while preserving timestamp-desc/sourcePath ordering, stable exact ties, and exact totalMatches
- add structural 80,000-match retention coverage plus ordering, invalid-timestamp boundary, and fractional-limit regressions
- regenerate and verify the canonical inventory graph

## Exact-head evidence
Head: `e528e4f40c829776952c1a6fedfe57e3bdef4d8d`
Base: `dev@369caf12f29ce9f15a5fcb77d32a8cdfa53f980d`

Deterministic 80,000-match corpus, limit 10:
- base heap delta: 141.7 MiB
- fixed heap delta: 39.4 MiB
- totalMatches: 80,000 before/after
- returned: 10 before/after
- normalized ordered-result SHA-256: `26c722b26d3348ffb4f0758e8746b7bcd226dc02ba5d3a5c8a742497ea101938` before/after
- retained structure independently observed never above 10

Malformed non-timestamp strings previously made the comparator non-total and engine-sort-dependent. They remain searchable and now explicitly use the existing missing-timestamp epoch-zero fallback; valid and missing timestamp behavior retains the stated ordering contract.

## Verification
- `npx vitest run src/__tests__/session-history-search.test.ts src/cli/__tests__/session-search.test.ts src/cli/__tests__/session-search-help.test.ts src/__tests__/standalone-server.test.ts src/__tests__/omc-tools-server.test.ts` — 48 passed
- `npx eslint src/features/session-history-search/index.ts src/__tests__/session-history-search.test.ts` — clean
- `npx tsc --noEmit` — clean
- `npm run generate:inventory && npm run generate:inventory:verify` — current
- `npx vitest run tests/lint/inventory-graph-drift.test.ts` — 11 passed
- exhaustive deterministic heap/prefix parity: 100,000 cases, zero mismatches
- full suite was also attempted: 13,583 passed; unrelated pre-existing concurrency/state tests failed outside this change surface and are listed in local evidence rather than suppressed

Closes #3925

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*