### PR TITLE
fix(hud): bound git calls in worktree-paths (#3946)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "bc540e523f23b2fc30970a94e767b9178ca4bef5",
-    "sourceSha256": "edf1bab0688240cf38e4ae50963c9dda41c8b40a6595a2b9b53a52a173d27881",
+    "head": "e30d899944b3f97df30304a966910a9f2c92df65",
+    "sourceSha256": "16ec9a6d5be8713f13ee2b72927275ce1806ad7fcb5bc67615ebabef78fb8da6",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "bc540e523f23b2fc30970a94e767b9178ca4bef5",
-  "sourceSha256": "edf1bab0688240cf38e4ae50963c9dda41c8b40a6595a2b9b53a52a173d27881",
+  "head": "e30d899944b3f97df30304a966910a9f2c92df65",
+  "sourceSha256": "16ec9a6d5be8713f13ee2b72927275ce1806ad7fcb5bc67615ebabef78fb8da6",
   "counts": {
     "public": {
       "skills": 35,
@@ -26,10 +26,10 @@
       "hookFiles": 295,
       "featureFiles": 69,
       "toolFiles": 61,
-      "libFiles": 39,
+      "libFiles": 40,
       "templateHooks": 21,
-      "srcFiles": 1325,
-      "total": 1346
+      "srcFiles": 1326,
+      "total": 1347
     },
     "generated": {
       "distFiles": 4955,
@@ -585,6 +585,7 @@
       "src/lib/__tests__/worktree-cleanup-safety.test.ts",
       "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
       "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts",
+      "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
       "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
       "src/lib/__tests__/worktree-paths-split-warning.test.ts",
       "src/lib/__tests__/worktree-paths-superproject-cache.test.ts",
@@ -38156,6 +38157,11 @@
         "path": "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-git-timeout.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts"
@@ -64643,6 +64649,36 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -77029,12 +77065,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6856,
-      "edgeCount": 7292,
-      "importEdgeCount": 5998,
+      "nodeCount": 6857,
+      "edgeCount": 7298,
+      "importEdgeCount": 6004,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "8487e17b5bbdcb30389d7276d19a1d6fc52826c645bd3f46a994b4ef14df6e32",
-  "manifestSha256": "6a8c44a723b62dbfe58f5840a957edeff49746fe33ceb2cc286947c640487e3e"
+  "inventorySha256": "59ad647e8e80a683726c3483953a07d3d29eb4e85818137f15e518ce8d2985d0",
+  "manifestSha256": "869341d864c7c7a5bff6446a61eddd0e0b2d82c3c9341a3f012c9c9349c96aa4"
 }

--- a/src/lib/__tests__/worktree-paths-git-timeout.test.ts
+++ b/src/lib/__tests__/worktree-paths-git-timeout.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, delimiter } from 'node:path';
+import {
+  clearWorktreeCache,
+  getProjectIdentifier,
+  resolveTranscriptPath,
+} from '../../lib/worktree-paths.js';
+
+// Every execFileSync('git', ...) in worktree-paths.ts must pass a timeout.
+// Without one the call blocks until git exits, so a wedged git turns a HUD
+// render into a process that never returns (#3946). These tests wedge exactly
+// one subcommand and assert the caller still returns.
+// Resolved lazily: this module is collected on Windows too, where the
+// describe below is skipped and `command -v` does not exist.
+function realGitPath(): string {
+  return execSync('command -v git', { encoding: 'utf-8' }).trim();
+}
+const WEDGE_SECONDS = 60;
+// The bound each call site declares, plus room for the surrounding real git
+// calls. Far below WEDGE_SECONDS, so an unbounded call cannot pass.
+const RETURN_BUDGET_MS = 25_000;
+
+function git(cwd: string, command: string): void {
+  execSync(`git ${command}`, { cwd, stdio: 'pipe' });
+}
+
+/** A git shim that hangs on one subcommand and delegates everything else. */
+function installWedgedGit(dir: string, wedgedArgs: string): string {
+  const bin = join(dir, 'wedged-git-bin');
+  mkdirSync(bin, { recursive: true });
+  const gitPath = join(bin, 'git');
+  writeFileSync(
+    gitPath,
+    [
+      '#!/bin/sh',
+      `case "$*" in`,
+      // `exec` so the shim process *becomes* sleep: execFileSync's timeout
+      // kills the process it spawned, and a forked child would outlive it.
+      `  ${wedgedArgs}) exec sleep ${WEDGE_SECONDS} ;;`,
+      `  *) exec ${realGitPath()} "$@" ;;`,
+      'esac',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(gitPath, 0o755);
+  return bin;
+}
+
+describe.skipIf(process.platform === 'win32')('worktree-paths git calls are bounded (#3946)', () => {
+  let tempDir: string;
+  let repo: string;
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+    tempDir = mkdtempSync(join(tmpdir(), 'wtp-git-timeout-3946-'));
+    repo = join(tempDir, 'project');
+    mkdirSync(repo, { recursive: true });
+    git(repo, 'init');
+    git(repo, 'config user.email "test@example.com"');
+    git(repo, 'config user.name "Test User"');
+    writeFileSync(join(repo, 'README.md'), 'project\n');
+    git(repo, 'add README.md');
+    git(repo, 'commit -m initial');
+    git(repo, 'remote add origin https://example.invalid/owner/project.git');
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    clearWorktreeCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('the wedged shim really does hang the subcommand it targets', () => {
+    const bin = installWedgedGit(tempDir, "'remote get-url origin'");
+    const started = Date.now();
+    expect(() =>
+      execFileSync(join(bin, 'git'), ['remote', 'get-url', 'origin'], {
+        cwd: repo,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 2_000,
+      }),
+    ).toThrow();
+    expect(Date.now() - started).toBeGreaterThanOrEqual(1_500);
+
+    // Same shim, a subcommand it does not target: delegated, so it returns.
+    expect(
+      execFileSync(join(bin, 'git'), ['rev-parse', '--show-toplevel'], {
+        cwd: repo,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5_000,
+      }).trim(),
+    ).toBeTruthy();
+  });
+
+  it('getProjectIdentifier returns when `git remote get-url origin` hangs', () => {
+    const bin = installWedgedGit(tempDir, "'remote get-url origin'");
+    process.env.PATH = `${bin}${delimiter}${originalPath ?? ''}`;
+    clearWorktreeCache();
+
+    const started = Date.now();
+    const identifier = getProjectIdentifier(repo);
+    const elapsed = Date.now() - started;
+
+    expect(identifier).toBeTruthy();
+    expect(elapsed).toBeLessThan(RETURN_BUDGET_MS);
+  }, 90_000);
+
+  it('resolveTranscriptPath returns when `git rev-parse --git-common-dir` hangs', () => {
+    const bin = installWedgedGit(tempDir, "'rev-parse --git-common-dir'");
+    process.env.PATH = `${bin}${delimiter}${originalPath ?? ''}`;
+    clearWorktreeCache();
+
+    const missingTranscript = join(tempDir, 'projects', 'encoded-project', 'session.jsonl');
+    const started = Date.now();
+    const resolved = resolveTranscriptPath(missingTranscript, repo);
+    const elapsed = Date.now() - started;
+
+    // Nothing resolves, so the contract is to hand back the input path
+    // (worktree-paths.ts:1855). Asserting the value, not just its type,
+    // is what keeps an undefined-returning regression from passing here.
+    expect(resolved).toBe(missingTranscript);
+    expect(elapsed).toBeLessThan(RETURN_BUDGET_MS);
+  }, 90_000);
+
+  it('resolveTranscriptPath returns when `git rev-parse --show-toplevel` hangs', () => {
+    const bin = installWedgedGit(tempDir, "'rev-parse --show-toplevel'");
+    process.env.PATH = `${bin}${delimiter}${originalPath ?? ''}`;
+    clearWorktreeCache();
+
+    const missingTranscript = join(tempDir, 'projects', 'encoded-project', 'session.jsonl');
+    const started = Date.now();
+    const resolved = resolveTranscriptPath(missingTranscript, repo);
+    const elapsed = Date.now() - started;
+
+    expect(resolved).toBe(missingTranscript);
+    expect(elapsed).toBeLessThan(RETURN_BUDGET_MS);
+  }, 90_000);
+});


### PR DESCRIPTION
Fixes #3946

## Summary

Three `execFileSync('git', ...)` call sites in `src/lib/worktree-paths.ts`
passed no `timeout`. `execFileSync` without one blocks until the child exits,
so a wedged `git` hangs the caller indefinitely. Both enclosing functions are
on the HUD render path, which turns a slow render into a resident
`omc-hud.mjs` process rather than a degraded statusline.

The four sibling calls in the same file already pass `timeout: 5000`, and
`src/hud/elements/git.ts:43` uses `timeout: 1000`, so this mirrors the
existing bound rather than introducing a new policy.

## The change

```
src/lib/worktree-paths.ts
  getProjectIdentifier()   remote get-url origin              + timeout: 5000
  resolveTranscriptPath()  rev-parse --git-common-dir         + timeout: 5000
  resolveTranscriptPath()  rev-parse --show-toplevel          + timeout: 5000
```

All seven `execFileSync('git', ...)` sites in the file are now bounded.

## Regression test

`src/lib/__tests__/worktree-paths-git-timeout.test.ts` installs a `git` shim on
`PATH` that hangs one subcommand for 60 s and `exec`s the real git for every
other subcommand, so only the site under test is wedged. It then asserts the
caller still returns.

A first test asserts the shim itself behaves: the targeted subcommand hangs,
a non-targeted one is delegated and returns. Without that, a shim that
silently failed to install would make the other three tests pass for the
wrong reason.

The wedge branch is `exec sleep`, not `sleep`. `execFileSync`'s timeout kills
the process it spawned, so a forked child would outlive the shim; `exec` makes
the shim itself the process that gets killed. Measured after one run:
`pgrep -x sleep` shows a `PPID=1 sleep 60` orphan with a plain `sleep`, and
none with `exec sleep`.

Measured on this branch:

```
$ npx vitest run src/lib/__tests__/worktree-paths-git-timeout.test.ts
 ✓ the wedged shim really does hang the subcommand it targets  2122ms
 ✓ getProjectIdentifier returns when `git remote get-url origin` hangs  5141ms
 ✓ resolveTranscriptPath returns when `git rev-parse --git-common-dir` hangs  5104ms
 ✓ resolveTranscriptPath returns when `git rev-parse --show-toplevel` hangs  5308ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Each bounded call returns at ~5.1 s — the declared timeout, not the 60 s wedge.

Negative control, with the three-line source change reverted and the same test
file in place:

```
$ git apply -R  # the three-line source change only; test file unchanged
$ npx vitest run src/lib/__tests__/worktree-paths-git-timeout.test.ts -t 'getProjectIdentifier returns'
 FAIL  src/lib/__tests__/worktree-paths-git-timeout.test.ts > worktree-paths git calls are bounded (#3946) > getProjectIdentifier returns when `git remote get-url origin` hangs
AssertionError: expected 60190 to be less than 25000
 Test Files  1 failed (1)
      Tests  1 failed | 3 skipped (4)
```

60190 ms without the fix, 5141 ms with it. The test fails for the intended
reason.

## Gates

```
$ npx tsc --noEmit                                                    exit 0
$ npx eslint src/lib/worktree-paths.ts src/lib/__tests__/worktree-paths-git-timeout.test.ts   exit 0
```

Related suites, this branch vs. the same command on the unmodified branch
point, run on macOS:

```
$ npx vitest run src/lib/__tests__/ src/hud/__tests__/
  before:  71 failed | 327 passed (398)
  after:   71 failed | 331 passed (402)
```

Same 71 failures before and after — pre-existing on this platform, mostly
`/var` vs `/private/var` realpath comparisons — and the 4 added tests account
for the whole delta. No regression introduced.

## Notes for review

- `inventory/inventory-graph.json` is regenerated via `npm run
  generate:inventory` because `generate:inventory:verify` fails on any source
  change (`provenance.sourceSha256 must match the current inventoried source
  content`). It verifies clean on the unmodified branch point, and clean again
  after regeneration. The generator derives the file set from `git ls-files`,
  so the regeneration was run *after* staging the new test — otherwise the
  test is absent from the graph and verify still fails. It is carried as its
  own `chore:` commit, matching how `dev` lands inventory refreshes.
  The regeneration also re-anchors `provenance.head` from `dd84654902eb` to
  `3cbc55e26963`; that part is a side effect of the generator, not of this
  fix — say the word if you would rather land it separately.
- `dist/` and `bridge/` are untouched, per CONTRIBUTING §6.
- The test skips on Windows: the shim is a POSIX `sh` script. The two other
  Windows-relevant paths in this file are already covered by the existing
  Windows path-handling job.

## Not fixed here

Which of the three call sites was the one blocked in the reported incident is
still unestablished — the hang did not reproduce once memory pressure cleared
on the reporting machine. All three are bounded here regardless, since any one
of them is sufficient to strand a render.
