### PR TITLE
fix(inventory): rebaseline inventory-graph provenance.head onto dev (dev CI red)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "bec03daf0f67782260023d56e17e6c9fde87008b",
+    "head": "dd84654902eb8d94bf379161085722fc34fc7c16",
     "sourceSha256": "ae4e4afdc2d79c00ade0986b337e13831b2c9751355ff33f2309111955914969",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "bec03daf0f67782260023d56e17e6c9fde87008b",
+  "head": "dd84654902eb8d94bf379161085722fc34fc7c16",
   "sourceSha256": "ae4e4afdc2d79c00ade0986b337e13831b2c9751355ff33f2309111955914969",
   "counts": {
     "public": {
@@ -77036,5 +77036,5 @@
     }
   },
   "inventorySha256": "8487e17b5bbdcb30389d7276d19a1d6fc52826c645bd3f46a994b4ef14df6e32",
-  "manifestSha256": "b60a62c89c471b9db5f415d00bc3871e9c2501a9285efd619c39013ce0dc3bea"
+  "manifestSha256": "0ed752f4072379d7cb4e70886cd7a7cfcafb90b318c7c93c32548e9644a664c7"
 }


### PR DESCRIPTION
## Problem

`dev` CI is red at `dd84654902eb8d94bf379161085722fc34fc7c16` (run 33744835254, job `Test`).

`tests/lint/inventory-graph-drift.test.ts > verify mode passes when baseline is current (drift closed)` fails:

```
[inventory-graph] committed provenance.head must be an ancestor of the current HEAD
: expected 2 to be +0
```

Root cause: #3943 committed `inventory/inventory-graph.json` with `provenance.head=bec03daf0f67782260023d56e17e6c9fde87008b`, a PR-branch commit. After the squash merge that sha is not an ancestor of `dev`, so `--verify` exits 2 for every subsequent commit on `dev`.

## Fix

Regenerated the baseline at `dev` head `dd846549` via `scripts/generate-inventory-graph.mjs --write`.

- `provenance.head`: `bec03daf` → `dd846549` (now an ancestor of dev)
- `manifestSha256` refreshed
- No graph content change: `nodes=6856 edges=7292`, `public=84 internal=1346 generated=4964`, `inventorySha256` unchanged

## Verification

`bun scripts/generate-inventory-graph.mjs --verify` → `verify ok — baseline is current`.

Follow-up (not in this PR): the drift gate is structurally fragile for squash-merged PRs that touch the baseline — any PR that regenerates it lands a non-ancestor head on `dev`. Worth making the gate accept the merge commit or regenerating post-merge.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*