### PR TITLE
fix(dev): regenerate inventory graph provenance at dev head 222c38f7

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "c3484517a244689490eeac71683971c3d5dcb640",
+    "head": "222c38f74d6100c6b97fb10bae37784f04b5dea9",
     "sourceSha256": "22dbf6047f0184e465826f39c8de842d9678dd17fa6e01aa364d0cc101e40704",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "c3484517a244689490eeac71683971c3d5dcb640",
+  "head": "222c38f74d6100c6b97fb10bae37784f04b5dea9",
   "sourceSha256": "22dbf6047f0184e465826f39c8de842d9678dd17fa6e01aa364d0cc101e40704",
   "counts": {
     "public": {
@@ -76901,5 +76901,5 @@
     }
   },
   "inventorySha256": "6f19977e33ab6ba2fd7e7fd9b0a75162a355348efa7841f13c234b00b0d74999",
-  "manifestSha256": "f983f6335e41cc957341d5094f7ee3744380777dbb997af87e125742e368f4a4"
+  "manifestSha256": "41c2b051526619565fe2b307842848e68c3d02a7eb256e14af28171c03b59bd7"
 }


### PR DESCRIPTION
## Summary

Regenerates `inventory/inventory-graph.json` so its provenance is anchored to the current `dev` head. Unblocks required `dev` CI without weakening the drift gate.

## Failing run

- Run: https://github.com/Yeachan-Heo/oh-my-claudecode/actions/runs/33717343780
- Job: `Test` (`100529212221`) failing at `dev` `222c38f74d61`
- Failure: `tests/lint/inventory-graph-drift.test.ts:353` — `node scripts/generate-inventory-graph.mjs --verify` exits 2 with `[inventory-graph] committed provenance.head must be an ancestor of the current HEAD`
- Rest of suite on same run: 11 success / 4 skipped / 1 failure, 724 files / 13,707 tests passing

## Root cause

Committed baseline had `provenance.head = c3484517a244689490eeac71683971c3d5dcb640` (`Merge dev@7db7bc5eb198 (issue #3938) into fix/issue-3937-state-root-split`), a commit that only existed on the `fix/issue-3937-state-root-split` branch underlying PR #3940. `git merge-base --is-ancestor c3484517a HEAD` is false at `dev` `222c38f7` after that PR merged, so the stranded branch head makes the baseline non-ancestral on `dev`. PRs #3939 and #3940 each regenerated the deterministic aggregate on their own branch and merged back-to-back, landing the second baseline with a branch head.

## Fix

- Regenerated `inventory/inventory-graph.json` from `dev` `222c38f74d61` via `node scripts/generate-inventory-graph.mjs --write` only. No edits to the generator's ancestry assertion, no change to `tests/lint/inventory-graph-drift.test.ts`, no revert of #3939/#3940.
- Provenance now: `base=05c800f40d1a planningHead=0a91273e61db head=222c38f74d61` (`222c38f74d6100c6b97fb10bae37784f04b5dea9`)
- `sourceSha256` unchanged: `22dbf6047f0184e465826f39c8de842d9678dd17fa6e01aa364d0cc101e40704`
- Counts: `public=84 internal=1342 generated=4964 prompt=62` · Graph: `nodes=6851 edges=7270`

## Verification (pre-push, branch head `5e5ca31`)

- `node scripts/generate-inventory-graph.mjs --verify` → exit 0, `verify ok`
- `npx vitest run tests/lint/inventory-graph-drift.test.ts` → 11/11 passing
- `npx tsc --noEmit` → clean, `npm run build` → clean, `npm pack --dry-run` → `oh-my-claude-sisyphus-5.0.0.tgz` (8.0 MB pack / 42.6 MB unpack, 5464 files)

## Structural note (no code change in this lane)

This is a repeatable hazard: two sibling PRs regenerating the same deterministic aggregate and merging in quick succession will race on the committed baseline, and a baseline stamped with the source branch head will strand after squash-merge. Worth hardening separately (for example, regenerating the inventory baseline at queue/merge time rather than committing branch heads, or refining the provenance rule so a branch head does not land as the dev baseline). Left as a follow-up — this PR intentionally keeps the change minimal to close the red `dev` fast. The generator's ancestry gate is correct; the committed fixture was wrong.

Fixes red `dev` after #3940.
