### PR TITLE
fix(hooks): omit unsupported PostToolUse suppressOutput

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "9f238484d7e85dfd0eba26d9c5e09a44d9c6c335",
-    "sourceSha256": "c47bf8899a58ebf8df9d714dc3d5ea0a05e3591542a5c4b91e347daebe31f0d2",
+    "head": "9916831d0085c222848fb28fcf052ff5e0a52302",
+    "sourceSha256": "337a78c9ed374a6f4ff15fba80943c91feb08421a9aabaa67f52c886e41e70dc",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "9f238484d7e85dfd0eba26d9c5e09a44d9c6c335",
-  "sourceSha256": "c47bf8899a58ebf8df9d714dc3d5ea0a05e3591542a5c4b91e347daebe31f0d2",
+  "head": "9916831d0085c222848fb28fcf052ff5e0a52302",
+  "sourceSha256": "337a78c9ed374a6f4ff15fba80943c91feb08421a9aabaa67f52c886e41e70dc",
   "counts": {
     "public": {
       "skills": 35,
@@ -77082,5 +77082,5 @@
     }
   },
   "inventorySha256": "59ad647e8e80a683726c3483953a07d3d29eb4e85818137f15e518ce8d2985d0",
-  "manifestSha256": "7e4fcc7ec563daa8c834d02564ddbf20ffc564ea43e8459f5b85d98937d740dd"
+  "manifestSha256": "bff2362715edde608f39f63a33d3580f778f36e4cf08a2f55d44eb6eeb8d4091"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "8d54b629cfb4aca47e61efe9b66686dda75564cc",
-    "sourceSha256": "27341be6697fbf54c9364a042ed39c3195acdf71aa71a0c712837ec10496ec87",
+    "head": "9f238484d7e85dfd0eba26d9c5e09a44d9c6c335",
+    "sourceSha256": "c47bf8899a58ebf8df9d714dc3d5ea0a05e3591542a5c4b91e347daebe31f0d2",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "8d54b629cfb4aca47e61efe9b66686dda75564cc",
-  "sourceSha256": "27341be6697fbf54c9364a042ed39c3195acdf71aa71a0c712837ec10496ec87",
+  "head": "9f238484d7e85dfd0eba26d9c5e09a44d9c6c335",
+  "sourceSha256": "c47bf8899a58ebf8df9d714dc3d5ea0a05e3591542a5c4b91e347daebe31f0d2",
   "counts": {
     "public": {
       "skills": 35,
@@ -77082,5 +77082,5 @@
     }
   },
   "inventorySha256": "59ad647e8e80a683726c3483953a07d3d29eb4e85818137f15e518ce8d2985d0",
-  "manifestSha256": "aa4b635a38d814edd9b948d972a58bb22d25db9d3697c6237d53978775b54270"
+  "manifestSha256": "7e4fcc7ec563daa8c834d02564ddbf20ffc564ea43e8459f5b85d98937d740dd"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "602b283d937f9f5b946849cd6c17c92f223c7d81",
-    "sourceSha256": "fc281637d7fef0741f98c7cc405685443fb5cfc0fc491d71d7c873032fad2532",
+    "head": "8d54b629cfb4aca47e61efe9b66686dda75564cc",
+    "sourceSha256": "27341be6697fbf54c9364a042ed39c3195acdf71aa71a0c712837ec10496ec87",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "602b283d937f9f5b946849cd6c17c92f223c7d81",
-  "sourceSha256": "fc281637d7fef0741f98c7cc405685443fb5cfc0fc491d71d7c873032fad2532",
+  "head": "8d54b629cfb4aca47e61efe9b66686dda75564cc",
+  "sourceSha256": "27341be6697fbf54c9364a042ed39c3195acdf71aa71a0c712837ec10496ec87",
   "counts": {
     "public": {
       "skills": 35,
@@ -46675,6 +46675,16 @@
       },
       {
         "from": "src/__tests__/post-tool-rules-injector.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/post-tool-rules-injector.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/post-tool-rules-injector.test.ts",
         "to": "external:node:path",
         "kind": "imports"
       },
@@ -77066,11 +77076,11 @@
     ],
     "stats": {
       "nodeCount": 6857,
-      "edgeCount": 7298,
-      "importEdgeCount": 6004,
+      "edgeCount": 7300,
+      "importEdgeCount": 6006,
       "registerEdgeCount": 56
     }
   },
   "inventorySha256": "59ad647e8e80a683726c3483953a07d3d29eb4e85818137f15e518ce8d2985d0",
