### PR TITLE
fix(hud): pid-aware lock recovery and bounded .err reclamation (fix #3933)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "0266f1e5f64321a192946700009e4c781f4e9dac",
-    "sourceSha256": "40d255727fbc85c6410dacad070d786d872d053862e5b504261d42e65a0fb3eb",
+    "head": "e836deb017c20ad94134bdcdc1bc953b873ca39a",
+    "sourceSha256": "98ff4f88215fda9ee3001d79453043907ef04620b50dc804189eb2264a7940ca",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "0266f1e5f64321a192946700009e4c781f4e9dac",
-  "sourceSha256": "40d255727fbc85c6410dacad070d786d872d053862e5b504261d42e65a0fb3eb",
+  "head": "e836deb017c20ad94134bdcdc1bc953b873ca39a",
+  "sourceSha256": "98ff4f88215fda9ee3001d79453043907ef04620b50dc804189eb2264a7940ca",
   "counts": {
     "public": {
       "skills": 35,
@@ -76787,5 +76787,5 @@
     }
   },
   "inventorySha256": "c1d8aa2e942388c4a0bf6b0db08b31577d36245fcfe3368dc8ab48695904619f",
-  "manifestSha256": "02c1a81e87d6d6cff68be26c7fd34a544effa540f8f7dd1e187bd2ad5ccd665a"
+  "manifestSha256": "29d700a8f40d3bf501e731b66ce2a77f7a95165f9989dfcbb5c571156c23951c"
 }

--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -42,8 +42,96 @@ is_stale_path() {
   [ $((now - path_mtime)) -gt "$LOCK_STALE_SECONDS" ] || return 1
 }
 
