### PR TITLE
fix(hud): bound the three unbounded git calls in worktree-paths (#3946)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "dd84654902eb8d94bf379161085722fc34fc7c16",
-    "sourceSha256": "ae4e4afdc2d79c00ade0986b337e13831b2c9751355ff33f2309111955914969",
+    "head": "bc540e523f23b2fc30970a94e767b9178ca4bef5",
+    "sourceSha256": "edf1bab0688240cf38e4ae50963c9dda41c8b40a6595a2b9b53a52a173d27881",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "dd84654902eb8d94bf379161085722fc34fc7c16",
-  "sourceSha256": "ae4e4afdc2d79c00ade0986b337e13831b2c9751355ff33f2309111955914969",
+  "head": "bc540e523f23b2fc30970a94e767b9178ca4bef5",
+  "sourceSha256": "edf1bab0688240cf38e4ae50963c9dda41c8b40a6595a2b9b53a52a173d27881",
   "counts": {
     "public": {
       "skills": 35,
@@ -77036,5 +77036,5 @@
     }
   },
   "inventorySha256": "8487e17b5bbdcb30389d7276d19a1d6fc52826c645bd3f46a994b4ef14df6e32",
-  "manifestSha256": "0ed752f4072379d7cb4e70886cd7a7cfcafb90b318c7c93c32548e9644a664c7"
+  "manifestSha256": "6a8c44a723b62dbfe58f5840a957edeff49746fe33ceb2cc286947c640487e3e"
 }

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -1099,6 +1099,7 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
+      timeout: 5000,
     }).trim();
   } catch {
     // No git remote (local-only repo or not a git repo) — use the normalized
@@ -1811,6 +1812,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
+      timeout: 5000,
     }).trim();
 
     const absoluteCommonDir = resolve(effectiveCwd, gitCommonDir);
@@ -1829,6 +1831,7 @@ export function resolveTranscriptPath(transcriptPath: string | undefined, cwd?: 
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
+      timeout: 5000,
     }).trim();
 
     if (mainRepoRoot !== worktreeTop) {

--- a/tests/lint/windows-hide-hooks.test.ts
+++ b/tests/lint/windows-hide-hooks.test.ts
@@ -426,6 +426,18 @@ describe('Windows Git child-process hardening', () => {
     expect(genericHookManifest().flatMap(({ path, content }) => scanGitTimeouts(path, content))).toEqual([]);
   });
 
+  it('requires every Git child-process call on the HUD render path to have a positive timeout (#3946)', () => {
+    const hudRenderPath = [
+      join(REPO_ROOT, 'src', 'lib', 'worktree-paths.ts'),
+      ...walkFiles(join(REPO_ROOT, 'src', 'hud'), (path) => path.endsWith('.ts') && !/\.(?:test|spec)\.ts$/.test(path)),
+    ]
+      .sort()
+      .map((path) => ({ path: toForwardSlash(relative(REPO_ROOT, path)), content: readFileSync(path, 'utf8') }));
+
+    expect(hudRenderPath.map(({ path }) => path)).toContain('src/lib/worktree-paths.ts');
+    expect(hudRenderPath.flatMap(({ path, content }) => scanGitTimeouts(path, content))).toEqual([]);
+  });
+
   it('requires the owned #3493 nested-git sites to use the shared BOUNDED_GIT_TIMEOUT_MS constant', () => {
     const manifest = productionManifest();
     const owned = manifest.filter(({ path }) => OWNED_NESTED_GIT_FILES.includes(path));


### PR DESCRIPTION
Fixes #3946.

## Change

Three `execFileSync('git', …)` call sites in `src/lib/worktree-paths.ts` had no `timeout` while their four siblings in the same file already pass `timeout: 5000`. All three are on the HUD render path, so a wedged `git` turned a render into a resident `omc-hud.mjs` process:

| line | call | enclosing function |
| --- | --- | --- |
| 1097 | `remote get-url origin` | `getProjectIdentifier()` → `src/hud/state.ts` |
| 1809 | `rev-parse --git-common-dir` | `resolveTranscriptPath()` → `src/hud/index.ts:300` |
| 1827 | `rev-parse --show-toplevel` | `resolveTranscriptPath()` → `src/hud/index.ts:300` |

All three already sit inside `try`/`catch` blocks that fall back (normalized repository identity at 1097, unresolved transcript path at 1809/1827), so a timeout degrades exactly like the "no git remote" case instead of hanging.

## Regression guard

`tests/lint/windows-hide-hooks.test.ts` already has an AST scanner (`scanGitTimeouts`) that enforces positive timeouts, but only over the generic-hook manifest. Added a tier that runs the same scanner over the HUD render path (`src/lib/worktree-paths.ts` + `src/hud/**/*.ts`), so a future unbounded `git` call there fails CI rather than shipping.

## Verification

- `bun x vitest run tests/lint/windows-hide-hooks.test.ts` → 9/9 pass
- Guard has value: removing the `timeout: 5000` from the `remote get-url origin` site makes only the new tier fail (`1 failed | 8 passed`), then passes again once restored
- `bun x tsc --noEmit` → clean

## Note on `inventory/inventory-graph.json`

The drift gate requires a baseline refresh because `sourceSha256` changes with the edited files. It was regenerated with `ISSUE_3702_HEAD=bc540e523f23b2fc30970a94e767b9178ca4bef5` (current `dev`) rather than the PR-branch HEAD, so `provenance.head` remains an ancestor of `dev` after the squash merge. Regenerating with the default HEAD is what took `dev` red in #3943 → #3944, so this is the recipe to use for any PR that touches the baseline.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