-  "manifestSha256": "19b0d0d401f7370bdbbccada2990156225f73810bc385397f8fc84b038149a43"
+  "manifestSha256": "aa4b635a38d814edd9b948d972a58bb22d25db9d3697c6237d53978775b54270"
 }

--- a/scripts/post-tool-rules-injector.mjs
+++ b/scripts/post-tool-rules-injector.mjs
@@ -67,7 +67,7 @@ async function main() {
   try {
     const input = await readStdin();
     if (!input.trim()) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify({ continue: true }));
       return;
     }
 
@@ -75,7 +75,7 @@ async function main() {
     try { data = JSON.parse(input); } catch { /* ignore parse errors */ }
 
     if (!createRulesInjectorHook) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify({ continue: true }));
       return;
     }
 
@@ -86,7 +86,7 @@ async function main() {
 
     const rawPath = extractFilePath(toolInput);
     if (!rawPath) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify({ continue: true }));
       return;
     }
 
@@ -109,11 +109,11 @@ async function main() {
         },
       }));
     } else {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify({ continue: true }));
     }
   } catch {
     // Always continue on error — rules injection is additive only
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    console.log(JSON.stringify({ continue: true }));
   }
 }
 

--- a/scripts/post-tool-verifier.mjs
+++ b/scripts/post-tool-verifier.mjs
@@ -1107,14 +1107,12 @@ async function main() {
         hookEventName: 'PostToolUse',
         additionalContext: message
       };
-    } else {
-      response.suppressOutput = true;
     }
 
     console.log(JSON.stringify(response, null, 2));
   } catch (error) {
     // On error, always continue
-    console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+    console.log(JSON.stringify({ continue: true }));
   }
 }
 

--- a/scripts/project-memory-posttool.mjs
+++ b/scripts/project-memory-posttool.mjs
@@ -58,7 +58,7 @@ async function main() {
 
     // Early exit if imports failed
     if (!learnFromToolOutput || !findProjectRoot) {
-      console.log(JSON.stringify({ continue: true, suppressOutput: true }));
+      console.log(JSON.stringify({ continue: true }));
       return;
     }
 
@@ -77,16 +77,10 @@ async function main() {
     }
 
     // Return success
-    console.log(JSON.stringify({
-      continue: true,
-      suppressOutput: true
-    }));
+    console.log(JSON.stringify({ continue: true }));
   } catch (error) {
     // Always continue on error
-    console.log(JSON.stringify({
-      continue: true,
-      suppressOutput: true
-    }));
+    console.log(JSON.stringify({ continue: true }));
   }
 }
 

--- a/src/__tests__/post-tool-rules-injector.test.ts
+++ b/src/__tests__/post-tool-rules-injector.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 const NODE = process.execPath;
 const REPO_ROOT = resolve(join(__dirname, '..', '..'));
 const SCRIPT_PATH = join(REPO_ROOT, 'scripts', 'post-tool-rules-injector.mjs');
