### PR TITLE
fix(hud): reclaim stale non-empty stdin tmp orphans and bounded per-session caches (#3938)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2312df264241d27772f39f67312add0e040efe87",
-    "sourceSha256": "9cebd06b5b6aa8b71f6725cb47a5df6161fe54395cb3d5e9b75b2821c8bd350e",
+    "head": "71ed78eb7bc5a97885b10885134e0090ceb96825",
+    "sourceSha256": "9b4f5e5d84087b7a69997cdfdabda20fdeb26c42e92debbe69cb121884898e44",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2312df264241d27772f39f67312add0e040efe87",
-  "sourceSha256": "9cebd06b5b6aa8b71f6725cb47a5df6161fe54395cb3d5e9b75b2821c8bd350e",
+  "head": "71ed78eb7bc5a97885b10885134e0090ceb96825",
+  "sourceSha256": "9b4f5e5d84087b7a69997cdfdabda20fdeb26c42e92debbe69cb121884898e44",
   "counts": {
     "public": {
       "skills": 35,
@@ -76865,5 +76865,5 @@
     }
   },
   "inventorySha256": "59d8e7887c4f056d32685499f2fef5ea8af9663a529f1d159c61fdfc038efce4",
-  "manifestSha256": "b556dc027126211938deba1e7d8746b51a22dbc030720583fabc5f698a3713c6"
+  "manifestSha256": "07246f0b3cbb79e9a15e66764ba565ff156791cf2bbfed658eef1d02e644f5af"
 }

--- a/scripts/lib/hud-cache-wrapper.sh
+++ b/scripts/lib/hud-cache-wrapper.sh
@@ -18,6 +18,7 @@ CACHE_DIR=${OMC_HUD_CACHE_DIR:-"$CONFIG_DIR/hud/cache"}
 HUD_SCRIPT=${1:-"$SCRIPT_DIR/omc-hud.mjs"}
 INPUT_TMP="$CACHE_DIR/stdin.$$.tmp"
 LOCK_STALE_SECONDS=${OMC_HUD_LOCK_STALE_SECONDS:-10}
