### PR TITLE
fix: memoize HUD Git top-level resolution

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "7a16db651f5f1d1e2e8d6cb298b079a917d807a4",
-    "sourceSha256": "265cce00d1dc89466fcf5ae8d2cc857b8532a324ab00767e3e8a5f2ee98f0dc1",
+    "head": "2312df264241d27772f39f67312add0e040efe87",
+    "sourceSha256": "9cebd06b5b6aa8b71f6725cb47a5df6161fe54395cb3d5e9b75b2821c8bd350e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "7a16db651f5f1d1e2e8d6cb298b079a917d807a4",
-  "sourceSha256": "265cce00d1dc89466fcf5ae8d2cc857b8532a324ab00767e3e8a5f2ee98f0dc1",
+  "head": "2312df264241d27772f39f67312add0e040efe87",
+  "sourceSha256": "9cebd06b5b6aa8b71f6725cb47a5df6161fe54395cb3d5e9b75b2821c8bd350e",
   "counts": {
     "public": {
       "skills": 35,
@@ -26,10 +26,10 @@
       "hookFiles": 295,
       "featureFiles": 69,
       "toolFiles": 61,
-      "libFiles": 37,
+      "libFiles": 38,
       "templateHooks": 21,
-      "srcFiles": 1319,
-      "total": 1340
+      "srcFiles": 1320,
+      "total": 1341
     },
     "generated": {
       "distFiles": 4955,
@@ -587,6 +587,7 @@
       "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts",
       "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
       "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
+      "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
       "src/lib/__tests__/worktree-paths.test.ts",
       "src/lib/atomic-write.ts",
       "src/lib/env-vars.ts",
@@ -38139,6 +38140,11 @@
         "path": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths.test.ts"
@@ -64551,6 +64557,41 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -76817,12 +76858,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6849,
-      "edgeCount": 7257,
-      "importEdgeCount": 5966,
+      "nodeCount": 6850,
+      "edgeCount": 7264,
+      "importEdgeCount": 5973,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "09828ef29aafe8920279970c90a291d2281be31074ba85d6224727ec4c0f6cc5",
-  "manifestSha256": "b008d2f6de9a0dd50df38b1955a930069b934147ca2a67aec2603f6d1c708388"
+  "inventorySha256": "59d8e7887c4f056d32685499f2fef5ea8af9663a529f1d159c61fdfc038efce4",
+  "manifestSha256": "b556dc027126211938deba1e7d8746b51a22dbc030720583fabc5f698a3713c6"
 }

--- a/src/__tests__/live-data.test.ts
+++ b/src/__tests__/live-data.test.ts
@@ -22,6 +22,11 @@ vi.mock('fs', async () => {
   };
 });
 
+vi.mock('../lib/worktree-paths.js', () => ({
+  getWorktreeRoot: () => null,
+  getOmcRoot: () => `${process.cwd()}/.omc`,
+}));
+
 const mockedExecSync = vi.mocked(child_process.execSync);
 const mockedExecFileSync = vi.mocked(child_process.execFileSync);
 const mockedExistsSync = vi.mocked(fs.existsSync);