+const ISOLATED_CONFIG_DIR = join(tmpdir(), 'omc-issue-3956-no-global-rules');
 
 function runHook(input: Record<string, unknown>, extraEnv?: Record<string, string>) {
   const raw = execFileSync(NODE, [SCRIPT_PATH], {
@@ -15,6 +16,7 @@ function runHook(input: Record<string, unknown>, extraEnv?: Record<string, strin
     env: {
       ...process.env,
       CLAUDE_PLUGIN_ROOT: REPO_ROOT,
+      CLAUDE_CONFIG_DIR: ISOLATED_CONFIG_DIR,
       NODE_ENV: 'test',
       ...extraEnv,
     },
@@ -42,6 +44,42 @@ describe('post-tool-rules-injector.mjs skip guards (DISABLE_OMC / OMC_SKIP_HOOKS
     expect(runHook(INPUT, extraEnv)).toEqual({ continue: true });
   }
 
+  function expectInjectedContext(extraEnv: Record<string, string>) {
+    const root = mkdtempSync(join(tmpdir(), 'post-tool-rules-injector-'));
+    const home = join(root, 'home');
+    const filePath = join(root, 'README.md');
+    mkdirSync(join(root, '.claude', 'rules'), { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(root, '.git'), 'gitdir: placeholder');
+    writeFileSync(join(root, '.claude', 'rules', 'style.md'), '---\nalwaysApply: true\n---\nUse this rule.');
+    writeFileSync(filePath, '# fixture');
+
+    try {
+      expect(runHook(
+        {
+          cwd: root,
+          tool_name: 'Read',
+          tool_input: { file_path: filePath },
+          session_id: 'issue-3956-rules',
+        },
+        {
+          HOME: home,
+          USERPROFILE: home,
+          CLAUDE_CONFIG_DIR: join(root, 'config'),
+          ...extraEnv,
+        },
+      )).toEqual({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext: expect.stringContaining('Use this rule.'),
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
   it('no-ops when DISABLE_OMC=1', () => {
     expectSkipped({ DISABLE_OMC: '1', OMC_SKIP_HOOKS: '' });
   });
@@ -58,56 +96,15 @@ describe('post-tool-rules-injector.mjs skip guards (DISABLE_OMC / OMC_SKIP_HOOKS
     expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: ' keyword-detector , post-tool-use ' });
   });
 
-  it('returns a Codex-compatible no-op response when processing is enabled', () => {
-    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: '' })).toEqual({ continue: true });
+  it('preserves context without unsupported response fields when processing is enabled', () => {
+    expectInjectedContext({ DISABLE_OMC: '', OMC_SKIP_HOOKS: '' });
   });
 
-  it('returns a Codex-compatible no-op response for unrelated skip tokens', () => {
-    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: 'keyword-detector' })).toEqual({
-      continue: true,
-    });
+  it('preserves context when OMC_SKIP_HOOKS has an unrelated token', () => {
+    expectInjectedContext({ DISABLE_OMC: '', OMC_SKIP_HOOKS: 'keyword-detector' });
   });
 
-  it('returns a Codex-compatible no-op response when DISABLE_OMC=false', () => {
-    expect(runHook(INPUT, { DISABLE_OMC: 'false', OMC_SKIP_HOOKS: '' })).toEqual({
-      continue: true,
-    });
-  });
-
-  it('preserves additionalContext without unsupported response fields', () => {
-    const root = mkdtempSync(join(tmpdir(), 'post-tool-rules-injector-'));
-    const home = join(root, 'home');
-    const filePath = join(root, 'README.md');
-    mkdirSync(join(root, '.claude', 'rules'), { recursive: true });
-    mkdirSync(home, { recursive: true });
-    writeFileSync(join(root, '.git'), 'gitdir: placeholder');
-    writeFileSync(join(root, '.claude', 'rules', 'style.md'), '---\nalwaysApply: true\n---\nUse this rule.');
-    writeFileSync(filePath, '# fixture');
-
-    try {
-      const output = runHook(
-        {
-          cwd: root,
-          tool_name: 'Read',
-          tool_input: { file_path: filePath },
-          session_id: `issue-3956-${Date.now()}`,
-        },
-        {
-          HOME: home,
-          USERPROFILE: home,
-          CLAUDE_CONFIG_DIR: join(root, 'config'),
-        },
-      );
-
-      expect(output).toEqual({
-        continue: true,
-        hookSpecificOutput: {
-          hookEventName: 'PostToolUse',
-          additionalContext: expect.stringContaining('Use this rule.'),
-        },
-      });
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+  it('preserves context when DISABLE_OMC=false', () => {
+    expectInjectedContext({ DISABLE_OMC: 'false', OMC_SKIP_HOOKS: '' });
   });
 });

--- a/src/__tests__/post-tool-rules-injector.test.ts
+++ b/src/__tests__/post-tool-rules-injector.test.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -21,7 +23,6 @@ function runHook(input: Record<string, unknown>, extraEnv?: Record<string, strin
 
   return JSON.parse(raw) as {
     continue: boolean;
-    suppressOutput?: boolean;
     hookSpecificOutput?: { hookEventName?: string; additionalContext?: string };
   };
 }
@@ -57,21 +58,56 @@ describe('post-tool-rules-injector.mjs skip guards (DISABLE_OMC / OMC_SKIP_HOOKS
     expectSkipped({ DISABLE_OMC: '', OMC_SKIP_HOOKS: ' keyword-detector , post-tool-use ' });
   });
 
-  it('does not short-circuit when skip vars are empty', () => {
-    // Not skipped: the hook runs its processing path, which always adds
-    // suppressOutput (or injected context) rather than a bare continue.
-    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: '' })).not.toEqual({ continue: true });
+  it('returns a Codex-compatible no-op response when processing is enabled', () => {
+    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: '' })).toEqual({ continue: true });
   });
 
