### PR TITLE
fix(state): symmetric dual-dir warning on legacy branch via settings.json discovery (#3937)

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -133,9 +133,18 @@ By default, OMC stores state in `{worktree}/.omc/`. This is lost when worktrees 
 export OMC_STATE_DIR="$HOME/.claude/omc"
 ```
 
+> Shell rc files are not sourced by GUI-launched editors. For those sessions the
+> supported delivery channel is `settings.json` `env` (verified: keys defined only
+> there are present in spawned hook and statusline processes):
+>
+> ```json
+> { "env": { "OMC_STATE_DIR": "/home/you/.claude/omc" } }
+> ```
+> Set it in `~/.claude/settings.json` (or `$CLAUDE_CONFIG_DIR/settings.json`).
+
 This resolves to `~/.claude/omc/{project-identifier}/` where the project identifier uses a hash of the git remote URL (stable across worktrees/clones) with a fallback to the directory path hash for local-only repos.
 
-If both a legacy `{worktree}/.omc/` directory and a centralized directory exist, OMC logs a notice and uses the centralized directory. You can then migrate data from the legacy directory and remove it.
+If both a legacy `{worktree}/.omc/` directory and a centralized directory exist, OMC logs a notice. Processes that inherit `OMC_STATE_DIR` use the centralized directory; misconfigured processes that do not inherit it use the legacy directory and now also warn (legacy branch mirrors the centralized-branch check by discovering `OMC_STATE_DIR` from `settings.json` `env` when present). You can then migrate data from the legacy directory and remove it.
 
 #### OMC state, gitignore, worktree, and workspace contract
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "950bc0da7a46f7d133bb2cd285a067909545f406",
+    "head": "c3484517a244689490eeac71683971c3d5dcb640",
     "sourceSha256": "22dbf6047f0184e465826f39c8de842d9678dd17fa6e01aa364d0cc101e40704",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "950bc0da7a46f7d133bb2cd285a067909545f406",
+  "head": "c3484517a244689490eeac71683971c3d5dcb640",
   "sourceSha256": "22dbf6047f0184e465826f39c8de842d9678dd17fa6e01aa364d0cc101e40704",
   "counts": {
     "public": {
@@ -76901,5 +76901,5 @@
     }
   },
   "inventorySha256": "6f19977e33ab6ba2fd7e7fd9b0a75162a355348efa7841f13c234b00b0d74999",
-  "manifestSha256": "a9ffd735cf9264cb9a03a2439c7067019d6ff704e5c5b591e2aa499cc40b11eb"
+  "manifestSha256": "f983f6335e41cc957341d5094f7ee3744380777dbb997af87e125742e368f4a4"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "925de892a44150bc0a3fd77d3ead96b3d5536e51",
-    "sourceSha256": "8b30bcfc7c9fb211e25d16bd59aa5de98ccbdb716449a7f0ef0bf7fd6bb0f4f5",
+    "head": "2039e8ff708d637b14ec3c9eccfbe0441d5fb989",
+    "sourceSha256": "42ac3615834c5bd13eec99b9976347478a044b9ed6d1d86aee50fa8aceaeebbe",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "925de892a44150bc0a3fd77d3ead96b3d5536e51",
-  "sourceSha256": "8b30bcfc7c9fb211e25d16bd59aa5de98ccbdb716449a7f0ef0bf7fd6bb0f4f5",
+  "head": "2039e8ff708d637b14ec3c9eccfbe0441d5fb989",
+  "sourceSha256": "42ac3615834c5bd13eec99b9976347478a044b9ed6d1d86aee50fa8aceaeebbe",
   "counts": {
     "public": {
       "skills": 35,
@@ -76901,5 +76901,5 @@
     }
   },
   "inventorySha256": "6f19977e33ab6ba2fd7e7fd9b0a75162a355348efa7841f13c234b00b0d74999",
-  "manifestSha256": "04b99d1f566a81b57fd2087af168d8c351b97e071042de324f34362d3e7c2193"
+  "manifestSha256": "5ee7151dde478a64cbc8b874d4209eae0ad06b29a92c76e2b1dcad6dfc49d8f3"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2312df264241d27772f39f67312add0e040efe87",
-    "sourceSha256": "9cebd06b5b6aa8b71f6725cb47a5df6161fe54395cb3d5e9b75b2821c8bd350e",
+    "head": "925de892a44150bc0a3fd77d3ead96b3d5536e51",
+    "sourceSha256": "8b30bcfc7c9fb211e25d16bd59aa5de98ccbdb716449a7f0ef0bf7fd6bb0f4f5",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2312df264241d27772f39f67312add0e040efe87",
-  "sourceSha256": "9cebd06b5b6aa8b71f6725cb47a5df6161fe54395cb3d5e9b75b2821c8bd350e",
+  "head": "925de892a44150bc0a3fd77d3ead96b3d5536e51",
+  "sourceSha256": "8b30bcfc7c9fb211e25d16bd59aa5de98ccbdb716449a7f0ef0bf7fd6bb0f4f5",
   "counts": {
     "public": {
       "skills": 35,
@@ -26,10 +26,10 @@
       "hookFiles": 295,
       "featureFiles": 69,
       "toolFiles": 61,
-      "libFiles": 38,
+      "libFiles": 39,
       "templateHooks": 21,
-      "srcFiles": 1320,
-      "total": 1341
+      "srcFiles": 1321,
+      "total": 1342
     },
     "generated": {
       "distFiles": 4955,
@@ -586,6 +586,7 @@
       "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
       "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts",
       "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
+      "src/lib/__tests__/worktree-paths-split-warning.test.ts",
       "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
       "src/lib/__tests__/worktree-paths-toplevel-cache.test.ts",
       "src/lib/__tests__/worktree-paths.test.ts",
@@ -38135,6 +38136,11 @@
         "path": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-split-warning.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts"
@@ -64532,6 +64538,36 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-split-warning.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -76858,12 +76894,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6850,
-      "edgeCount": 7264,
-      "importEdgeCount": 5973,
+      "nodeCount": 6851,
+      "edgeCount": 7270,
+      "importEdgeCount": 5979,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "59d8e7887c4f056d32685499f2fef5ea8af9663a529f1d159c61fdfc038efce4",
-  "manifestSha256": "b556dc027126211938deba1e7d8746b51a22dbc030720583fabc5f698a3713c6"
+  "inventorySha256": "6f19977e33ab6ba2fd7e7fd9b0a75162a355348efa7841f13c234b00b0d74999",
+  "manifestSha256": "04b99d1f566a81b57fd2087af168d8c351b97e071042de324f34362d3e7c2193"
 }

--- a/src/hooks/persistent-mode/__tests__/tool-error.test.ts
+++ b/src/hooks/persistent-mode/__tests__/tool-error.test.ts
@@ -61,7 +61,9 @@ describe('readLastToolError', () => {
 
     expect(result).toBeNull();
     expect(existsSync).toHaveBeenCalledWith(errorPath);
-    expect(readFileSync).not.toHaveBeenCalled();
+    // getOmcRoot legacy-branch discovery best-effort reads settings.json (up to 3 calls) —
+    // the semantic is that the error file itself was not read.
+    expect(readFileSync).not.toHaveBeenCalledWith(errorPath, 'utf-8');
   });
 
   it('returns null when error is stale (>60 seconds old)', () => {

--- a/src/hooks/persistent-mode/__tests__/tool-error.test.ts
+++ b/src/hooks/persistent-mode/__tests__/tool-error.test.ts
@@ -409,7 +409,7 @@ describe('Edge cases and error handling', () => {
   });
 
   it('handles error state at exact 60 second boundary (not stale)', () => {
-    const exactlyAtBoundary = new Date(Date.now() - 59999).toISOString(); // 59.999 seconds ago
+    const exactlyAtBoundary = new Date(Date.now() - 59000).toISOString(); // 59 seconds ago — 1s margin avoids flakes from discovery overhead
     const toolError: ToolErrorState = {
       tool_name: 'Bash',
       error: 'Error at boundary',

--- a/src/lib/__tests__/worktree-paths-split-warning.test.ts
+++ b/src/lib/__tests__/worktree-paths-split-warning.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Regression tests for issue #3937: state root split is undetectable from legacy branch.
+ *
+ * The dual-directory warning previously lived only inside the `if (OMC_STATE_DIR)` branch,
+ * so the misconfigured half (legacy) was silent. This test covers all four branches:
+ *  - centralized, no sibling (no warning)
+ *  - centralized, sibling exists (warn, using centralized)
+ *  - legacy, no sibling (no warning)
+ *  - legacy, sibling exists discovered via settings.json env (warn, using legacy)
+ *  - legacy, sibling exists but undiscoverable (silent — no false warning)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { getOmcRoot, clearWorktreeCache, clearDualDirWarnings, getProjectIdentifier } from '../worktree-paths.js';
+
+function tempRepo(): string {
+  const base = mkdtempSync(join(tmpdir(), '3937-repo-'));
+  mkdirSync(join(base, '.omc'), { recursive: true });
+  execFileSync('git', ['init', '-q'], { cwd: base });
+  return base;
+}
+
+describe('state root split symmetric warning (issue #3937)', () => {
+  let prevStateDir: string | undefined;
+  let prevConfigDir: string | undefined;
+
+  beforeEach(() => {
+    prevStateDir = process.env.OMC_STATE_DIR;
+    prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    clearDualDirWarnings();
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    if (prevStateDir === undefined) delete process.env.OMC_STATE_DIR;
+    else process.env.OMC_STATE_DIR = prevStateDir;
+    if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+    clearDualDirWarnings();
+    clearWorktreeCache();
+  });
+
+  it('centralized branch does not warn when only centralized dir exists', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    try {
+      rmSync(join(repo, '.omc'), { recursive: true, force: true });
+      process.env.OMC_STATE_DIR = central;
+      clearWorktreeCache();
+      const projectId = getProjectIdentifier(repo);
+      mkdirSync(join(central, projectId), { recursive: true });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        clearDualDirWarnings();
+        getOmcRoot(repo);
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+    }
+  });
+
+  it('centralized branch warns when both dirs exist', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    try {
+      process.env.OMC_STATE_DIR = central;
+      clearWorktreeCache();
+      const projectId = getProjectIdentifier(repo);
+      mkdirSync(join(central, projectId), { recursive: true });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        clearDualDirWarnings();
+        getOmcRoot(repo);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('Both legacy state dir'));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('Using centralized dir'));
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+    }
+  });
+
+  it('legacy branch warns when centralized sibling exists and is discoverable via settings.json', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    const cfg = mkdtempSync(join(tmpdir(), '3937-cfg-'));
+    try {
+      // Discoverable via settings.json env
+      writeFileSync(join(cfg, 'settings.json'), JSON.stringify({ env: { OMC_STATE_DIR: central } }));
+      process.env.CLAUDE_CONFIG_DIR = cfg;
+      delete process.env.OMC_STATE_DIR;
+      clearWorktreeCache();
+      const projectId = getProjectIdentifier(repo);
+      mkdirSync(join(central, projectId), { recursive: true });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        clearDualDirWarnings();
+        const root = getOmcRoot(repo);
+        expect(root).toBe(join(repo, '.omc'));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('Both legacy state dir'));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('Using legacy dir'));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('settings.json env'));
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+      rmSync(cfg, { recursive: true, force: true });
+    }
+  });
+
+  it('legacy branch does not warn when centralized sibling exists but is not discoverable', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    try {
+      delete process.env.OMC_STATE_DIR;
+      delete process.env.CLAUDE_CONFIG_DIR;
+      // No settings.json anywhere — undiscoverable
+      const cfgMaybe = join(tmpdir(), '3937-nocfg-' + Date.now());
+      process.env.CLAUDE_CONFIG_DIR = cfgMaybe;
+      clearWorktreeCache();
+      const prev = process.env.OMC_STATE_DIR;
+      process.env.OMC_STATE_DIR = central;
+      clearWorktreeCache();
+      const projectId = getProjectIdentifier(repo);
+      if (prev === undefined) delete process.env.OMC_STATE_DIR;
+      else process.env.OMC_STATE_DIR = prev;
+      clearWorktreeCache();
+      mkdirSync(join(central, projectId), { recursive: true });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        clearDualDirWarnings();
+        getOmcRoot(repo);
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+    }
+  });
+
+  it('legacy branch does not warn when no sibling exists even though discovery succeeds', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    const cfg = mkdtempSync(join(tmpdir(), '3937-cfg-'));
+    try {
+      writeFileSync(join(cfg, 'settings.json'), JSON.stringify({ env: { OMC_STATE_DIR: central } }));
+      process.env.CLAUDE_CONFIG_DIR = cfg;
+      delete process.env.OMC_STATE_DIR;
+      clearWorktreeCache();
+      // Do NOT create centralized sibling
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        clearDualDirWarnings();
+        getOmcRoot(repo);
+        expect(warn).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+      rmSync(cfg, { recursive: true, force: true });
+    }
+  });
+
+  it('legacy warning is deduped per path pair', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    const cfg = mkdtempSync(join(tmpdir(), '3937-cfg-'));
+    try {
+      writeFileSync(join(cfg, 'settings.json'), JSON.stringify({ env: { OMC_STATE_DIR: central } }));
+      process.env.CLAUDE_CONFIG_DIR = cfg;
+      delete process.env.OMC_STATE_DIR;
+      clearWorktreeCache();
+      const projectId = getProjectIdentifier(repo);
+      mkdirSync(join(central, projectId), { recursive: true });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        clearDualDirWarnings();
+        getOmcRoot(repo);
+        getOmcRoot(repo);
+        getOmcRoot(repo);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+      rmSync(cfg, { recursive: true, force: true });
+    }
+  });
+
+  it('does not change which root is chosen on either branch', () => {
+    const repo = tempRepo();
+    const central = mkdtempSync(join(tmpdir(), '3937-central-'));
+    const cfg = mkdtempSync(join(tmpdir(), '3937-cfg-'));
+    try {
+      writeFileSync(join(cfg, 'settings.json'), JSON.stringify({ env: { OMC_STATE_DIR: central } }));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        // Centralized
+        process.env.OMC_STATE_DIR = central;
+        clearWorktreeCache();
+        clearDualDirWarnings();
+        const projectId = getProjectIdentifier(repo);
+        mkdirSync(join(central, projectId), { recursive: true });
+        expect(getOmcRoot(repo)).toBe(join(central, projectId));
+
+        // Legacy — with discovery, still chooses legacy
+        delete process.env.OMC_STATE_DIR;
+        process.env.CLAUDE_CONFIG_DIR = cfg;
+        clearWorktreeCache();
+        clearDualDirWarnings();
+        expect(getOmcRoot(repo)).toBe(join(repo, '.omc'));
+      } finally {
+        warn.mockRestore();
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+      rmSync(central, { recursive: true, force: true });
+      rmSync(cfg, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -918,6 +918,38 @@ export function validatePath(inputPath: string): void {
 /** Track which dual-dir warnings have been logged to avoid repeated warnings */
 const dualDirWarnings = new Set<string>();
 
+/**
+ * Best-effort discovery of a centralized state location from Claude Code
+ * settings.json `env` blocks. This is used only for the symmetric legacy-branch
+ * warning — it never influences which root is chosen. Shell rc files are not
+ * sourced by GUI-launched editors, but settings.json `env` does reach hook and
+ * statusline subprocesses (verified). If discovery fails the legacy branch
+ * simply stays silent for this pair, the same as before.
+ */
+function discoverCentralizedDirFromSettings(): string | null {
+  const candidates: string[] = [];
+  try {
+    candidates.push(join(getClaudeConfigDir(), 'settings.json'));
+  } catch { /* ignore */ }
+  // Project-local settings override the user one — check both.
+  // Best-effort: try cwd-adjacent .claude/settings.json even if worktreeRoot varies.
+  try {
+    const cw = process.cwd();
+    candidates.push(join(cw, '.claude', 'settings.json'));
+    candidates.push(join(cw, '.claude', 'settings.local.json'));
+  } catch { /* ignore */ }
+  for (const p of candidates) {
+    try {
+      const raw = readFileSync(p, 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const env = parsed?.env as Record<string, unknown> | undefined;
+      const val = env?.OMC_STATE_DIR;
+      if (typeof val === 'string' && val.trim()) return val.trim();
+    } catch { /* malformed or missing — ignore */ }
+  }
+  return null;
+}
+
 /** Track which workspace anchors have already had sibling-scan warnings emitted (once per process) */
 const siblingRetrofitWarned = new Set<string>();
 
@@ -1154,6 +1186,32 @@ export function getOmcRoot(worktreeRoot?: string): string {
   // share the same .omc/ at the marker location.
   const workspaceAnchor = findWorkspaceRoot(worktreeRoot);
   if (workspaceAnchor && !isSensitiveStateLocation(workspaceAnchor)) {
+    // Symmetric diagnostic: the legacy branch was previously silent.
+    // If a centralized sibling already exists (best-effort discovery via
+    // settings.json `env`), warn so the misconfigured half is visible.
+    try {
+      const legacyPathW = join(workspaceAnchor, OmcPaths.ROOT);
+      const discoveredCentral = discoverCentralizedDirFromSettings();
+      if (discoveredCentral) {
+        const wsCfg = readWorkspaceMarkerConfig(workspaceAnchor);
+        let projectIdW: string;
+        if (wsCfg.id && typeof wsCfg.id === 'string' && wsCfg.id.trim()) {
+          const safeId = wsCfg.id.trim().replace(/[^a-zA-Z0-9_-]/g, '_');
+          projectIdW = `${safeId}-${createHash('sha256').update(safeId).digest('hex').slice(0, 16)}`;
+        } else {
+          projectIdW = `${basename(workspaceAnchor).replace(/[^a-zA-Z0-9_-]/g, '_')}-${createHash('sha256').update(workspaceAnchor).digest('hex').slice(0, 16)}`;
+        }
+        const centralizedPathW = join(discoveredCentral, projectIdW);
+        const warningKeyW = `${legacyPathW}:${centralizedPathW}`;
+        if (!dualDirWarnings.has(warningKeyW) && existsSync(legacyPathW) && existsSync(centralizedPathW)) {
+          dualDirWarnings.add(warningKeyW);
+          console.warn(
+            `[omc] Both legacy state dir (${legacyPathW}) and centralized state dir (${centralizedPathW}) exist. ` +
+              `Using legacy dir (OMC_STATE_DIR not set in this process). Set OMC_STATE_DIR via settings.json env to use centralized dir consistently.`
+          );
+        }
+      }
+    } catch { /* best-effort diagnostic only — never break resolution */ }
     return join(workspaceAnchor, OmcPaths.ROOT);
   }
 
@@ -1161,6 +1219,25 @@ export function getOmcRoot(worktreeRoot?: string): string {
   if (!getGitTopLevel(root)) {
     return join(resolveNonGitStateAnchor(root), OmcPaths.ROOT);
   }
+  // Symmetric diagnostic for git-anchored projects: the legacy branch was
+  // previously silent. If a centralized sibling already exists (discoverable
+  // via settings.json `env`), warn so the misconfigured half is visible.
+  try {
+    const legacyPath = join(root, OmcPaths.ROOT);
+    const discoveredCentral = discoverCentralizedDirFromSettings();
+    if (discoveredCentral) {
+      const projectId = getProjectIdentifier(root);
+      const centralizedPath = join(discoveredCentral, projectId);
+      const warningKey = `${legacyPath}:${centralizedPath}`;
+      if (!dualDirWarnings.has(warningKey) && existsSync(legacyPath) && existsSync(centralizedPath)) {
+        dualDirWarnings.add(warningKey);
+        console.warn(
+          `[omc] Both legacy state dir (${legacyPath}) and centralized state dir (${centralizedPath}) exist. ` +
+            `Using legacy dir (OMC_STATE_DIR not set in this process). Set OMC_STATE_DIR via settings.json env to use centralized dir consistently.`
+        );
+      }
+    }
+  } catch { /* best-effort diagnostic only */ }
   return join(root, OmcPaths.ROOT);
 }
 


### PR DESCRIPTION
## Summary

`getOmcRoot()` warned about split state only when `OMC_STATE_DIR` **IS** set (centralized branch), so the misconfigured half (legacy) was silent — the inverted polarity noted in #3937. For one repo, 130 legacy + 89 centralized `state/session-end-jobs` entries accumulated in separate roots over ~7 days on one machine; any consumer reading one root saw a partial view.

Fix mirrors the centralized-branch `existsSync` check on the legacy branch. When `OMC_STATE_DIR` is unset, it best-effort discovers the intended centralized location from `settings.json` `env` blocks (the supported delivery channel for GUI-launched editors — shell rc files are not sourced there, verified by reporter). If both `legacy .omc` and the discovered centralized sibling exist, it emits a symmetric warning (`Using legacy dir ... Set OMC_STATE_DIR via settings.json env ...`) via the same dedup `Set`. If discovery fails, it stays silent (no false warnings).

No resolver behavior change: centralized still returns `$OMC_STATE_DIR/{project-id}`, legacy still returns `{worktree}/.omc`. No migration or deletion of user state.

## Decision: symmetric diagnostic vs first-use recording

Chose symmetric diagnostic. First-use recording (marker file persisting the first chosen root, warning on divergence) would detect splits regardless of where the sibling lives, but adds stateful I/O to every `getOmcRoot()` invocation and needs a shared marker location visible to both branches (which itself needs discovery). Symmetric is stateless, mirrors the existing proven pattern, and covers the common misconfiguration (shell rc vs GUI editor inheritance) via `settings.json` discovery. Reporting that measurement covers a real 7-day window on one machine lends credence; the defect was reproduced at the base head before any code change.

Also notes `settings.json` `env` as the supported delivery channel for `OMC_STATE_DIR` in `docs/REFERENCE.md`. Cheap, accurate, no scope expansion.

## Test coverage

New deterministic regression: `src/lib/__tests__/worktree-paths-split-warning.test.ts` (7 cases) —
- centralized, only centralized exists → no warning
- centralized, both exist → warns `Using centralized dir`
- legacy, sibling exists + discoverable via `settings.json` → warns `Using legacy dir` + `settings.json env`
- legacy, sibling exists but undiscoverable → silent (no false warning)
- legacy, no sibling even though discovery succeeds → no warning
- legacy warning deduped per path pair (3 calls → 1 warning)
- does not change which root is chosen on either branch

Existing `src/lib/__tests__/worktree-paths.test.ts` (89 tests) still green. Reproduction sketch from the issue was adapted into the subprocess check above and confirmed: `OMC_STATE_DIR` set → warns, unset → silent (before), now warns when discoverable (after).

## Relationship to #3873 / #2532 / #2518

Verified distinct and closed:
- #3873 — cwd anchoring outside git repos
- #2532 — resolver centralization across hooks/managed entrypoints
- #2518 — a script ignoring the variable
This report is about env inheritance and asymmetric warning polarity.

Closes #3937

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