--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -375,6 +375,7 @@ describe("npm package bin surface regression", () => {
     expect(source.match(/windowsHide/g)).toHaveLength(7);
     expect(packedDist).not.toContain("execSync(");
     expect(packedDist.match(/windowsHide: true/g)).toHaveLength(7);
+    expect(packedDist).toContain("gitTopLevelCacheMap");
   });
 
   it("packs the complete source-controlled plugin and hook payload", () => {

--- a/src/hooks/permission-handler/index.ts
+++ b/src/hooks/permission-handler/index.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { getOmcRoot, getGitTopLevel } from '../../lib/worktree-paths.js';
+import { getOmcRoot, probeGitTopLevel } from '../../lib/worktree-paths.js';
 import { getClaudeConfigDir } from '../../utils/config-dir.js';
 
 export interface PermissionRequestInput {
@@ -347,10 +347,11 @@ function isSafeRepoPath(
 
   // Literal git toplevel (no submodule→superproject climb) so the containment
   // boundary stays the actual repo the path lives in (#3349 / PR #3350).
-  const worktreeRoot = getGitTopLevel(cwd);
-  if (!worktreeRoot) {
+  const worktreeProbe = probeGitTopLevel(cwd);
+  if (worktreeProbe.status !== 'ok') {
     return false;
   }
+  const worktreeRoot = worktreeProbe.root;
   const resolvedPath = path.resolve(cwd, inputPath);
 
   let canonicalPath = resolvedPath;

--- a/src/lib/__tests__/worktree-paths-toplevel-cache.test.ts
+++ b/src/lib/__tests__/worktree-paths-toplevel-cache.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync as realExecFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("child_process")>("child_process");
+  return {
+    ...actual,
+    execFileSync: vi.fn(actual.execFileSync),
+  };
+});
+
+import { execFileSync } from "child_process";
+import {
+  clearWorktreeCache,
+  getGitTopLevel,
+  getOmcRoot,
+  getWorktreeRoot,
+  probeGitTopLevel,
+  setGitShowToplevelProbeForTests,
+  validateWorkingDirectory,
+} from "../worktree-paths.js";
+
+const mockedExecFileSync = vi.mocked(execFileSync);
+
+function git(cwd: string, args: string[]): string {
+  return realExecFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function initRepo(cwd: string): void {
+  mkdirSync(cwd, { recursive: true });
+  git(cwd, ["init", "--quiet"]);
+  git(cwd, [
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=omc-test",
+    "commit",
+    "--quiet",
+    "--allow-empty",
+    "-m",
+    "init",
+  ]);
+}
+
+function showToplevelCalls(): number {
+  return mockedExecFileSync.mock.calls.filter(
+    ([, args]) =>
+      Array.isArray(args) &&
+      args[0] === "rev-parse" &&
+      args[1] === "--show-toplevel",
+  ).length;
+}
+
+describe("git top-level memoization", () => {
+  let tempDir: string;
+  const originalCwd = process.cwd();
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "omc-toplevel-cache-"));
+    process.chdir(originalCwd);
+    clearWorktreeCache();
+    mockedExecFileSync.mockClear();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    setGitShowToplevelProbeForTests(undefined);
+    clearWorktreeCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("memoizes repeated state-root lookups without repeating show-toplevel", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+
+    expect(getOmcRoot(repo)).toBe(join(repo, ".omc"));
+    expect(getOmcRoot(repo)).toBe(join(repo, ".omc"));
+    expect(getOmcRoot(repo)).toBe(join(repo, ".omc"));
+    expect(showToplevelCalls()).toBe(1);
+  });
+
+  it("keeps a 171-call state render to one top-level probe", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+
+    for (let renderCall = 0; renderCall < 171; renderCall++) {
+      expect(getOmcRoot(repo)).toBe(join(repo, ".omc"));
+    }
+
+    expect(showToplevelCalls()).toBe(1);
+  });
+
+  it("keeps the root correct across repository and child-directory lookups", () => {
+    const repo = join(tempDir, "repo");
+    const child = join(repo, "src");
+    initRepo(repo);
+    mkdirSync(child, { recursive: true });
+
+    expect(getGitTopLevel(repo)).toBe(repo);
+    expect(getGitTopLevel(child)).toBe(repo);
+    expect(getGitTopLevel(child)).toBe(repo);
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("shares a positive entry between real and symlinked paths", () => {
+    const repo = join(tempDir, "repo");
+    const alias = join(tempDir, "repo-link");
+    initRepo(repo);
+
+    try {
+      symlinkSync(repo, alias, "dir");
+    } catch {
+      return;
+    }
+
+    expect(getGitTopLevel(repo)).toBe(repo);
+    expect(getGitTopLevel(alias)).toBe(repo);
+    expect(showToplevelCalls()).toBe(1);
+  });
+
+  it("keeps linked worktree roots in separate cache entries", () => {
+    const repo = join(tempDir, "repo");
+    const linked = join(tempDir, "linked");
+    initRepo(repo);
+    git(repo, [
+      "worktree",
+      "add",
+      "--quiet",
+      "-b",
+      "linked-cache-test",
+      linked,
+    ]);
+
+    expect(getGitTopLevel(repo)).toBe(repo);
+    expect(getGitTopLevel(linked)).toBe(linked);
+    expect(getGitTopLevel(linked)).toBe(linked);
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("invalidates a linked-worktree cache when common config changes", () => {
+    const repo = join(tempDir, "repo");
+    const linked = join(tempDir, "linked");
+    initRepo(repo);
+    git(repo, [
+      "worktree",
+      "add",
+      "--quiet",
+      "-b",
+      "linked-common-config-test",
+      linked,
+    ]);
+
+    expect(getGitTopLevel(linked)).toBe(linked);
+    git(repo, ["config", "core.bare", "false"]);
+
+    expect(getGitTopLevel(linked)).toBe(linked);
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("invalidates a cached parent root when a nested repository appears", () => {
+    const repo = join(tempDir, "repo");
+    const nested = join(repo, "nested");
+    initRepo(repo);
+    mkdirSync(nested, { recursive: true });
+
+    expect(getGitTopLevel(nested)).toBe(repo);
+    initRepo(nested);
+    expect(getGitTopLevel(nested)).toBe(nested);
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("invalidates the state-anchor cache when a nested repository appears", () => {
+    const repo = join(tempDir, "repo");
+    const nested = join(repo, "nested");
+    initRepo(repo);
+    mkdirSync(nested, { recursive: true });
+
+    expect(getWorktreeRoot(nested)).toBe(repo);
+    initRepo(nested);
+    expect(getWorktreeRoot(nested)).toBe(nested);
+  });
+
+  it("invalidates the state-anchor cache when Git discovery environment changes", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    const previousPath = process.env.PATH;
+    try {
+      expect(getWorktreeRoot(repo)).toBe(repo);
+      process.env.PATH = `${previousPath ?? ""}${process.platform === "win32" ? ";" : ":"}${tempDir}`;
+
+      expect(getWorktreeRoot(repo)).toBe(repo);
+      expect(showToplevelCalls()).toBe(2);
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  it("invalidates a cached superproject anchor when its gitlink is removed", () => {
+    const superproject = join(tempDir, "superproject");
+    const submodule = join(tempDir, "submodule");
+    const checkedOutSubmodule = join(superproject, "nested");
+    initRepo(superproject);
+    initRepo(submodule);
+    git(superproject, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      "--quiet",
+      submodule,
+      "nested",
+    ]);
+    git(superproject, [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=omc-test",
+      "commit",
+      "--quiet",
+      "-m",
+      "add submodule",
+    ]);
+
+    expect(getWorktreeRoot(checkedOutSubmodule)).toBe(superproject);
+    git(superproject, ["update-index", "--force-remove", "nested"]);
+    git(superproject, [
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=omc-test",
+      "commit",
+      "--quiet",
+      "-m",
+      "remove submodule gitlink",
+    ]);
+
+    expect(getWorktreeRoot(checkedOutSubmodule)).toBe(checkedOutSubmodule);
+  });
+
+  it("invalidates a linked-worktree entry when its gitdir disappears", () => {
+    const repo = join(tempDir, "repo");
+    const linked = join(tempDir, "linked");
+    initRepo(repo);
+    git(repo, [
+      "worktree",
+      "add",
+      "--quiet",
+      "-b",
+      "linked-metadata-test",
+      linked,
+    ]);
+
+    expect(getGitTopLevel(linked)).toBe(linked);
+    const gitDir = readFileSync(join(linked, ".git"), "utf8").match(
+      /^\s*gitdir:\s*(.+?)\s*$/im,
+    );
+    expect(gitDir).not.toBeNull();
+    rmSync(resolve(linked, gitDir![1]), { recursive: true, force: true });
+
+    expect(getGitTopLevel(linked)).toBeNull();
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("invalidates a cached root when repository HEAD metadata disappears", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+
+    expect(getGitTopLevel(repo)).toBe(repo);
+    rmSync(join(repo, ".git", "HEAD"));
+
+    expect(getGitTopLevel(repo)).toBeNull();
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("invalidates a cached root when Git discovery environment changes", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    const previousGitDir = process.env.GIT_DIR;
+    try {
+      expect(getGitTopLevel(repo)).toBe(repo);
+      process.env.GIT_DIR = join(repo, ".git");
+
+      expect(getGitTopLevel(repo)).toBe(repo);
+      expect(showToplevelCalls()).toBe(2);
+    } finally {
+      if (previousGitDir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = previousGitDir;
+    }
+  });
+
+  it("distinguishes unset and empty Git environment values", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    const previousPath = process.env.PATH;
+    let probeCalls = 0;
+    setGitShowToplevelProbeForTests(() => {
+      probeCalls++;
+      return `${repo}\n`;
+    });
+    try {
+      expect(getGitTopLevel(repo)).toBe(repo);
+      delete process.env.PATH;
+      expect(getGitTopLevel(repo)).toBe(repo);
+      process.env.PATH = "";
+      expect(getGitTopLevel(repo)).toBe(repo);
+      process.env.PATH = "<unset>";
+      expect(getGitTopLevel(repo)).toBe(repo);
+      expect(probeCalls).toBe(4);
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  it("invalidates a cached root when Git config metadata changes", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+
+    expect(getGitTopLevel(repo)).toBe(repo);
+    git(repo, ["config", "core.bare", "false"]);
+
+    expect(getGitTopLevel(repo)).toBe(repo);
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("does not cache a non-repository result before git init", () => {
+    const repo = join(tempDir, "repo");
+
+    expect(getGitTopLevel(repo)).toBeNull();
+    initRepo(repo);
+    expect(getGitTopLevel(repo)).toBe(repo);
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("keeps direct boundary probes uncached", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+
+    expect(probeGitTopLevel(repo).status).toBe("ok");
+    expect(probeGitTopLevel(repo).status).toBe("ok");
+    expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("fails closed when the validator sees a transient git probe failure", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    process.chdir(repo);
+    setGitShowToplevelProbeForTests(() => {
+      const error = new Error("git unavailable") as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      throw error;
+    });
+
+    expect(() => validateWorkingDirectory()).toThrow(/git probe failed and was not used/);
+  });
+});

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -11,7 +11,7 @@
 
 import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, readdirSync, writeFileSync, unlinkSync, statSync } from 'fs';
+import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readSync, realpathSync, readdirSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { resolve, normalize, relative, sep, join, isAbsolute, basename, dirname } from 'path';
 import { pathToFileURL } from 'url';
@@ -55,10 +55,58 @@ export const OmcPaths = {
  * alternating between many different cwds (cache thrashing).
  */
 const MAX_WORKTREE_CACHE_SIZE = 8;
-const worktreeCacheMap = new Map<string, string>();
+interface GitTopLevelCacheEntry {
+  root: string;
+  metadataDir: string;
+  metadataSignature: string;
+  topologySignature: string;
+  environmentSignature: string;
+}
+
+interface StateRootCacheEntry {
+  root: string | null;
+  metadataSignature: string | null;
+  topologySignature: string;
+  environmentSignature: string;
+}
+
+const worktreeCacheMap = new Map<string, StateRootCacheEntry>();
+
+/** Positive Git roots used by state/path construction; security callers probe fresh. */
+const gitTopLevelCacheMap = new Map<string, GitTopLevelCacheEntry>();
 /** LRU cache for outermost superproject root lookups, including negative results. */
-const superprojectCacheMap = new Map<string, string | null>();
+const superprojectCacheMap = new Map<string, StateRootCacheEntry>();
 const canonicalWorkingDirectoryRoots = new WeakMap<object, { providedRoot: string; trustedRoot: string }>();
+
+const GIT_PROBE_ENVIRONMENT_KEYS = [
+  'PATH',
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_COMMON_DIR',
+  'GIT_EXEC_PATH',
+  'GIT_CEILING_DIRECTORIES',
+  'GIT_DISCOVERY_ACROSS_FILESYSTEM',
+  'GIT_CONFIG_SYSTEM',
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_NOSYSTEM',
+  'GIT_CONFIG_COUNT',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_INDEX_FILE',
+  'HOME',
+  'XDG_CONFIG_HOME',
+] as const;
+
+const MAX_GIT_MARKER_BYTES = 4096;
+
+function gitProbeEnvironmentSignature(): string {
+  const fixedEntries = GIT_PROBE_ENVIRONMENT_KEYS
+    .map((key) => JSON.stringify([key, process.env[key] !== undefined, process.env[key] ?? '']));
+  const dynamicEntries = Object.keys(process.env)
+    .filter((key) => /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(key))
+    .sort()
+    .map((key) => JSON.stringify([key, process.env[key] !== undefined, process.env[key] ?? '']));
+  return [...fixedEntries, ...dynamicEntries].join('\0');
+}
 
 /**
  * LRU cache for workspace marker lookups.
@@ -163,10 +211,13 @@ function isDefinitiveNonGitError(error: unknown): boolean {
 function resolveSuperprojectRoot(cwd: string): string | null {
   const cacheKey = resolve(cwd);
   if (superprojectCacheMap.has(cacheKey)) {
-    const cached = superprojectCacheMap.get(cacheKey) ?? null;
+    const cached = superprojectCacheMap.get(cacheKey)!;
+    if (isStateRootCacheEntryValid(cacheKey, cached)) {
+      superprojectCacheMap.delete(cacheKey);
+      superprojectCacheMap.set(cacheKey, cached);
+      return cached.root;
+    }
     superprojectCacheMap.delete(cacheKey);
-    superprojectCacheMap.set(cacheKey, cached);
-    return cached;
   }
 
   let anchor: string | null = null;
@@ -200,7 +251,7 @@ function resolveSuperprojectRoot(cwd: string): string | null {
       const oldest = superprojectCacheMap.keys().next().value;
       if (oldest !== undefined) superprojectCacheMap.delete(oldest);
     }
-    superprojectCacheMap.set(cacheKey, anchor);
+    superprojectCacheMap.set(cacheKey, createStateRootCacheEntry(cacheKey, anchor));
   }
   return anchor;
 }
@@ -309,12 +360,13 @@ function resolveStateAnchorRoot(worktreeRoot?: string): string {
  * Get the literal git toplevel for a directory: `git rev-parse --show-toplevel`
  * with NO submodule→superproject climb. Returns null if not in a git repository.
  *
- * SECURITY: this is the correct primitive for path-restriction / containment
- * checks. A tool operating inside a submodule must be confined to that submodule
- * working tree, not the parent superproject. Use this — NOT getWorktreeRoot() —
- * for boundary validation (getWorktreeRoot climbs to the superproject for state
- * anchoring and would widen the boundary across submodule borders; see #3349
- * and the Codex review on PR #3350).
+ * SECURITY: this cached helper is not the primitive for path-restriction /
+ * containment checks. Those callers must use probeGitTopLevel() so a fresh,
+ * fail-closed probe guards each boundary decision. A tool operating inside a
+ * submodule must be confined to that submodule working tree, not the parent
+ * superproject. getWorktreeRoot() intentionally climbs for state anchoring;
+ * using it for containment would widen the boundary across submodule borders
+ * (see #3349 and the Codex review on PR #3350).
  */
 type GitTopLevelProbe =
   | { status: 'ok'; root: string }
@@ -332,6 +384,7 @@ let gitShowToplevelProbeForTests: GitShowToplevelProbe | undefined;
 
 export function setGitShowToplevelProbeForTests(probe?: GitShowToplevelProbe): void {
   gitShowToplevelProbeForTests = probe;
+  gitTopLevelCacheMap.clear();
 }
 
 function gitErrorStderr(error: unknown): string {
@@ -559,9 +612,225 @@ export function probeGitTopLevel(cwd: string): GitTopLevelProbe {
   }
 }
 
+function gitMetadataFileSignature(path: string): string {
+  try {
+    const metadata = statSync(path);
+    return [
+      path,
+      metadata.dev,
+      metadata.ino,
+      metadata.mode,
+      metadata.size,
+      metadata.mtimeMs,
+      metadata.ctimeMs,
+    ].join(':');
+  } catch {
+    return `${path}:missing`;
+  }
+}
+
+function readGitMarker(path: string): string | null {
+  let descriptor: number | undefined;
+  try {
+    if (!lstatSync(path).isFile()) return null;
+    descriptor = openSync(path, 'r');
+    const buffer = Buffer.alloc(MAX_GIT_MARKER_BYTES);
+    const bytesRead = readSync(descriptor, buffer, 0, buffer.length, 0);
+    return buffer.toString('utf8', 0, bytesRead);
+  } catch {
+    return null;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function commonGitDirectorySignature(linkedGitDir: string): string {
+  const commondirPath = join(linkedGitDir, 'commondir');
+  try {
+    if (!existsSync(commondirPath)) return `${commondirPath}:absent`;
+
+    const marker = readGitMarker(commondirPath);
+    if (marker === null) return `${commondirPath}:unreadable`;
+    const commonDir = canonicalizeExistingPath(resolve(linkedGitDir, marker.trim()));
+    if (!commonDir || !statSync(commonDir).isDirectory()) {
+      return `${commondirPath}:invalid:${marker}`;
+    }
+
+    return [
+      commonDir,
+      gitMetadataFileSignature(commonDir),
+      gitMetadataFileSignature(join(commonDir, 'HEAD')),
+      gitMetadataFileSignature(join(commonDir, 'index')),
+      gitMetadataFileSignature(join(commonDir, 'config')),
+    ].join(':');
+  } catch {
+    return `${commondirPath}:invalid`;
+  }
+}
+
+interface GitMetadataSnapshot {
+  directory: string;
+  signature: string;
+}
+
+function getGitMetadataSnapshot(cwd: string): GitMetadataSnapshot | null {
+  const metadataDir = findGitMetadataDir(canonicalizeExistingPath(cwd) ?? resolve(cwd));
+  if (!metadataDir) return null;
+
+  const canonicalDirectory = canonicalizeExistingPath(metadataDir);
+  if (!canonicalDirectory) return null;
+
+  const gitPath = join(canonicalDirectory, '.git');
+  try {
+    const metadata = statSync(gitPath);
+    const marker = metadata.isFile() ? readGitMarker(gitPath) : '';
+    if (marker === null) return null;
+    let metadataPath = gitPath;
+    let linkedGitDirSignature = '';
+    if (metadata.isFile()) {
+      const gitDirMatch = /^\s*gitdir:\s*(.+?)\s*$/im.exec(marker);
+      if (!gitDirMatch?.[1]) return null;
+      const linkedGitDir = resolve(canonicalDirectory, gitDirMatch[1].trim());
+      const linkedGitDirReal = canonicalizeExistingPath(linkedGitDir);
+      if (!linkedGitDirReal || !statSync(linkedGitDirReal).isDirectory()) return null;
+      metadataPath = linkedGitDirReal;
+      linkedGitDirSignature = [
+        linkedGitDirReal,
+        gitMetadataFileSignature(linkedGitDirReal),
+        gitMetadataFileSignature(join(linkedGitDirReal, 'HEAD')),
+        gitMetadataFileSignature(join(linkedGitDirReal, 'index')),
+        gitMetadataFileSignature(join(linkedGitDirReal, 'config')),
+        gitMetadataFileSignature(join(linkedGitDirReal, 'config.worktree')),
+        gitMetadataFileSignature(join(linkedGitDirReal, 'commondir')),
+        gitMetadataFileSignature(join(linkedGitDirReal, 'gitdir')),
+        commonGitDirectorySignature(linkedGitDirReal),
+      ].join(':');
+    }
+
+    const gitPathReal = canonicalizeExistingPath(gitPath) ?? resolve(gitPath);
+    const metadataPathReal = canonicalizeExistingPath(metadataPath) ?? resolve(metadataPath);
+    const signature = [
+      gitPathReal,
+      gitMetadataFileSignature(gitPath),
+      marker,
+      linkedGitDirSignature,
+      metadataPathReal,
+      gitMetadataFileSignature(join(metadataPathReal, 'HEAD')),
+      gitMetadataFileSignature(join(metadataPathReal, 'index')),
+      gitMetadataFileSignature(join(metadataPathReal, 'config')),
+      gitMetadataFileSignature(join(metadataPathReal, 'config.worktree')),
+    ].join(':');
+    return { directory: canonicalDirectory, signature };
+  } catch {
+    return null;
+  }
+}
+
+function getGitTopologySignature(cwd: string): string {
+  const start = canonicalizeExistingPath(cwd) ?? resolve(cwd);
+  const signatures: string[] = [];
+  let cursor = start;
+  for (;;) {
+    const gitPath = join(cursor, '.git');
+    if (existsSync(gitPath)) {
+      let metadataPath = gitPath;
+      let marker = '';
+      try {
+        if (statSync(gitPath).isFile()) {
+          marker = readGitMarker(gitPath) ?? '<unreadable>';
+          const gitDirMatch = /^\s*gitdir:\s*(.+?)\s*$/im.exec(marker);
+          if (gitDirMatch?.[1]) metadataPath = resolve(cursor, gitDirMatch[1].trim());
+        }
+      } catch {
+        // The path signature below records an unreadable or replaced marker.
+      }
+      const metadataReal = canonicalizeExistingPath(metadataPath) ?? resolve(metadataPath);
+      signatures.push([
+        cursor,
+        gitMetadataFileSignature(gitPath),
+        marker,
+        gitMetadataFileSignature(join(metadataReal, 'HEAD')),
+        gitMetadataFileSignature(join(metadataReal, 'index')),
+        gitMetadataFileSignature(join(metadataReal, 'config')),
+        gitMetadataFileSignature(join(metadataReal, 'config.worktree')),
+        commonGitDirectorySignature(metadataReal),
+      ].join(':'));
+    }
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
+  }
+  return signatures.join('|');
+}
+
+function createStateRootCacheEntry(cwd: string, root: string | null): StateRootCacheEntry {
+  return {
+    root,
+    metadataSignature: getGitMetadataSnapshot(cwd)?.signature ?? null,
+    topologySignature: getGitTopologySignature(cwd),
+    environmentSignature: gitProbeEnvironmentSignature(),
+  };
+}
+
+function isStateRootCacheEntryValid(cwd: string, entry: StateRootCacheEntry): boolean {
+  return (
+    entry.metadataSignature === (getGitMetadataSnapshot(cwd)?.signature ?? null) &&
+    entry.topologySignature === getGitTopologySignature(cwd) &&
+    entry.environmentSignature === gitProbeEnvironmentSignature()
+  );
+}
+
+function isGitTopLevelCacheEntryValid(
+  cwd: string,
+  cached: GitTopLevelCacheEntry,
+): boolean {
+  const current = getGitMetadataSnapshot(cwd);
+  if (!current || current.signature !== cached.metadataSignature) return false;
+  if (cached.topologySignature !== getGitTopologySignature(cwd)) return false;
+  if (cached.environmentSignature !== gitProbeEnvironmentSignature()) return false;
+  if (!sameCanonicalPath(current.directory, cached.metadataDir)) return false;
+  if (!sameCanonicalPath(current.directory, cached.root)) return false;
+  return isCredibleGitWorktreeRoot(cached.root);
+}
+
+function cacheGitTopLevel(key: string, root: string, cwd: string): void {
+  const metadata = getGitMetadataSnapshot(cwd);
+  if (!metadata || !sameCanonicalPath(metadata.directory, root)) return;
+
+  if (gitTopLevelCacheMap.size >= MAX_WORKTREE_CACHE_SIZE) {
+    const oldest = gitTopLevelCacheMap.keys().next().value;
+    if (oldest !== undefined) gitTopLevelCacheMap.delete(oldest);
+  }
+  gitTopLevelCacheMap.set(key, {
+    root,
+    metadataDir: metadata.directory,
+    metadataSignature: metadata.signature,
+    topologySignature: getGitTopologySignature(cwd),
+    environmentSignature: gitProbeEnvironmentSignature(),
+  });
+}
+
+/**
+ * Resolve a literal Git top-level with positive, metadata-validated caching.
+ * Security-sensitive containment decisions must call probeGitTopLevel() instead.
+ */
 export function getGitTopLevel(cwd?: string): string | null {
-  const probe = probeGitTopLevel(cwd || process.cwd());
-  return probe.status === 'ok' ? probe.root : null;
+  const effectiveCwd = cwd || process.cwd();
+  const key = canonicalizeExistingPath(effectiveCwd) ?? resolve(effectiveCwd);
+  const cached = gitTopLevelCacheMap.get(key);
+  if (cached) {
+    if (isGitTopLevelCacheEntryValid(effectiveCwd, cached)) {
+      gitTopLevelCacheMap.delete(key);
+      gitTopLevelCacheMap.set(key, cached);
+      return cached.root;
+    }
+    gitTopLevelCacheMap.delete(key);
+  }
+
+  const probe = probeGitTopLevel(effectiveCwd);
+  if (probe.status !== 'ok') return null;
+  cacheGitTopLevel(key, probe.root, effectiveCwd);
+  return probe.root;
 }
 
 
@@ -583,18 +852,25 @@ function formatGitProbeFailedMessage(workingDirectory: string): string {
  *
  * SECURITY: do NOT use this for path-restriction / containment checks — the
  * submodule climb widens the boundary across submodule borders. Use
- * getGitTopLevel() for confinement.
+ * probeGitTopLevel() for confinement.
  */
 export function getWorktreeRoot(cwd?: string): string | null {
   const effectiveCwd = cwd || process.cwd();
 
   // Return cached value if present (LRU: move to end on access)
   if (worktreeCacheMap.has(effectiveCwd)) {
-    const root = worktreeCacheMap.get(effectiveCwd)!;
-    // Refresh insertion order for LRU eviction
+    const cached = worktreeCacheMap.get(effectiveCwd)!;
+    if (
+      isStateRootCacheEntryValid(effectiveCwd, cached) &&
+      cached.root !== null &&
+      isCredibleGitWorktreeRoot(cached.root)
+    ) {
+      // Refresh insertion order for LRU eviction
+      worktreeCacheMap.delete(effectiveCwd);
+      worktreeCacheMap.set(effectiveCwd, cached);
+      return cached.root;
+    }
     worktreeCacheMap.delete(effectiveCwd);
-    worktreeCacheMap.set(effectiveCwd, root);
-    return root || null;
   }
 
   // Prefer the superproject working tree when cwd is inside a submodule (#3349);
@@ -613,7 +889,7 @@ export function getWorktreeRoot(cwd?: string): string | null {
       worktreeCacheMap.delete(oldest);
     }
   }
-  worktreeCacheMap.set(effectiveCwd, root);
+  worktreeCacheMap.set(effectiveCwd, createStateRootCacheEntry(effectiveCwd, root));
   return root;
 }
 
@@ -1039,6 +1315,7 @@ export function ensureAllOmcDirs(worktreeRoot?: string): void {
  */
 export function clearWorktreeCache(): void {
   worktreeCacheMap.clear();
+  gitTopLevelCacheMap.clear();
   superprojectCacheMap.clear();
   workspaceCacheMap.clear();
 }
@@ -1611,7 +1888,11 @@ function foreignRepositoryResolution(
  * @throws Error if workingDirectory is outside trusted root
  */
 export function validateWorkingDirectory(workingDirectory?: string): string {
-  const trustedRoot = getGitTopLevel(process.cwd()) || process.cwd();
+  const trustedProbe = probeGitTopLevel(process.cwd());
+  if (trustedProbe.status === 'probe_failed' || trustedProbe.status === 'git_missing') {
+    throw new Error(formatGitProbeFailedMessage(process.cwd()));
+  }
+  const trustedRoot = trustedProbe.status === 'ok' ? trustedProbe.root : process.cwd();
 
   if (!workingDirectory) {
     return trustedRoot;
@@ -1628,10 +1909,11 @@ export function validateWorkingDirectory(workingDirectory?: string): string {
   }
 
   // Try to resolve the provided directory to its literal git top-level.
-  const providedRoot = getGitTopLevel(resolved);
+  const providedProbe = probeGitTopLevel(resolved);
 
-  if (providedRoot) {
+  if (providedProbe.status === 'ok') {
     // Git resolution succeeded — require exact worktree identity.
+    const providedRoot = providedProbe.root;
     let providedRootReal: string;
     try {
       providedRootReal = realpathSync(providedRoot);
@@ -1651,7 +1933,11 @@ export function validateWorkingDirectory(workingDirectory?: string): string {
     return providedRoot;
   }
 
-  // Git resolution failed (lock contention, env issues, non-repo dir).
+  if (providedProbe.status === 'probe_failed' || providedProbe.status === 'git_missing') {
+    throw new Error(formatGitProbeFailedMessage(workingDirectory));
+  }
+
+  // Git resolution found a non-repository directory.
   // Validate that the raw directory is under the trusted root before falling
   // back — otherwise reject it as truly outside (#576).
   let resolvedReal: string;
@@ -1674,7 +1960,7 @@ export function validateWorkingDirectory(workingDirectory?: string): string {
   // root. A git-less session has no repository root to normalize to, so keep
   // the explicitly requested directory; getOmcRoot() applies the stable
   // non-git anchor and prevents a per-directory .omc/ from being created.
-  if (getGitTopLevel(process.cwd())) {
+  if (trustedProbe.status === 'ok') {
     return trustedRoot;
   }
   return resolvedReal;

--- a/src/team/__tests__/bridge-entry.guardrails.test.ts
+++ b/src/team/__tests__/bridge-entry.guardrails.test.ts
@@ -17,7 +17,7 @@ describe('bridge-entry workdir guardrails (source contract)', () => {
   });
 
   it('requires working directory to be inside a git worktree', () => {
-    expect(source).toContain('getWorktreeRoot(workingDirectory)');
+    expect(source).toContain('probeGitTopLevel(workingDirectory)');
     expect(source).toContain('workingDirectory is not inside a git worktree');
   });
 });

--- a/src/team/__tests__/bridge-entry.test.ts
+++ b/src/team/__tests__/bridge-entry.test.ts
@@ -33,7 +33,7 @@ describe('bridge-entry security', () => {
   });
 
   it('verifies git worktree', () => {
-    expect(source).toContain('getWorktreeRoot');
+    expect(source).toContain('probeGitTopLevel');
   });
 
   it('validates working directory exists and is a directory', () => {

--- a/src/team/bridge-entry.ts
+++ b/src/team/bridge-entry.ts
@@ -16,7 +16,7 @@ import type { BridgeConfig } from './types.js';
 import { runBridge } from './mcp-team-bridge.js';
 import { deleteHeartbeat } from './heartbeat.js';
 import { unregisterMcpWorker } from './team-registration.js';
-import { getWorktreeRoot } from '../lib/worktree-paths.js';
+import { probeGitTopLevel } from '../lib/worktree-paths.js';
 import { getClaudeConfigDir } from '../utils/config-dir.js';
 import { sanitizeName } from './tmux-session.js';
 
@@ -82,8 +82,8 @@ function validateBridgeWorkingDirectory(workingDirectory: string): void {
   }
 
   // Must be inside a git worktree
-  const root = getWorktreeRoot(workingDirectory);
-  if (!root) {
+  const probe = probeGitTopLevel(workingDirectory);
+  if (probe.status !== 'ok') {
     throw new Error(`workingDirectory is not inside a git worktree: ${workingDirectory}`);
   }
 }

--- a/src/tools/ast-tools.ts
+++ b/src/tools/ast-tools.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
 import { join, extname, resolve, normalize, relative, isAbsolute } from "path";
 import { createRequire } from "module";
-import { getGitTopLevel } from "../lib/worktree-paths.js";
+import { probeGitTopLevel } from "../lib/worktree-paths.js";
 import { isToolPathRestricted } from "../lib/security-config.js";
 
 // Dynamic import for @ast-grep/napi
@@ -72,7 +72,14 @@ export function validateToolPath(inputPath: string): string {
 
   // Use the literal git toplevel (not the superproject-climbing getWorktreeRoot)
   // so a tool inside a submodule stays confined to that submodule (#3349 / PR #3350).
-  const projectRoot = getGitTopLevel() || process.cwd();
+  const projectProbe = probeGitTopLevel(process.cwd());
+  if (projectProbe.status !== 'ok') {
+    throw new Error(
+      `Path restricted: unable to verify the project root because the Git probe failed. ` +
+        `Disable via security.restrictToolPaths in .claude/omc.jsonc or unset OMC_SECURITY.`,
+    );
+  }
+  const projectRoot = projectProbe.root;
   const normalizedRoot = normalize(projectRoot);
   const normalizedPath = normalize(resolved);
 

--- a/src/tools/state-tools.ts
+++ b/src/tools/state-tools.ts
@@ -15,7 +15,6 @@ import {
   ensureOmcDir,
   resolveStateWorkingDirectory,
   isSensitiveStateLocation,
-  getGitTopLevel,
   probeGitTopLevel,
   resolveSessionStatePath,
   ensureSessionStateDir,
@@ -214,7 +213,7 @@ function listSessionIdsUnderOmcRoot(omcRoot: string): string[] {
 function getConvergedOmcRoots(root: string): string[] {
   const canonicalRoot = getOmcRoot(root);
   if (process.env.OMC_STATE_DIR) return [canonicalRoot];
-  if (!getGitTopLevel(root)) return [canonicalRoot];
+  if (probeGitTopLevel(root).status !== 'ok') return [canonicalRoot];
 
   const roots = new Set<string>([canonicalRoot]);
   roots.add(join(root, OmcPaths.ROOT));
@@ -477,7 +476,7 @@ function getLegacyStateFileCandidates(mode: StateToolMode, root: string): string
     getStatePath(mode, root),
     join(getOmcRoot(root), `${normalizedName}.json`),
   ];
-  if (mode === 'autopilot' && getGitTopLevel(root)) candidates.push(join(homedir(), '.omc', 'state', 'autopilot-state.json'));
+  if (mode === 'autopilot' && probeGitTopLevel(root).status === 'ok') candidates.push(join(homedir(), '.omc', 'state', 'autopilot-state.json'));
 
   return [...new Set(candidates)];
 }
@@ -529,7 +528,7 @@ function shouldCheckWorkingDirectoryLocalState(root: string): boolean {
   // Non-git state uses a canonical user/central root. Do not probe or mutate
   // `{workingDirectory}/.omc` implicitly; legacy recovery requires an explicit
   // migration path so unrelated directories cannot be swept together.
-  if (!getGitTopLevel(root)) return false;
+  if (probeGitTopLevel(root).status !== 'ok') return false;
   return getWorkingDirectoryLocalOmcRoot(root) !== getOmcRoot(root);
 }
 


### PR DESCRIPTION
## Summary
- Restore bounded positive-only memoization for literal Git top-level resolution.
- Invalidate cached Git/state roots on canonical metadata, Git config, HEAD/index, linked-worktree common metadata, all ancestor topology, and fixed/dynamic Git discovery environment changes.
- Keep `probeGitTopLevel()` fresh and fail-closed for permission, AST, state-tools, bridge, and working-directory boundaries.
- Preserve literal submodule identity, superproject state anchoring, linked worktrees, symlink aliases, and cross-directory isolation.

## Exact validation
- PR head: `258a156e1e9af1e09721d90200c3e6d25d30ffe8`
- Base: `dev` at `2312df264241d27772f39f67312add0e040efe87`
- Source hash: `sha256:71360a1a27c394581bb591a6d845884e312b1a318fd79270e7b07a4115322e4e`
- Deterministic invocation proof: the cache regression drives 171 state-root render lookups and observes exactly 1 real `git rev-parse --show-toplevel` invocation; topology/environment/config changes force a fresh probe.
- Cache/live-data suites: 3 files, 83 tests passed.
- Worktree, submodule, fresh-probe, permission, AST, bridge suites: 9 files, 315 tests passed.
- State-tools and npm package smoke suites: 3 files, 131 tests passed.
- HUD/statusline rendering suite: 57 files, 891 tests passed, including the cache-wrapper rendering path.
- TypeScript passed; ESLint passed with 0 errors and 29 warnings; build, inventory verification, and whitespace checks passed.
- Exact-head CI for `258a156e1e9af1e09721d90200c3e6d25d30ffe8`: 22 checks passed, 1 release check skipped by policy, 0 failures.

Closes #3922