-  it('does not short-circuit for an unrelated OMC_SKIP_HOOKS token', () => {
-    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: 'keyword-detector' })).not.toEqual({
+  it('returns a Codex-compatible no-op response for unrelated skip tokens', () => {
+    expect(runHook(INPUT, { DISABLE_OMC: '', OMC_SKIP_HOOKS: 'keyword-detector' })).toEqual({
       continue: true,
     });
   });
 
-  it('processes normally when DISABLE_OMC=false', () => {
-    expect(runHook(INPUT, { DISABLE_OMC: 'false', OMC_SKIP_HOOKS: '' })).not.toEqual({
+  it('returns a Codex-compatible no-op response when DISABLE_OMC=false', () => {
+    expect(runHook(INPUT, { DISABLE_OMC: 'false', OMC_SKIP_HOOKS: '' })).toEqual({
       continue: true,
     });
+  });
+
+  it('preserves additionalContext without unsupported response fields', () => {
+    const root = mkdtempSync(join(tmpdir(), 'post-tool-rules-injector-'));
+    const home = join(root, 'home');
+    const filePath = join(root, 'README.md');
+    mkdirSync(join(root, '.claude', 'rules'), { recursive: true });
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(root, '.git'), 'gitdir: placeholder');
+    writeFileSync(join(root, '.claude', 'rules', 'style.md'), '---\nalwaysApply: true\n---\nUse this rule.');
+    writeFileSync(filePath, '# fixture');
+
+    try {
+      const output = runHook(
+        {
+          cwd: root,
+          tool_name: 'Read',
+          tool_input: { file_path: filePath },
+          session_id: `issue-3956-${Date.now()}`,
+        },
+        {
+          HOME: home,
+          USERPROFILE: home,
+          CLAUDE_CONFIG_DIR: join(root, 'config'),
+        },
+      );
+
+      expect(output).toEqual({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext: expect.stringContaining('Use this rule.'),
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/__tests__/post-tool-verifier.test.mjs
+++ b/src/__tests__/post-tool-verifier.test.mjs
@@ -633,6 +633,7 @@ describe('agent output summarization / truncation (issue #1373)', () => {
     expect(out.continue).toBe(true);
     expect(out.hookSpecificOutput?.additionalContext).toContain('TaskOutput summary:');
     expect(out.hookSpecificOutput?.additionalContext).toContain('TaskOutput clipped');
+    expect(out).not.toHaveProperty('suppressOutput');
   });
 });
 
@@ -720,7 +721,7 @@ describe('post-tool hook regression coverage (issue #2615)', () => {
       cwd: process.cwd(),
     });
 
-    expect(out).toEqual({ continue: true, suppressOutput: true });
+    expect(out).toEqual({ continue: true });
   });
 });
 
@@ -979,7 +980,7 @@ describe('OMC_QUIET hook message suppression (issue #1646)', () => {
       { OMC_QUIET: '1' },
     );
 
-    expect(edit).toEqual({ continue: true, suppressOutput: true });
+    expect(edit).toEqual({ continue: true });
 
     const grep = runPostToolVerifier(
       {
@@ -991,7 +992,7 @@ describe('OMC_QUIET hook message suppression (issue #1646)', () => {
       { OMC_QUIET: '1' },
     );
 
-    expect(grep).toEqual({ continue: true, suppressOutput: true });
+    expect(grep).toEqual({ continue: true });
 
     const writeFailure = runPostToolVerifier(
       {
@@ -1043,7 +1044,7 @@ describe('OMC_QUIET hook message suppression (issue #1646)', () => {
       );
     });
 
-    expect(taskSummary).toEqual({ continue: true, suppressOutput: true });
+    expect(taskSummary).toEqual({ continue: true });
   });
 });
 
@@ -1061,7 +1062,7 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
         cwd: tempDir,
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
       expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
       expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
     });
@@ -1080,7 +1081,7 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
         cwd: tempDir,
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
       expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(true);
       expect(existsSync(legacySkillStatePath(tempDir))).toBe(true);
     });
@@ -1142,7 +1143,7 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
         cwd: tempDir,
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
 
       const state = JSON.parse(readFileSync(ralplanStatePath(tempDir, sessionId), 'utf-8'));
       expect(state.active).toBe(false);
@@ -1191,7 +1192,7 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
         cwd: tempDir,
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
       expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
       expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
     });
