### PR TITLE
fix(team): platform-aware worker launch wrapper for POSIX hosts (closes #3931)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "afd7c36ab3b85fadd41568e44ede97b5721024d4",
-    "sourceSha256": "c459a96d8d6b1b5d95e97d89455e28a872c4aaeb6cff54aefbb28137a7856264",
+    "head": "0266f1e5f64321a192946700009e4c781f4e9dac",
+    "sourceSha256": "40d255727fbc85c6410dacad070d786d872d053862e5b504261d42e65a0fb3eb",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "afd7c36ab3b85fadd41568e44ede97b5721024d4",
-  "sourceSha256": "c459a96d8d6b1b5d95e97d89455e28a872c4aaeb6cff54aefbb28137a7856264",
+  "head": "0266f1e5f64321a192946700009e4c781f4e9dac",
+  "sourceSha256": "40d255727fbc85c6410dacad070d786d872d053862e5b504261d42e65a0fb3eb",
   "counts": {
     "public": {
       "skills": 35,
@@ -28,8 +28,8 @@
       "toolFiles": 60,
       "libFiles": 37,
       "templateHooks": 21,
-      "srcFiles": 1317,
-      "total": 1338
+      "srcFiles": 1318,
+      "total": 1339
     },
     "generated": {
       "distFiles": 4955,
@@ -39352,6 +39352,11 @@
         "path": "src/team/__tests__/worker-launch-posix-transport.test.ts"
       },
       {
+        "id": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "kind": "src",
+        "path": "src/team/__tests__/worker-launch-wrapper-posix.test.ts"
+      },
+      {
         "id": "src/team/__tests__/worker-restart.test.ts",
         "kind": "src",
         "path": "src/team/__tests__/worker-restart.test.ts"
@@ -70634,6 +70639,41 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "src/team/worker-launch-ack.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-wrapper-posix.test.ts",
+        "to": "src/team/worker-launch-ack.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/team/__tests__/worker-restart.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -76740,12 +76780,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6847,
-      "edgeCount": 7244,
-      "importEdgeCount": 5954,
+      "nodeCount": 6848,
+      "edgeCount": 7251,
+      "importEdgeCount": 5960,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "4283f8f695d63821b3b3d94c9f54a71dd69a336e3944c8816a8c3a2f000e33ec",
-  "manifestSha256": "8411a1b2e6cc3685f69d114de58be280f394e35d29334aa7951e06acb50180b1"
+  "inventorySha256": "c1d8aa2e942388c4a0bf6b0db08b31577d36245fcfe3368dc8ab48695904619f",
+  "manifestSha256": "02c1a81e87d6d6cff68be26c7fd34a544effa540f8f7dd1e187bd2ad5ccd665a"
 }

--- a/src/team/__tests__/worker-launch-wrapper-posix.test.ts
+++ b/src/team/__tests__/worker-launch-wrapper-posix.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Regression suite for issue #3931 — POSIX worker launch wrapper content.
+ *
+ * buildWorkerLaunchWrapper() previously unconditionally emitted a Windows
+ * .cmd batch script (CRLF, @echo off, %~dp0, %ERRORLEVEL%) on all platforms,
+ * breaking worker launches on macOS/Linux. This suite pins the platform-aware
+ * contract: Windows wrapper stays as batch, POSIX wrapper is a valid sh script.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildWorkerLaunchWrapper, quotePosixShellArgument, quoteWindowsCreateProcessArgument } from '../worker-launch-ack.js';
+import type { WorkerLaunchAttempt } from '../worker-launch-ack.js';
+
+function makeAttempt(overrides: Partial<WorkerLaunchAttempt> = {}): WorkerLaunchAttempt {
+  return {
+    schema_version: 1,
+    attempt_id: '11111111-1111-4111-8111-111111111111',
+    nonce: '22222222-2222-4222-8222-222222222222',
+    team_name: 'team',
+    worker_name: 'worker-1',
+    pane_id: '%1',
+    provider: 'codex',
+    created_at: '2026-01-01T00:00:00.000Z',
+    currentPath: '/tmp/current.json',
+    expectedPath: '/tmp/expected.json',
+    ackPath: '/tmp/ack.json',
+    decisionPath: '/tmp/decision.json',
+    startedPath: '/tmp/started.json',
+    transportOwnerPath: '/tmp/transport-owner.json',
+    bootstrapDescriptorPath: '/tmp/bootstrap.json',
+    wrapperPath: '/tmp/launch.cmd',
+    transportCleanupCompletePath: '/tmp/cleanup.json',
+    runtimeCliPath: '/opt/omc/runtime-cli.cjs',
+    ...overrides,
+  };
+}
+
+describe('buildWorkerLaunchWrapper platform contract (issue #3931)', () => {
+  describe('Windows wrapper (platform=win32)', () => {
+    it('emits CRLF batch script with Windows tokens', () => {
+      const wrapper = buildWorkerLaunchWrapper(makeAttempt(), 'win32');
+      expect(wrapper).toContain('@echo off');
+      expect(wrapper).toContain('setlocal DisableDelayedExpansion');
+      expect(wrapper).toContain('OMC_WORKER_LAUNCH_SPEC_FILE=%~dp0bootstrap.json');
+      expect(wrapper).toContain('--worker-launch');
+      expect(wrapper).toContain('%ERRORLEVEL%');
+      expect(wrapper).toContain('del /f /q "%~f0"');
+      expect(wrapper).toContain('endlocal & exit /b %_OMC_WORKER_LAUNCH_EXIT%');
+      expect(wrapper).toContain('\r\n');
+      expect(wrapper).not.toContain('#!/bin/sh');
+      expect(wrapper).not.toContain('omc_wrapper_dir');
+      expect(wrapper).not.toContain("rm -f");
+    });
+
+    it('preserves Windows quoting for paths with spaces and percent', () => {
+      const wrapper = buildWorkerLaunchWrapper(
+        makeAttempt({ runtimeCliPath: 'C:\\Program Files\\omc\\runtime-cli.cjs' }),
+        'win32',
+      );
+      // Windows quoting uses doubled percent and doubled quotes inside double-quotes
+      expect(wrapper).toContain('"C:\\Program Files\\omc\\runtime-cli.cjs"');
+      expect(wrapper).toContain('\r\n');
+    });
+
+    it('does not emit POSIX shebang', () => {
+      const wrapper = buildWorkerLaunchWrapper(makeAttempt(), 'win32');
+      expect(wrapper.startsWith('#!')).toBe(false);
+    });
+  });
+
+  describe('POSIX wrapper (platform=linux/darwin)', () => {
+    for (const platform of ['linux', 'darwin', 'freebsd'] as const) {
+      it(`emits LF sh script with POSIX bootstrap derivation on ${platform}`, () => {
+        const wrapper = buildWorkerLaunchWrapper(makeAttempt(), platform);
+        expect(wrapper).toContain('#!/bin/sh');
+        expect(wrapper).toContain('set -u');
+        expect(wrapper).toContain('omc_wrapper_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)');
+        expect(wrapper).toContain('export OMC_WORKER_LAUNCH_SPEC_FILE="$omc_wrapper_dir/bootstrap.json"');
+        expect(wrapper).toContain('--worker-launch');
+        expect(wrapper).toContain('_omc_exit=$?');
+        expect(wrapper).toContain('rm -f -- "$0"');
+        expect(wrapper).toContain('exit $_omc_exit');
+        expect(wrapper).not.toContain('@echo off');
+        expect(wrapper).not.toContain('%~dp0');
+        expect(wrapper).not.toContain('%ERRORLEVEL%');
+        expect(wrapper).not.toContain('del /f /q');
+        expect(wrapper).not.toContain('endlocal');
+        // LF only, no CRLF
+        expect(wrapper).not.toContain('\r\n');
+        expect(wrapper).toContain('\n');
+        // Valid sh syntax
+        const dir = mkdtempSync(join(tmpdir(), 'wrapper-syntax-'));
+        const path = join(dir, 'test.sh');
+        try {
+          writeFileSync(path, wrapper, 'utf8');
+          const result = spawnSync('sh', ['-n', path], { encoding: 'utf8' });
+          expect(result.status).toBe(0);
+          expect(result.stderr).toBe('');
+        } finally {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      });
+    }
+
+    it('single-quote-escapes runtimeCliPath with spaces', () => {
+      const wrapper = buildWorkerLaunchWrapper(
+        makeAttempt({ runtimeCliPath: '/opt/my project/runtime-cli.cjs' }),
+        'linux',
+      );
+      expect(wrapper).toContain("'/opt/my project/runtime-cli.cjs'");
+      expect(wrapper).not.toContain('/opt/my project/runtime-cli.cjs --worker-launch');
+    });
+
+    it('escapes single quotes via close-open pattern', () => {
+      const wrapper = buildWorkerLaunchWrapper(
+        makeAttempt({ runtimeCliPath: "/opt/omc/runtime's/cli.cjs" }),
+        'linux',
+      );
+      // '/opt/omc/runtime'"'"'/cli.cjs' is the standard single-quote escape: close ', add escaped ', reopen '
+      expect(wrapper).toContain(`'"'"'`);
+      // Verify round-trip via shell for the produced quoting
+      const quoted = quotePosixShellArgument("/opt/omc/runtime's/cli.cjs");
+      const result = spawnSync('sh', ['-c', `printf '%s' ${quoted}`], { encoding: 'utf8' });
+      expect(result.stdout).toBe("/opt/omc/runtime's/cli.cjs");
+    });
+
+    it('keeps shell metacharacters inert (no injection)', () => {
+      const malicious = '/tmp/test; rm -rf /; echo/cli.cjs';
+      const wrapper = buildWorkerLaunchWrapper(makeAttempt({ runtimeCliPath: malicious }), 'linux');
+      expect(wrapper).toContain(`'${malicious}'`);
+      // Metachars inside single quotes are inert; sh -n validates
+      const dir = mkdtempSync(join(tmpdir(), 'wrapper-inject-'));
+      const path = join(dir, 'test.sh');
+      try {
+        writeFileSync(path, wrapper, 'utf8');
+        const result = spawnSync('sh', ['-n', path], { encoding: 'utf8' });
+        expect(result.status).toBe(0);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects CRLF/CR/NUL in runtimeCliPath', () => {
+      expect(() => buildWorkerLaunchWrapper(makeAttempt({ runtimeCliPath: '/tmp/a\r\nb/c.cjs' }), 'linux'))
+        .toThrow('worker_launch_provider_argv_invalid');
+      expect(() => buildWorkerLaunchWrapper(makeAttempt({ runtimeCliPath: '/tmp/a\0b/c.cjs' }), 'linux'))
+        .toThrow('worker_launch_provider_argv_invalid');
+    });
+
+    it('executes correctly: bootstrap derivation, exit propagation, self-delete', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'wrapper-exec-'));
+      const runtimeCliPath = join(dir, 'runtime-cli.cjs');
+      // Place wrapper alongside bootstrap
+      const wrapperDir = join(dir, 'attempt');
+      const { mkdirSync } = await import('node:fs');
+      mkdirSync(wrapperDir, { recursive: true });
+      const bootstrapPath = join(wrapperDir, 'bootstrap.json');
+      writeFileSync(bootstrapPath, '{}', 'utf8');
+      // Minimal runtime that checks env and exits with specific code
+      writeFileSync(runtimeCliPath, `if (process.env.OMC_WORKER_LAUNCH_SPEC_FILE !== "${bootstrapPath}") process.exit(99); process.exit(42);`, 'utf8');
+
+      const attempt = makeAttempt({ runtimeCliPath });
+      const wrapper = buildWorkerLaunchWrapper(attempt, 'linux');
+      const wrapperPath = join(wrapperDir, 'launch.cmd');
+      writeFileSync(wrapperPath, wrapper, 'utf8');
+      chmodSync(wrapperPath, 0o700);
+
+      const result = spawnSync(wrapperPath, [], { encoding: 'utf8' });
+      expect(result.status).toBe(42);
+      expect(result.stderr).toBe('');
+      // Self-delete
+      expect(result.status).toBe(42);
+      // Wrapper should have deleted itself
+      const { existsSync } = await import('node:fs');
+      expect(existsSync(wrapperPath)).toBe(false);
+
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('handles bootstrap path with spaces via symlink-safe derivation', () => {
+      const wrapper = buildWorkerLaunchWrapper(
+        makeAttempt({ runtimeCliPath: '/opt/omc/runtime-cli.cjs' }),
+        'linux',
+      );
+      // Uses dirname $0 + pwd, not %~dp0, handles spaces via quoted "$0"
+      expect(wrapper).toContain('dirname -- "$0"');
+      expect(wrapper).toContain('CDPATH=');
+    });
+  });
+
+  describe('quotePosixShellArgument', () => {
+    it('single-quote wraps and escapes internal single quotes', () => {
+      expect(quotePosixShellArgument("a'b")).toBe(`'a'"'"'b'`);
+      expect(quotePosixShellArgument("a")).toBe(`'a'`);
+      expect(quotePosixShellArgument(" ")).toBe(`' '`);
+      expect(quotePosixShellArgument("a b c")).toBe(`'a b c'`);
+    });
+
+    it('keeps metachars inert inside single quotes', () => {
+      for (const value of ['$(whoami)', '`whoami`', 'a; b', 'a|b', 'a&b', '$HOME', '!bang']) {
+        const quoted = quotePosixShellArgument(value);
+        const result = spawnSync('sh', ['-c', `printf '%s' ${quoted}`], { encoding: 'utf8' });
+        expect(result.stdout).toBe(value);
+      }
+    });
+
+    it('rejects CRLF/NUL', () => {
+      expect(() => quotePosixShellArgument('a\r\nb')).toThrow('worker_launch_provider_argv_invalid');
+      expect(() => quotePosixShellArgument('a\0b')).toThrow('worker_launch_provider_argv_invalid');
+    });
+  });
+});

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -556,19 +556,39 @@ function windowsWrapperRelativePath(cwd: string, wrapperPath: string): string {
   return relativePath;
 }
 
-function buildWorkerLaunchWrapper(attempt: WorkerLaunchAttempt): string {
-  const runtimeCli = quoteWindowsCmdArgument(attempt.runtimeCliPath);
-  const nodeExecutable = quoteWindowsCmdArgument(process.execPath);
+export function buildWorkerLaunchWrapper(attempt: WorkerLaunchAttempt, platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    const runtimeCli = quoteWindowsCmdArgument(attempt.runtimeCliPath);
+    const nodeExecutable = quoteWindowsCmdArgument(process.execPath);
+    return [
+      '@echo off',
+      'setlocal DisableDelayedExpansion',
+      'set "OMC_WORKER_LAUNCH_SPEC_FILE=%~dp0bootstrap.json"',
+      `${nodeExecutable} ${runtimeCli} --worker-launch`,
+      'set "_OMC_WORKER_LAUNCH_EXIT=%ERRORLEVEL%"',
+      'del /f /q "%~f0" >nul 2>&1',
+      'endlocal & exit /b %_OMC_WORKER_LAUNCH_EXIT%',
+      '',
+    ].join('\r\n');
+  }
+  const runtimeCli = quotePosixShellArgument(attempt.runtimeCliPath);
+  const nodeExecutable = quotePosixShellArgument(process.execPath);
   return [
-    '@echo off',
-    'setlocal DisableDelayedExpansion',
-    'set "OMC_WORKER_LAUNCH_SPEC_FILE=%~dp0bootstrap.json"',
+    '#!/bin/sh',
+    'set -u',
+    'omc_wrapper_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)',
+    'export OMC_WORKER_LAUNCH_SPEC_FILE="$omc_wrapper_dir/bootstrap.json"',
     `${nodeExecutable} ${runtimeCli} --worker-launch`,
-    'set "_OMC_WORKER_LAUNCH_EXIT=%ERRORLEVEL%"',
-    'del /f /q "%~f0" >nul 2>&1',
-    'endlocal & exit /b %_OMC_WORKER_LAUNCH_EXIT%',
+    '_omc_exit=$?',
+    'rm -f -- "$0"',
+    'exit $_omc_exit',
     '',
-  ].join('\\r\\n');
+  ].join('\n');
+}
+
+export function quotePosixShellArgument(value: string): string {
+  if (/[\r\n\0]/.test(value)) throw new Error('worker_launch_provider_argv_invalid');
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 export async function materializeWorkerLaunchTransport(input: {
@@ -597,7 +617,7 @@ export async function materializeWorkerLaunchTransport(input: {
   const wrapperRelativePath = windowsDelivery
     ? windowsWrapperRelativePath(input.cwd, attempt.wrapperPath)
     : '';
-  const wrapper = buildWorkerLaunchWrapper(attempt);
+  const wrapper = buildWorkerLaunchWrapper(attempt, windowsDelivery ? 'win32' : process.platform);
   let ownerCreated = false;
   let descriptorCreated = false;
   let wrapperCreated = false;


### PR DESCRIPTION
Fixes #3931.

## Summary

`buildWorkerLaunchWrapper` unconditionally emitted a Windows `.cmd` batch script (CRLF, `@echo off`, `%~dp0`, `%ERRORLEVEL%`) on all platforms, breaking all worker launches on macOS/Linux. This PR adds an explicit platform branch mirroring `buildProviderSpawnInvocation`: Windows behavior is preserved on `win32`, POSIX hosts emit a correct `#!/bin/sh` launcher.

## Changes

- **`src/team/worker-launch-ack.ts`**:
  - `buildWorkerLaunchWrapper(attempt, platform)` now branches on `platform === 'win32'`.
  - POSIX path: `#!/bin/sh` + `set -u`, `CDPATH`-safe `dirname` derivation (`omc_wrapper_dir`), single-quote escaping via `quotePosixShellArgument`, exit propagation (`_omc_exit`), self-delete (`rm -f -- "$0"`), LF line endings.
  - Windows path: preserved exactly (CRLF, `@echo off`, `%~dp0bootstrap.json`, `double-quote` escaping, `%ERRORLEVEL%`).
  - `materializeWorkerLaunchTransport` forwards `windowsDelivery ? 'win32' : process.platform` to the wrapper builder.
  - Exported `buildWorkerLaunchWrapper` and `quotePosixShellArgument` for testing.
- **`src/team/__tests__/worker-launch-wrapper-posix.test.ts`** (new): 15 regression tests covering both platform wrappers, quoting edge cases (spaces, single quotes, metacharacters, CRLF/NUL rejection), `sh -n` syntax validity, and end-to-end execution (bootstrap derivation, exit propagation, self-delete).

## Reproduction

On Linux host (this worktree), `materializeWorkerLaunchTransport(..., windowsDelivery: false)` previously produced a batch file; now produces a valid sh script that passes `sh -n`, handles paths with spaces/quotes, and correctly executes to propagate exit codes and self-delete. `windowsDelivery: true` still produces the original batch file. Verified via direct wrapper execution and `spawnSync`.

## Validation

- TypeScript: `npx tsc --noEmit` — pass
- Build: `npm run build` — pass (bridge artifacts are generated, not committed per repo convention)
- Worker launch tests: `worker-launch-ack` (44 passed), `worker-launch-wrapper-posix` (15 passed), `worker-launch-posix-transport` (4 passed), `tmux-session` (53 passed), `tmux-session.startup` (38 passed) — all green

## Evidence

- **Exact head**: `753a5cd8076a545bdc55d4616b9383e9b0d68b64` (`753a5cd80`)
- **Exact base**: `0266f1e5f64321a192946700009e4c781f4e9dac` (`0266f1e5f`, `origin/dev`)
- **Branch**: `fix/issue-3931-posix-worker-launch`
- No sibling PR/issue touched; targets `dev` only.

Closes #3931.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*