+CACHE_TTL_SECONDS=${OMC_HUD_CACHE_TTL_SECONDS:-604800}
 
 mkdir -p "$CACHE_DIR" 2>/dev/null || {
   printf '[OMC] Starting...\n'
@@ -40,6 +41,15 @@ is_stale_path() {
   [ -n "$path_mtime" ] || return 1
   [ "$now" -gt 0 ] || return 1
   [ $((now - path_mtime)) -gt "$LOCK_STALE_SECONDS" ] || return 1
+}
+
+is_cache_stale_path() {
+  path=$1
+  now=$(date +%s 2>/dev/null || printf '0')
+  path_mtime=$(file_mtime "$path")
+  [ -n "$path_mtime" ] || return 1
+  [ "$now" -gt 0 ] || return 1
+  [ $((now - path_mtime)) -gt "$CACHE_TTL_SECONDS" ] || return 1
 }
 
 is_numeric_pid() {
@@ -130,10 +140,9 @@ release_lock_if_owned() {
   fi
 }
 
-cleanup_empty_temp_files() {
+cleanup_stale_temp_files() {
   for temp_path in "$CACHE_DIR"/stdin.*.tmp "$CACHE_DIR"/statusline.*.tmp; do
     [ -f "$temp_path" ] || continue
-    [ -s "$temp_path" ] && continue
     is_stale_path "$temp_path" || continue
     rm -f "$temp_path" 2>/dev/null || :
   done
@@ -151,14 +160,22 @@ cleanup_stale_render_locks() {
   for stale_lock_dir in "$CACHE_DIR"/render.*.lock; do
     [ -d "$stale_lock_dir" ] || continue
     is_lock_stale "$stale_lock_dir" || continue
-    is_lock_stale "$stale_lock_dir" || continue
     rm -rf "$stale_lock_dir" 2>/dev/null || :
   done
 }
 
-cleanup_empty_temp_files
+cleanup_stale_session_caches() {
+  for cache_path in "$CACHE_DIR"/stdin.*.json "$CACHE_DIR"/statusline.*.txt; do
+    [ -f "$cache_path" ] || continue
+    is_cache_stale_path "$cache_path" || continue
+    rm -f "$cache_path" 2>/dev/null || :
+  done
+}
+
+cleanup_stale_temp_files
 cleanup_stale_err_files
 cleanup_stale_render_locks
+cleanup_stale_session_caches
 
 # Capture Claude's current statusLine stdin first so rendered output can be
 # scoped per session/worktree instead of leaking across concurrent sessions.

--- a/src/__tests__/hud-cache-wrapper.test.ts
+++ b/src/__tests__/hud-cache-wrapper.test.ts
@@ -12,6 +12,11 @@ function makeOld(path: string): void {
   utimesSync(path, old, old);
 }
 
+function makeVeryOld(path: string): void {
+  const veryOld = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+  utimesSync(path, veryOld, veryOld);
+}
+
 function makeFresh(path: string): void {
   const now = new Date();
   utimesSync(path, now, now);
@@ -317,6 +322,138 @@ describe('HUD cache wrapper err reclamation (issue #3933 defect 2)', () => {
     });
     expect(result.stdout).toBe('CACHED\n');
     expect(readFileSync(activeErr, 'utf8')).toContain('concurrent');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+});
+
+describe('HUD cache wrapper orphan reclamation (issue #3938)', () => {
+  it('reclaims stale non-empty stdin/statusline tmps while preserving fresh in-flight tmps', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-3938-orphan-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const staleNonEmptyStdin = join(cacheDir, 'stdin.orphan.99999.tmp');
+    const staleNonEmptyStatusline = join(cacheDir, 'statusline.orphan.99999.tmp');
+    const staleEmptyStdin = join(cacheDir, 'stdin.88888.tmp');
+    writeFileSync(staleNonEmptyStdin, '{"session_id":"orphan"}\n');
+    writeFileSync(staleNonEmptyStatusline, 'render output\n');
+    writeFileSync(staleEmptyStdin, '');
+    makeOld(staleNonEmptyStdin);
+    makeOld(staleNonEmptyStatusline);
+    makeOld(staleEmptyStdin);
+
+    const freshNonEmptyStdin = join(cacheDir, 'stdin.11111.tmp');
+    const freshNonEmptyStatusline = join(cacheDir, 'statusline.fresh.11111.tmp');
+    writeFileSync(freshNonEmptyStdin, '{"fresh":true}\n');
+    writeFileSync(freshNonEmptyStatusline, 'fresh render\n');
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('ok'));\n");
+
+    const output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'repro-3938', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(output).toBe('ok\n');
+    expect(existsSync(staleNonEmptyStdin)).toBe(false);
+    expect(existsSync(staleNonEmptyStatusline)).toBe(false);
+    expect(existsSync(staleEmptyStdin)).toBe(false);
+    expect(readFileSync(freshNonEmptyStdin, 'utf8')).toContain('fresh');
+    expect(readFileSync(freshNonEmptyStatusline, 'utf8')).toContain('fresh render');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('does not delete the current invocation stdin pid tmp via stale window', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-3938-live-tmp-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('live-ok'));\n");
+
+    const output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'live-tmp-check', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(output).toBe('live-ok\n');
+    expect(readFileSync(join(cacheDir, 'stdin.live-tmp-check.json'), 'utf8')).toContain('live-tmp-check');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+});
+
+describe('HUD cache wrapper per-session cache TTL (issue #3938)', () => {
+  it('reclaims stale per-session json/txt on bounded TTL without touching fresh session caches', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-3938-ttl-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const staleJson = join(cacheDir, 'stdin.old-session.json');
+    const staleTxt = join(cacheDir, 'statusline.old-session.txt');
+    writeFileSync(staleJson, '{"session_id":"old-session"}\n');
+    writeFileSync(staleTxt, 'old render\n');
+    makeVeryOld(staleJson);
+    makeVeryOld(staleTxt);
+
+    const freshJson = join(cacheDir, 'stdin.fresh-session.json');
+    const freshTxt = join(cacheDir, 'statusline.fresh-session.txt');
+    writeFileSync(freshJson, '{"session_id":"fresh-session"}\n');
+    writeFileSync(freshTxt, 'fresh render\n');
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('ttl-ok'));\n");
+
+    const output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: 'ttl-probe', cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(output).toBe('ttl-ok\n');
+    expect(existsSync(staleJson)).toBe(false);
+    expect(existsSync(staleTxt)).toBe(false);
+    expect(readFileSync(freshJson, 'utf8')).toContain('fresh-session');
+    expect(readFileSync(freshTxt, 'utf8')).toContain('fresh render');
+
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('active session json/txt survives because its mtime is refreshed on each render', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'omc-hud-3938-active-ttl-'));
+    const cacheDir = join(tempRoot, 'cache');
+    mkdirSync(cacheDir, { recursive: true });
+
+    const hudScript = join(tempRoot, 'fake-hud.mjs');
+    writeFileSync(hudScript, "process.stdin.resume(); process.stdin.on('end', () => console.log('active-ok'));\n");
+
+    const sessionId = 'active-ttl-session';
+    let output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: sessionId, cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(output).toBe('active-ok\n');
+    const activeJson = join(cacheDir, `stdin.${sessionId}.json`);
+    const activeTxt = join(cacheDir, `statusline.${sessionId}.txt`);
+    expect(existsSync(activeJson)).toBe(true);
+    expect(existsSync(activeTxt)).toBe(true);
+
+    output = execFileSync('sh', [wrapperPath, hudScript], {
+      input: JSON.stringify({ session_id: sessionId, cwd: tempRoot }),
+      encoding: 'utf8',
+      env: { ...process.env, OMC_HUD_CACHE_DIR: cacheDir, OMC_HUD_SYNC_REFRESH: '1' },
+      timeout: 2000,
+    });
+    expect(output).toBe('active-ok\n');
+    expect(existsSync(activeJson)).toBe(true);
+    expect(existsSync(activeTxt)).toBe(true);
 
     rmSync(tempRoot, { recursive: true, force: true });
   });


### PR DESCRIPTION
Fixes #3938 — regression from #3935 (`01d147a93`).

**Root cause at `dev @ 8d648c94d`:** `cleanup_empty_temp_files()` in `scripts/lib/hud-cache-wrapper.sh:133` guarded `stdin.*.tmp`/`statusline.*.tmp` with `[ -s "$temp_path" ] && continue`, so exactly the non-empty orphans left by a killed wrapper (the common kill-on-rerender case) were never reclaimed. `cleanup_stale_err_files()` was already correct (staleness-only).

**Fix (smallest correct change):**
- Drop the `-s` emptiness filter and reclaim `stdin.*.tmp`/`statusline.*.tmp` on the same staleness window as `.err` (`OMC_HUD_LOCK_STALE_SECONDS`, default 10s) — stale orphans reclaimed, fresh in-flight temps preserved. Rename to `cleanup_stale_temp_files`.
- Bounded TTL for live per-session `stdin.*.json`/`statusline.*.txt` (default 7 days via `OMC_HUD_CACHE_TTL_SECONDS`, active sessions stay fresh because `INPUT_FILE`/`OUTPUT_FILE` are rewritten on every render).
- Deduplicate the repeated `is_lock_stale` guard in `cleanup_stale_render_locks`.

Preserves the atomic `mkdir`-based lock acquisition and pid-aware `is_lock_stale` recovery added in #3935; no change to the HUD memoization path from #3932.

**Validation:** `sh -n` OK, `npx tsc --noEmit` OK, `npm run build` OK, deterministic regression tests (stale non-empty reclaimed / fresh preserved / TTL / lock & atomic & err suites) green. Reported measurement credited on close: ~80 `stdin.*.tmp` + 92 `stdin.*.json` + 74 `statusline.*.txt` / 984K leaked over ~3 days at the base head.