@@ -1210,7 +1211,7 @@ describe('Skill active state cleanup on PostToolUse (issue #2103)', () => {
         cwd: tempDir,
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
       expect(existsSync(skillStatePath(tempDir, sessionId))).toBe(false);
       expect(existsSync(legacySkillStatePath(tempDir))).toBe(false);
     });
@@ -1271,7 +1272,7 @@ describe('background operation detection (issue #3578)', () => {
           session_id: `bg-fp-${word}`,
         });
 
-        expect(out).toEqual({ continue: true, suppressOutput: true });
+        expect(out).toEqual({ continue: true });
       });
     }
 
@@ -1283,7 +1284,7 @@ describe('background operation detection (issue #3578)', () => {
         session_id: 'bg-fp-all',
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
     });
 
     it('does not fire for the reported repro payload', () => {
@@ -1294,7 +1295,7 @@ describe('background operation detection (issue #3578)', () => {
         session_id: 'bg-fp-repro',
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
     });
   });
 
@@ -1340,7 +1341,7 @@ describe('background operation detection (issue #3578)', () => {
         session_id: 'bg-fg-task-quote',
       });
 
-      expect(out).toEqual({ continue: true, suppressOutput: true });
+      expect(out).toEqual({ continue: true });
     });
   });
 
@@ -1361,7 +1362,7 @@ describe('background operation detection (issue #3578)', () => {
 
         const out = runPostToolVerifier(payload);
 
-        expect(out).toEqual({ continue: true, suppressOutput: true });
+        expect(out).toEqual({ continue: true });
       });
     }
   });