+is_numeric_pid() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+is_pid_alive() {
+  pid=$1
+  is_numeric_pid "$pid" || return 1
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  if command -v ps >/dev/null 2>&1; then
+    ps -p "$pid" >/dev/null 2>&1 && return 0
+  fi
+  return 1
+}
+
+read_lock_pid() {
+  lock_path=$1
+  if [ -f "$lock_path/pid" ]; then
+    awk 'NR==1{print $1}' "$lock_path/pid" 2>/dev/null | tr -d '\r\n'
+    return 0
+  fi
+  if [ -f "$lock_path" ] && [ ! -d "$lock_path" ]; then
+    awk 'NR==1{print $1}' "$lock_path" 2>/dev/null | tr -d '\r\n'
+  fi
+}
+
+is_lock_stale() {
+  lock_path=$1
+  if [ ! -e "$lock_path" ]; then
+    return 1
+  fi
+  lock_pid=$(read_lock_pid "$lock_path")
+  if [ -n "$lock_pid" ]; then
+    if is_numeric_pid "$lock_pid"; then
+      if is_pid_alive "$lock_pid"; then
+        return 1
+      fi
+      is_stale_path "$lock_path" || return 1
+      return 0
+    fi
+    is_stale_path "$lock_path" || return 1
+    return 0
+  fi
+  is_stale_path "$lock_path"
+}
+
+write_lock_pid() {
+  lock_path=$1
+  printf '%s\n' "$$" > "$lock_path/pid" 2>/dev/null || :
+}
+
+acquire_lock_owned() {
+  lock_path=$1
+  if mkdir "$lock_path" 2>/dev/null; then
+    write_lock_pid "$lock_path"
+    return 0
+  fi
+  return 1
+}
+
+release_lock_if_owned() {
+  lock_path=$1
+  owner_pid=$2
+  if [ ! -d "$lock_path" ]; then
+    return 0
+  fi
+  current_pid=$(read_lock_pid "$lock_path")
+  if [ -n "$current_pid" ] && [ -n "$owner_pid" ]; then
+    if [ "$current_pid" = "$owner_pid" ]; then
+      rm -rf "$lock_path" 2>/dev/null || :
+      return 0
+    fi
+    return 0
+  fi
+  if [ -z "$current_pid" ]; then
+    if [ -n "$owner_pid" ]; then
+      return 0
+    fi
+    if is_stale_path "$lock_path"; then
+      rm -rf "$lock_path" 2>/dev/null || :
+    fi
+  fi
+}
+
 cleanup_empty_temp_files() {
-  for temp_path in "$CACHE_DIR"/stdin.*.tmp "$CACHE_DIR"/statusline.*.tmp "$CACHE_DIR"/statusline.*.err; do
+  for temp_path in "$CACHE_DIR"/stdin.*.tmp "$CACHE_DIR"/statusline.*.tmp; do
     [ -f "$temp_path" ] || continue
     [ -s "$temp_path" ] && continue
     is_stale_path "$temp_path" || continue
@@ -51,15 +139,25 @@ cleanup_empty_temp_files() {
   done
 }
 
+cleanup_stale_err_files() {
+  for err_path in "$CACHE_DIR"/statusline.*.err; do
+    [ -f "$err_path" ] || continue
+    is_stale_path "$err_path" || continue
+    rm -f "$err_path" 2>/dev/null || :
+  done
+}
+
 cleanup_stale_render_locks() {
   for stale_lock_dir in "$CACHE_DIR"/render.*.lock; do
     [ -d "$stale_lock_dir" ] || continue
-    is_stale_path "$stale_lock_dir" || continue
+    is_lock_stale "$stale_lock_dir" || continue
+    is_lock_stale "$stale_lock_dir" || continue
     rm -rf "$stale_lock_dir" 2>/dev/null || :
   done
 }
 
 cleanup_empty_temp_files
+cleanup_stale_err_files
 cleanup_stale_render_locks
 
 # Capture Claude's current statusLine stdin first so rendered output can be
@@ -108,24 +206,29 @@ fi
 rm -f "$INPUT_TMP" 2>/dev/null || :
 
 try_acquire_lock() {
-  if mkdir "$LOCK_DIR" 2>/dev/null; then
+  if acquire_lock_owned "$LOCK_DIR"; then
     return 0
   fi
   if [ ! -d "$LOCK_DIR" ]; then
     return 1
   fi
-  is_stale_path "$LOCK_DIR" || return 1
+  is_lock_stale "$LOCK_DIR" || return 1
   rm -rf "$LOCK_DIR" 2>/dev/null || :
-  mkdir "$LOCK_DIR" 2>/dev/null
+  acquire_lock_owned "$LOCK_DIR"
 }
 
 refresh_cache() {
+  REFRESH_PID=$$
+  if [ -d "$LOCK_DIR" ]; then
+    printf '%s\n' "$REFRESH_PID" > "$LOCK_DIR/pid" 2>/dev/null || :
+  fi
+
   cleanup_refresh_artifacts() {
     rm -f "$NODE_STDOUT_TMP" 2>/dev/null || :
     if [ ! -s "$NODE_STDERR_TMP" ]; then
       rm -f "$NODE_STDERR_TMP" 2>/dev/null || :
     fi
-    rm -rf "$LOCK_DIR" 2>/dev/null || :
+    release_lock_if_owned "$LOCK_DIR" "$REFRESH_PID"
   }
 
   trap 'cleanup_refresh_artifacts' EXIT
@@ -148,14 +251,13 @@ refresh_cache() {
   fi
 
   rm -f "$NODE_STDOUT_TMP" "$NODE_STDERR_TMP" 2>/dev/null || :
-  rm -rf "$LOCK_DIR" 2>/dev/null || :
+  release_lock_if_owned "$LOCK_DIR" "$REFRESH_PID"
   trap - EXIT HUP INT TERM
 }
 
 # Hot path: return immediately from the last successful render for this session.
 if [ -s "$OUTPUT_FILE" ]; then
   cat "$OUTPUT_FILE" 2>/dev/null || printf '[OMC] Starting...\n'
-  # Refresh in background for the next frame.
   if try_acquire_lock; then
     if [ "${OMC_HUD_SYNC_REFRESH:-0}" = "1" ]; then
       refresh_cache
@@ -166,10 +268,6 @@ if [ -s "$OUTPUT_FILE" ]; then
   exit 0
 fi
 
-# First render for this session: do a synchronous refresh so the user
-# sees the real HUD from the first frame. Claude Code v2.1.x does not
-# re-poll the statusLine until user interaction, so an async background
-# refresh leaves the pane stuck on "[OMC] Starting..." until they type.
 if [ -s "$INPUT_FILE" ] && try_acquire_lock; then
   refresh_cache
   if [ -s "$OUTPUT_FILE" ]; then

--- a/src/__tests__/hud-cache-wrapper.test.ts
+++ b/src/__tests__/hud-cache-wrapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -9,8 +9,12 @@ const wrapperPath = join(root, 'scripts', 'lib', 'hud-cache-wrapper.sh');
 
 function makeOld(path: string): void {
   const old = new Date(Date.now() - 30_000);
-  // Directory mtimes are enough for the wrapper's stale lock check.
   utimesSync(path, old, old);
+}
+
+function makeFresh(path: string): void {
+  const now = new Date();
+  utimesSync(path, now, now);
 }
 
 describe('HUD cache wrapper stale render cleanup', () => {
@@ -51,8 +55,6 @@ describe('HUD cache wrapper stale render cleanup', () => {
       },
     });
 
-    // First render is synchronous when stdin is available so Claude Code v2.1.x
-    // does not stay stuck on the placeholder until the next user keystroke.
     expect(output).toBe('rendered issue 3002\n');
     expect(() => statSync(currentLock)).toThrow();
     expect(() => statSync(otherLock)).toThrow();
@@ -61,6 +63,260 @@ describe('HUD cache wrapper stale render cleanup', () => {
     expect(() => statSync(emptyInputTmp)).toThrow();
     expect(readFileSync(diagnosticErr, 'utf8')).toBe('renderer exploded\n');
     expect(readFileSync(join(cacheDir, 'statusline.issue-3002.txt'), 'utf8')).toBe('rendered issue 3002\n');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+});
+
+describe('HUD cache wrapper lock ownership (issue #3933 defect 1)', () => {
+  it('does not evict a live holder whose lock is mtime-stale', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-lock-live-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const liveLock = join(cacheDir, 'render.live-session.lock');
+    mkdirSync(liveLock);
+    writeFileSync(join(liveLock, 'pid'), `${process.pid}\n`);
+    makeOld(liveLock);
+    try {
+      makeOld(join(liveLock, 'pid'));
+    } catch {}
+
+    const cached = join(cacheDir, 'statusline.live-session.txt');
+    writeFileSync(cached, 'EXISTING\n');
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "console.log('should not render fresh');\n");
+    const fakeBin = join(tempRoot, 'bin');
+    mkdirSync(fakeBin, { recursive: true });
+    const marker = join(tempRoot, 'node-invoked');
+    writeFileSync(join(fakeBin, 'node'), `#!/bin/sh\ntouch ${JSON.stringify(marker)}\nexit 0\n`, 'utf8');
+    chmodSync(join(fakeBin, 'node'), 0o755);
+
+    try {
+      rmSync(liveLock, { recursive: true, force: true });
+    } catch {}
+    mkdirSync(liveLock, { recursive: true });
+    writeFileSync(join(liveLock, 'pid'), `${process.pid}\n`);
+    makeOld(liveLock);
+    try {
+      makeOld(join(liveLock, 'pid'));
+    } catch {}
+
+    const result = spawnSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'live-session', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:/usr/bin:/bin`,
+        OMC_HUD_CACHE_DIR: cacheDir,
+      },
+      timeout: 2000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('EXISTING\n');
+    expect(existsSync(liveLock)).toBe(true);
+    expect(existsSync(marker)).toBe(false);
+    expect(readFileSync(cached, 'utf8')).toBe('EXISTING\n');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('recovers a dead-holder lock that is mtime-stale', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-lock-dead-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const deadLock = join(cacheDir, 'render.dead-session.lock');
+    mkdirSync(deadLock);
+    writeFileSync(join(deadLock, 'pid'), '999999\n');
+    makeOld(deadLock);
+    try {
+      makeOld(join(deadLock, 'pid'));
+    } catch {}
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('recovered'));\n");
+
+    const output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'dead-session', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        OMC_HUD_CACHE_DIR: cacheDir,
+        OMC_HUD_SYNC_REFRESH: '1',
+      },
+    });
+
+    expect(output).toBe('recovered\n');
+    expect(readFileSync(join(cacheDir, 'statusline.dead-session.txt'), 'utf8')).toBe('recovered\n');
+    expect(existsSync(deadLock)).toBe(false);
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('treats malformed pid metadata as reclaimable only when stale', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-lock-malformed-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "console.log('x');\n");
+    const fakeBin = join(tempRoot, 'bin');
+    mkdirSync(fakeBin, { recursive: true });
+    const marker = join(tempRoot, 'marker');
+    writeFileSync(join(fakeBin, 'node'), `#!/bin/sh\ntouch ${JSON.stringify(marker)}\n printf "x\\n"\n`, 'utf8');
+    chmodSync(join(fakeBin, 'node'), 0o755);
+
+    const freshBad = join(cacheDir, 'render.malformed-fresh.lock');
+    mkdirSync(freshBad);
+    writeFileSync(join(freshBad, 'pid'), 'not-a-pid\n');
+    makeFresh(freshBad);
+    writeFileSync(join(cacheDir, 'statusline.malformed-fresh.txt'), 'CACHED\n');
+
+    let result = spawnSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'malformed-fresh', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${fakeBin}:/usr/bin:/bin`, OMC_HUD_CACHE_DIR: cacheDir },
+      timeout: 2000,
+    });
+    expect(result.stdout).toBe('CACHED\n');
+    expect(existsSync(freshBad)).toBe(true);
+    expect(existsSync(marker)).toBe(false);
+
+    const staleBad = join(cacheDir, 'render.malformed-stale.lock');
+    mkdirSync(staleBad);
+    writeFileSync(join(staleBad, 'pid'), 'also-bad-$$$\n');
+    makeOld(staleBad);
+    writeFileSync(join(cacheDir, 'statusline.malformed-stale.txt'), 'CACHED2\n');
+    result = spawnSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'unrelated', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${fakeBin}:/usr/bin:/bin`, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(existsSync(staleBad)).toBe(false);
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('serializes hot-path acquisition to at most one fresh render (no duplicate updates)', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-lock-race-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    writeFileSync(join(cacheDir, 'statusline.race-session.txt'), 'BASE\n');
+
+    const hudScript = join(tempRoot, 'slow-hud.mjs');
+    writeFileSync(
+      hudScript,
+      `
+      import fs from 'node:fs';
+      import path from 'node:path';
+      const c=process.env.OMC_HUD_CACHE_DIR;
+      const ctr=path.join(c,'ctr');
+      let n=0; try{ n=parseInt(fs.readFileSync(ctr,'utf8'),10)||0;}catch{}
+      n++;
+      const end=Date.now()+600; while(Date.now()<end){}
+      fs.writeFileSync(ctr,String(n));
+      console.log('RENDER '+n);
+    `,
+    );
+
+    const payload = JSON.stringify({ session_id: 'race-session', cwd: tempRoot });
+    const first = spawnSync('sh', [wrapperPath, hudScript], {
+      input: payload,
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 3000,
+    });
+    expect(first.stdout).toBe('BASE\n');
+    const ctr1 = existsSync(join(cacheDir, 'ctr')) ? readFileSync(join(cacheDir, 'ctr'), 'utf8').trim() : '0';
+    expect(ctr1).toBe('1');
+    expect(readFileSync(join(cacheDir, 'statusline.race-session.txt'), 'utf8')).toBe('RENDER 1\n');
+
+    const manualLock = join(cacheDir, 'render.race-session.lock');
+    mkdirSync(manualLock, { recursive: true });
+    writeFileSync(join(manualLock, 'pid'), `${process.pid}\n`);
+    makeFresh(manualLock);
+    const secondWhileLocked = spawnSync('sh', [wrapperPath, hudScript], {
+      input: payload,
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(secondWhileLocked.stdout).toBe('RENDER 1\n');
+    const ctr2 = readFileSync(join(cacheDir, 'ctr'), 'utf8').trim();
+    expect(ctr2).toBe('1');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+});
+
+describe('HUD cache wrapper err reclamation (issue #3933 defect 2)', () => {
+  it('reclaims non-empty stale .err files while retaining a fresh diagnostic', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-err-reclaim-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const staleErrA = join(cacheDir, 'statusline.s-n.111.err');
+    const staleErrB = join(cacheDir, 'statusline.s-n.222.err');
+    const freshErr = join(cacheDir, 'statusline.s-n.333.err');
+    writeFileSync(staleErrA, 'old diagnostic A\n');
+    writeFileSync(staleErrB, 'old diagnostic B\n');
+    writeFileSync(freshErr, 'fresh diagnostic keeps for triage\n');
+    makeOld(staleErrA);
+    makeOld(staleErrB);
+
+    const emptyTmp = join(cacheDir, 'statusline.s-n.999.tmp');
+    writeFileSync(emptyTmp, '');
+    makeOld(emptyTmp);
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('ok'));\n");
+
+    const output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 's-n', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(output).toBe('ok\n');
+    expect(existsSync(staleErrA)).toBe(false);
+    expect(existsSync(staleErrB)).toBe(false);
+    expect(readFileSync(freshErr, 'utf8')).toBe('fresh diagnostic keeps for triage\n');
+    expect(existsSync(emptyTmp)).toBe(false);
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('does not delete a freshly written non-empty .err (actively written guard via staleness)', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-err-fresh-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const activeErr = join(cacheDir, 'statusline.concurrent.999.err');
+    writeFileSync(activeErr, 'concurrent render currently writing...\n');
+    makeFresh(activeErr);
+
+    writeFileSync(join(cacheDir, 'statusline.concurrent.txt'), 'CACHED\n');
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "console.log('x')\n");
+    const fakeBin = join(tempRoot, 'bin');
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(join(fakeBin, 'node'), '#!/bin/sh\nexit 0\n', 'utf8');
+    chmodSync(join(fakeBin, 'node'), 0o755);
+    mkdirSync(join(cacheDir, 'render.concurrent.lock'));
+    writeFileSync(join(join(cacheDir, 'render.concurrent.lock'), 'pid'), `${process.pid}\n`);
+
+    const result = spawnSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'concurrent', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${fakeBin}:/usr/bin:/bin`, OMC_HUD_CACHE_DIR: cacheDir },
+      timeout: 2000,
+    });
+    expect(result.stdout).toBe('CACHED\n');
+    expect(readFileSync(activeErr, 'utf8')).toContain('concurrent');
 
     rmSync(tempRoot, { recursive: true, force: true });
   });

--- a/src/__tests__/hud-cache-wrapper.test.ts
+++ b/src/__tests__/hud-cache-wrapper.test.ts
@@ -80,7 +80,7 @@ describe('HUD cache wrapper lock ownership (issue #3933 defect 1)', () => {
     makeOld(liveLock);
     try {
       makeOld(join(liveLock, 'pid'));
-    } catch {}
+    } catch { void 0; }
 
     const cached = join(cacheDir, 'statusline.live-session.txt');
     writeFileSync(cached, 'EXISTING\n');
@@ -94,13 +94,13 @@ describe('HUD cache wrapper lock ownership (issue #3933 defect 1)', () => {
 
     try {
       rmSync(liveLock, { recursive: true, force: true });
-    } catch {}
+    } catch { void 0; }
     mkdirSync(liveLock, { recursive: true });
     writeFileSync(join(liveLock, 'pid'), `${process.pid}\n`);
     makeOld(liveLock);
     try {
       makeOld(join(liveLock, 'pid'));
-    } catch {}
+    } catch { void 0; }
 
     const result = spawnSync('sh', [wrapperPath, hudScript], {
       input: JSON.stringify({ session_id: 'live-session', cwd: tempRoot }),
@@ -133,7 +133,7 @@ describe('HUD cache wrapper lock ownership (issue #3933 defect 1)', () => {
     makeOld(deadLock);
     try {
       makeOld(join(deadLock, 'pid'));
-    } catch {}
+    } catch { void 0; }
 
     const hudScript = join(tempRoot, 'fake-hud.mjs');
     writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('recovered'));\n");


### PR DESCRIPTION
Fixes #3933

## Summary

`scripts/lib/hud-cache-wrapper.sh` had two independent wrapper-lifecycle defects — neither makes the HUD slow, but both turn a slow render into an unbounded runaway or leak instead of degraded statusline, and `PR #3932 / issue #3922` does not touch this file.

## Defect 1 — lock fails open (mtime-only staleness evicts live holder)

- `try_acquire_lock` / `cleanup_stale_render_locks` treated a lock as stale solely via `is_stale_path` (mtime age > `OMC_HUD_LOCK_STALE_SECONDS`, 10s default). Any render exceeding that wall time caused the next caller to `rm -rf` the live holder's `render.<session>.lock` and start unbounded concurrent renders (reporter: 179 concurrent HUD procs, load 173).
- Fix records holder PID in `render.<session>.lock/pid` after atomic `mkdir` and gates staleness on liveness: live holder is never evicted regardless of mtime; dead-holder / malformed metadata only reclaimed when pid is not alive **and** directory is mtime-stale (avoids racing a just-acquired lock). Liveness uses portable `kill -0` with `ps -p` EPERM disambiguation (fail-closed on alive). Global sweep double-checks staleness before `rm -rf` (TOCTOU). `release_lock_if_owned` only removes a lock when pid matches the refresh owner, preventing deletion of a newly acquired successor. Background refresh rewrites pid to the subshell owner to avoid parent-PID mismatch. No `pkill` / broad matching.
- Portable POSIX `sh` on macOS/Linux; invalid PID / empty pid / reused PID handled fail-closed (reuse only delays reclamation until PID dies).

## Defect 2 — non-empty `.err` files never reclaimed

- `cleanup_empty_temp_files` iterated `stdin.*.tmp`, `statusline.*.tmp`, **and** `statusline.*.err` behind ` [ -s ... ] && continue`, so every non-empty `.err` was kept forever. Reporter observed 6594 files / 26 MB oldest 3 months; after manual purge 236 files / 936 KB in 4 hours with 43 non-empty `.err` (render rate).
- Fix splits sweeps: `stdin.*.tmp` / `statusline.*.tmp` keep the empty-only semantic; `statusline.*.err` now reclaimed on staleness regardless of size, bounded by the same mtime threshold that protects actively-written files (fresh err within threshold is retained).

## Scope

- Only `scripts/lib/hud-cache-wrapper.sh` + its direct regression test `src/__tests__/hud-cache-wrapper.test.ts`. Installer shipping unchanged — `src/installer/index.ts:820-821` and `scripts/plugin-setup.mjs:59` already copy this wrapper to `$CLAUDE_CONFIG_DIR/hud/omc-hud-cache.sh` and are covered by `src/installer/__tests__/hud-cache-wrapper.test.ts` (8 tests pass). No changes to `#3922` / `PR #3932`.

## Tests

- Existing `src/__tests__/hud-cache-wrapper.test.ts` existing assertion preserved (fresh non-empty diagnostic retained; stale empties reclaimed).
- Added deterministic regression coverage for:
  - live holder not evicted when mtime-stale (pid alive via `process.pid`);
  - dead holder reclaimed when mtime-stale (`pid=999999`);
  - malformed pid metadata reclaimable only when stale (fresh vs stale pair);
  - hot-path serialization — `try_acquire_lock` allows at most one fresh render (counter-gated `slow-hud.mjs` with `OMC_HUD_SYNC_REFRESH=1`; manual lock held by `process.pid` blocks second refresh, counter stays 1);
  - non-empty stale `.err` reclamation vs fresh diagnostic retention;
  - fresh actively-written `.err` not deleted (staleness gate).
- Local: `npx vitest run src/__tests__/hud-cache-wrapper.test.ts` — 7 passed; `src/installer/__tests__/hud-cache-wrapper.test.ts` — 8 passed; `tsc --noEmit` OK; `eslint` OK; `npm run build` OK; inventory / entitlements / prompt-projections verify OK.
- Exact head: `8f219ac` (`fix/issue-3933-hud-cache-wrapper`), base `dev@0266f1e`.

## Repro

- Prior to fix, shell repro: `mkdir render.evict-test.lock; touch -d '30 seconds ago' render.evict-test.lock` with `LOCK_STALE_SECONDS=10` -> `is_stale_path` returns true and wrapper would `rm -rf` a live holder. After fix, `is_lock_stale` checks `lock/pid` liveness and refuses to evict while PID alive; non-empty stale `.err` previously skipped by `[ -s ] && continue` now removed via `cleanup_stale_err_files`.

## Checklist
- [x] Repro before edit (see evidence above / local shell repro)
- [x] Minimal robust fix, portable POSIX
- [x] Deterministic regression tests (no timing-only assertions)
- [x] Installer/package shipping surfaces inspected
- [x] Focused tests + typecheck/lint/build/package smoke + inventory checks