--- a/src/__tests__/preemptive-compaction-hook.test.ts
+++ b/src/__tests__/preemptive-compaction-hook.test.ts
@@ -187,7 +187,7 @@ describe('post-tool-verifier preemptive compaction warnings', () => {
     );
 
     expect(first.hookSpecificOutput).toBeDefined();
-    expect(second).toEqual({ continue: true, suppressOutput: true });
+    expect(second).toEqual({ continue: true });
   });
 
   it('does not let one session suppress another session in the same repo', () => {
@@ -396,7 +396,7 @@ describe('post-tool-verifier Write/Edit response envelopes', () => {
       { OMC_QUIET: '2' },
     );
 
-    expect(result).toEqual({ continue: true, suppressOutput: true });
+    expect(result).toEqual({ continue: true });
   });
 
   it('trusts Edit success markers extracted from object response message before JSON stringify analysis', () => {
@@ -413,7 +413,7 @@ describe('post-tool-verifier Write/Edit response envelopes', () => {
       { OMC_QUIET: '2' },
     );
 
-    expect(result).toEqual({ continue: true, suppressOutput: true });
+    expect(result).toEqual({ continue: true });
   });
 
   it('keeps real plain string Write failures failing', () => {

--- a/src/__tests__/project-memory-posttool.test.ts
+++ b/src/__tests__/project-memory-posttool.test.ts
@@ -13,7 +13,15 @@ const SKIP_ENVIRONMENTS: Record<string, string>[] = [
   { OMC_SKIP_HOOKS: ' keyword-detector , post-tool-use ' },
 ];
 
-function runHook(env: Record<string, string>) {
+function runHook(
+  env: Record<string, string>,
+  input: Record<string, unknown> | string = {
+    cwd: '',
+    tool_name: 'Read',
+    tool_input: { file_path: 'README.md' },
+    tool_response: 'ok',
+  },
+) {
   const root = mkdtempSync(join(tmpdir(), 'project-memory-posttool-'));
   tempDirs.push(root);
   mkdirSync(join(root, '.git'));
@@ -43,12 +51,12 @@ function runHook(env: Record<string, string>) {
   const result = spawnSync(process.execPath, [copiedScriptPath], {
     cwd: root,
     encoding: 'utf8',
-    input: JSON.stringify({
-      cwd: root,
-      tool_name: 'Read',
-      tool_input: { file_path: join(root, 'README.md') },
-      tool_response: 'ok',
-    }),
+    input: typeof input === 'string'
+      ? input
+      : JSON.stringify({
+          cwd: root,
+          ...input,
+        }),
     env: { ...process.env, DISABLE_OMC: '', OMC_SKIP_HOOKS: '', OMC_DEBUG: '1', ...env },
   });
   expect(result.status, result.stderr).toBe(0);
@@ -70,5 +78,19 @@ describe('project-memory-posttool skip guards', () => {
     expect(result.output).toEqual({ continue: true });
     expect(result.stderr).toBe('');
     expect(result.memory).toBe(result.expectedMemory);
+  });
+});
+
+describe('project-memory-posttool response contract', () => {
+  it('returns a bare continue response when runtime modules are unavailable', () => {
+    const result = runHook({ OMC_DEBUG: '' });
+
+    expect(result.output).toEqual({ continue: true });
+  });
+
+  it('returns a bare continue response when input parsing fails', () => {
+    const result = runHook({ OMC_DEBUG: '' }, '{');
+
+    expect(result.output).toEqual({ continue: true });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3956. Removed unsupported `suppressOutput` from the three named PostToolUse scripts. No-op and error paths emit exactly `{ "continue": true }`; contextual paths retain `hookSpecificOutput.additionalContext` unchanged. Unrelated PreToolUse and other hook responses remain untouched.

## Final evidence

- Exact base: `dev` at `8d54b629cfb4aca47e61efe9b66686dda75564cc`
- Exact PR head: `47577a2e0ab48237cc8b65b43b9a091702e1ac5d`
- Resulting merge SHA on `dev`: `47b1e5f968710b07dc3922cac9a565657126e198`
- CI run `33831564514`: passed all applicable jobs.
- Upgrade Test run `33831564481`: passed.
- Independent exact-head architect review: `MERGE_READY`, no findings.
- Focused local suites: 4 files, 147 tests passed.
- `npx tsc --noEmit`: passed.
- `npm run lint`: 0 errors; existing warnings only.
- Focused test lint: passed.
- `npm run generate:inventory:verify`: passed.

Merged into `dev`; issue #3956 is closed as completed.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*