### PR TITLE
feat(graph): remote approval gates + workspace checkpoints/rollback

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -610,6 +610,37 @@ omc session friction report --project all --json
 - Highlights context-bloat and operator-friction indicators such as high estimated context usage, large JSONL entries, tool error rates, long idle gaps, failed agents, and hook noise
 - Supports `--limit`, `--session`, `--since`, `--project`, and `--json`
 
+### `omc checkpoint`
+
+Workspace snapshot/rollback for autonomous runs, built on git "shadow commits": the full working tree (tracked, modified, and untracked non-ignored files) is captured into `refs/omc/checkpoints/` without touching HEAD, the index, or the worktree.
+
+```bash
+omc checkpoint create --label "before ralph run"
+omc checkpoint list
+omc checkpoint rollback <id> --force
+```
+
+- `create` never touches HEAD or the working tree; restore points appear only under `refs/omc/checkpoints/`
+- `rollback` restores the worktree and index and removes files created after the snapshot (`git clean -fd` keeps ignored paths such as `node_modules`)
+- `rollback` refuses to discard uncommitted changes unless `--force` is passed
+- Requires a git repository; no external storage is involved
+
+### Graph approval gates (remote approvals)
+
+Graph runtime `human-approval` nodes support two gate styles via `omc graph run`:
+
+```bash
+omc graph run ./my-graph.json --approval-mode stdin    # default: interactive y/n
+omc graph run ./my-graph.json --approval-mode remote --checkpoint
+```
+
+- `--approval-mode remote` persists each pending gate under `.omc/graph-runs/<run_id>/approvals/` and dispatches an `approval-request` notification (Telegram/Discord/Slack/webhook, following your notification config)
+- Reply `approved`/`denied` (or `y`/`n`, `批准`/`拒绝`) to the notification message to decide from your phone; the reply-listener daemon writes the decision artifact
+- Decide from any shell on the machine: `omc graph approvals list`, then `omc graph approvals decide <runId> <activationId> approved|denied`
+- `--approval-timeout <seconds>` bounds the wait; an expired gate resolves to `--approval-timeout-policy deny` (default, fail-closed) or `approve`
+- `--checkpoint` snapshots the working tree before the run; after a denial you can restore it: `omc graph approvals decide <runId> <activationId> denied --rollback <checkpointId>`
+- Malformed decision artifacts are ignored, never trusted; the runner journal remains the record of outcomes
+
 ### Non-interactive automation and CI/CD
 
 Use OMC's terminal and library surfaces in non-interactive environments:

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "9916831d0085c222848fb28fcf052ff5e0a52302",
-    "sourceSha256": "337a78c9ed374a6f4ff15fba80943c91feb08421a9aabaa67f52c886e41e70dc",
+    "head": "e3f200d8f6e1d4cefbc5fecf3dee02b3a1f28837",
+    "sourceSha256": "40af9be9d4dae728c2b3e06caf729259bdfbb08bb1397907a1f59d9452a7cff1",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "9916831d0085c222848fb28fcf052ff5e0a52302",
-  "sourceSha256": "337a78c9ed374a6f4ff15fba80943c91feb08421a9aabaa67f52c886e41e70dc",
+  "head": "e3f200d8f6e1d4cefbc5fecf3dee02b3a1f28837",
+  "sourceSha256": "40af9be9d4dae728c2b3e06caf729259bdfbb08bb1397907a1f59d9452a7cff1",
   "counts": {
     "public": {
       "skills": 35,
@@ -24,12 +24,12 @@
     },
     "internal": {
       "hookFiles": 295,
-      "featureFiles": 69,
+      "featureFiles": 71,
       "toolFiles": 61,
       "libFiles": 40,
       "templateHooks": 21,
-      "srcFiles": 1326,
-      "total": 1347
+      "srcFiles": 1332,
+      "total": 1353
     },
     "generated": {
       "distFiles": 4955,
@@ -440,6 +440,7 @@
     ],
     "featureFiles": [
       "src/features/AGENTS.md",
+      "src/features/__tests__/checkpoint.test.ts",
       "src/features/__tests__/magic-keywords.test.ts",
       "src/features/agent-addressability/__tests__/addressability.test.ts",
       "src/features/agent-addressability/index.ts",
@@ -457,6 +458,7 @@
       "src/features/builtin-skills/runtime-guidance.ts",
       "src/features/builtin-skills/skills.ts",
       "src/features/builtin-skills/types.ts",
+      "src/features/checkpoint/index.ts",
       "src/features/context-injector/collector.ts",
       "src/features/context-injector/index.ts",
       "src/features/context-injector/injector.ts",
@@ -6151,6 +6153,7 @@
     ],
     "featureFiles": [
       "src/features/AGENTS.md",
+      "src/features/__tests__/checkpoint.test.ts",
       "src/features/__tests__/magic-keywords.test.ts",
       "src/features/agent-addressability/__tests__/addressability.test.ts",
       "src/features/agent-addressability/index.ts",
@@ -6168,6 +6171,7 @@
       "src/features/builtin-skills/runtime-guidance.ts",
       "src/features/builtin-skills/skills.ts",
       "src/features/builtin-skills/types.ts",
+      "src/features/checkpoint/index.ts",
       "src/features/context-injector/collector.ts",
       "src/features/context-injector/index.ts",
       "src/features/context-injector/injector.ts",
@@ -35427,6 +35431,11 @@
         "path": "src/cli/autoresearch.ts"
       },
       {
+        "id": "src/cli/checkpoint.ts",
+        "kind": "src",
+        "path": "src/cli/checkpoint.ts"
+      },
+      {
         "id": "src/cli/claude-md-coordinator.ts",
         "kind": "src",
         "path": "src/cli/claude-md-coordinator.ts"
@@ -35632,6 +35641,11 @@
         "path": "src/features/AGENTS.md"
       },
       {
+        "id": "src/features/__tests__/checkpoint.test.ts",
+        "kind": "feature",
+        "path": "src/features/__tests__/checkpoint.test.ts"
+      },
+      {
         "id": "src/features/__tests__/magic-keywords.test.ts",
         "kind": "feature",
         "path": "src/features/__tests__/magic-keywords.test.ts"
@@ -35715,6 +35729,11 @@
         "id": "src/features/builtin-skills/types.ts",
         "kind": "feature",
         "path": "src/features/builtin-skills/types.ts"
+      },
+      {
+        "id": "src/features/checkpoint/index.ts",
+        "kind": "feature",
+        "path": "src/features/checkpoint/index.ts"
       },
       {
         "id": "src/features/context-injector/collector.ts",
@@ -36057,6 +36076,11 @@
         "path": "src/graph/__tests__/runtime/regression-matrix.test.ts"
       },
       {
+        "id": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/remote-approval.test.ts"
+      },
+      {
         "id": "src/graph/__tests__/runtime/run-dir.test.ts",
         "kind": "src",
         "path": "src/graph/__tests__/runtime/run-dir.test.ts"
@@ -36125,6 +36149,11 @@
         "id": "src/graph/runtime/progress.ts",
         "kind": "src",
         "path": "src/graph/runtime/progress.ts"
+      },
+      {
+        "id": "src/graph/runtime/remote-approval.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/remote-approval.ts"
       },
       {
         "id": "src/graph/runtime/run-dir.ts",
@@ -38390,6 +38419,11 @@
         "id": "src/mcp/tool-registry.ts",
         "kind": "src",
         "path": "src/mcp/tool-registry.ts"
+      },
+      {
+        "id": "src/notifications/__tests__/approval-reply.test.ts",
+        "kind": "src",
+        "path": "src/notifications/__tests__/approval-reply.test.ts"
       },
       {
         "id": "src/notifications/__tests__/config-merge.test.ts",
@@ -51099,6 +51133,21 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/cli/checkpoint.ts",
+        "to": "external:chalk",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/checkpoint.ts",
+        "to": "external:commander",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/checkpoint.ts",
+        "to": "src/features/checkpoint/index.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/cli/claude-md-coordinator.ts",
         "to": "external:node:crypto",
         "kind": "imports"
@@ -51645,6 +51694,11 @@
       },
       {
         "from": "src/cli/graph.ts",
+        "to": "src/features/checkpoint/index.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
         "to": "src/graph/descriptor.ts",
         "kind": "imports"
       },
@@ -51666,6 +51720,11 @@
       {
         "from": "src/cli/graph.ts",
         "to": "src/graph/runtime/progress.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/graph.ts",
+        "to": "src/graph/runtime/remote-approval.ts",
         "kind": "imports"
       },
       {
@@ -51704,6 +51763,11 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/cli/graph.ts",
+        "to": "src/notifications/index.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/cli/hud-watch.ts",
         "to": "src/mcp/standalone-shutdown.ts",
         "kind": "imports"
@@ -51736,6 +51800,11 @@
       {
         "from": "src/cli/index.ts",
         "to": "src/cli/autoresearch.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/index.ts",
+        "to": "src/cli/checkpoint.ts",
         "kind": "imports"
       },
       {
@@ -52249,6 +52318,36 @@
         "kind": "type-exports"
       },
       {
+        "from": "src/features/__tests__/checkpoint.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/__tests__/checkpoint.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/__tests__/checkpoint.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/__tests__/checkpoint.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/__tests__/checkpoint.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/__tests__/checkpoint.test.ts",
+        "to": "src/features/checkpoint/index.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/features/__tests__/magic-keywords.test.ts",
         "to": "external:vitest",
         "kind": "imports"
@@ -52512,6 +52611,26 @@
         "from": "src/features/builtin-skills/types.ts",
         "to": "src/utils/skill-pipeline.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/features/checkpoint/index.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/checkpoint/index.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/checkpoint/index.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/features/checkpoint/index.ts",
+        "to": "external:path",
+        "kind": "imports"
       },
       {
         "from": "src/features/context-injector/collector.ts",
@@ -53804,6 +53923,36 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "to": "src/graph/runtime/remote-approval.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/remote-approval.test.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
         "from": "src/graph/__tests__/runtime/run-dir.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -54217,6 +54366,41 @@
         "from": "src/graph/runtime/progress.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/graph/runtime/run-dir.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/graph/runtime/safe-fs.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/graph/runtime/types.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/lib/atomic-write.ts",
+        "kind": "imports"
       },
       {
         "from": "src/graph/runtime/run-dir.ts",
@@ -65689,6 +65873,31 @@
         "kind": "imports"
       },
       {
+        "from": "src/notifications/__tests__/approval-reply.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/notifications/__tests__/approval-reply.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/notifications/__tests__/approval-reply.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/notifications/__tests__/approval-reply.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/notifications/__tests__/approval-reply.test.ts",
+        "to": "src/notifications/reply-listener.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/notifications/__tests__/config-merge.test.ts",
         "to": "external:fs",
         "kind": "imports"
@@ -66361,6 +66570,11 @@
       {
         "from": "src/notifications/reply-listener.ts",
         "to": "src/features/rate-limit-wait/tmux-detector.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/notifications/reply-listener.ts",
+        "to": "src/graph/runtime/remote-approval.ts",
         "kind": "imports"
       },
       {
@@ -77075,12 +77289,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6857,
-      "edgeCount": 7300,
-      "importEdgeCount": 6006,
+      "nodeCount": 6863,
+      "edgeCount": 7336,
+      "importEdgeCount": 6039,
       "registerEdgeCount": 56
     }
   },
-  "inventorySha256": "59ad647e8e80a683726c3483953a07d3d29eb4e85818137f15e518ce8d2985d0",
-  "manifestSha256": "bff2362715edde608f39f63a33d3580f778f36e4cf08a2f55d44eb6eeb8d4091"
+  "inventorySha256": "48902e0c27f95a38180e82912e230183cb1cacfa1231dbdd635f91b772bafea2",
+  "manifestSha256": "8dd6d0062a5e44b4cdafab228ec4f9dce012e6cd63f03aa6f1b53ce2f9ce647e"
 }

--- a/src/cli/checkpoint.ts
+++ b/src/cli/checkpoint.ts
@@ -1,0 +1,92 @@
+/**
+ * Checkpoint command - Workspace snapshot/rollback for autonomous runs.
+ *
+ * Thin CLI adapter only: all snapshot logic lives in
+ * src/features/checkpoint/index.ts.
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  CheckpointError,
+  createCheckpoint,
+  isWorktreeDirty,
+  listCheckpoints,
+  rollbackToCheckpoint,
+} from '../features/checkpoint/index.js';
+
+function errorMessage(error: unknown): string {
+  if (error instanceof CheckpointError) return error.message;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function fail(message: string, code: number): void {
+  console.error(chalk.red(`Error: ${message}`));
+  process.exitCode = code;
+}
+
+/**
+ * Returns the `checkpoint` command:
+ *
+ *   omc checkpoint create [--label <text>]
+ *   omc checkpoint list
+ *   omc checkpoint rollback <id> [--force]
+ */
+export function checkpointCommand(): Command {
+  const command = new Command('checkpoint');
+  command.description('Snapshot and restore the working tree (git shadow commits)');
+
+  command
+    .command('create')
+    .description('Snapshot the working tree (tracked, modified, and untracked files)')
+    .option('--label <text>', 'Human-readable label', 'manual')
+    .action((options: { label: string }) => {
+      try {
+        const id = createCheckpoint(process.cwd(), options.label);
+        console.log(
+          `Checkpoint ${chalk.bold(id)} created${options.label ? ` (${options.label})` : ''}.`,
+        );
+        console.log(`Restore with: omc checkpoint rollback ${id}`);
+      } catch (error) {
+        fail(errorMessage(error), error instanceof CheckpointError ? error.exitCode : 1);
+      }
+    });
+
+  command
+    .command('list')
+    .description('List checkpoints (oldest first)')
+    .action(() => {
+      try {
+        const entries = listCheckpoints(process.cwd());
+        if (entries.length === 0) {
+          console.log('No checkpoints.');
+          return;
+        }
+        for (const entry of entries) {
+          console.log(`${chalk.bold(entry.id)}  ${entry.createdAt}  ${entry.label}`);
+        }
+      } catch (error) {
+        fail(errorMessage(error), error instanceof CheckpointError ? error.exitCode : 1);
+      }
+    });
+
+  command
+    .command('rollback <id>')
+    .description('Restore the working tree from a checkpoint (discards later changes)')
+    .option('--force', 'Required when the working tree has uncommitted changes', false)
+    .action((id: string, options: { force: boolean }) => {
+      try {
+        const dirty = isWorktreeDirty(process.cwd());
+        rollbackToCheckpoint(process.cwd(), id, options.force);
+        console.log(
+          dirty
+            ? `Rolled back to ${chalk.bold(id)} (uncommitted changes were discarded).`
+            : `Rolled back to ${chalk.bold(id)}.`,
+        );
+      } catch (error) {
+        fail(errorMessage(error), error instanceof CheckpointError ? error.exitCode : 1);
+      }
+    });
+
+  return command;
+}

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -287,6 +287,13 @@ Exit codes:
           fail(`invalid --approval-timeout-policy "${options.approvalTimeoutPolicy}" (expected deny or approve)`, 1);
           return;
         }
+        if (
+          options.approvalTimeout !== undefined &&
+          (!Number.isFinite(options.approvalTimeout) || options.approvalTimeout <= 0)
+        ) {
+          fail(`invalid --approval-timeout "${options.approvalTimeout}" (expected a positive number of seconds)`, 1);
+          return;
+        }
         await runAction(descriptorPath, options.runsRoot, options);
       },
     );
@@ -323,7 +330,7 @@ Exit codes:
     .option('--by <who>', 'Record who made the decision')
     .option(
       '--rollback <checkpointId>',
-      'After recording the decision, roll the working tree back to a checkpoint (omc checkpoint create/list)',
+      'After recording a denial, roll the working tree back to a checkpoint (omc checkpoint create/list)',
     )
     .option(
       '--force',
@@ -357,6 +364,10 @@ Exit codes:
           return;
         }
         if (options.rollback !== undefined) {
+          if (decision === 'approved') {
+            fail('--rollback applies to denied runs only; refusing to discard work on approval', 1);
+            return;
+          }
           try {
             const { rollbackToCheckpoint } = await import('../features/checkpoint/index.js');
             rollbackToCheckpoint(process.cwd(), options.rollback, options.force);

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -156,6 +156,7 @@ async function runAction(
       notifier: async (request, record) => {
         // Lazy import keeps `omc graph --help` free of the notifications stack.
         const { notify } = await import('../notifications/index.js');
+        const { resolve: resolvePath } = await import('node:path');
         await notify('approval-request', {
           sessionId: record.run_id,
           question: request.prompt_text,
@@ -163,9 +164,15 @@ async function runAction(
             `🔔 Approval required for graph run \`${record.run_id}\` ` +
             `(node \`${record.node_id}\`, activation \`${record.activation_id}\`).\n\n` +
             `${request.prompt_text}\n\n` +
-            `Decide with: omc graph approvals decide ${record.run_id} ${record.activation_id} <approved|denied>`,
+            `Reply "approved" or "denied" to decide, or run: ` +
+            `omc graph approvals decide ${record.run_id} ${record.activation_id} <approved|denied>`,
           projectPath: process.cwd(),
           reason: `graph approval gate: ${record.node_id}`,
+          approval: {
+            runsRoot: resolvePath(runsRoot),
+            runId: record.run_id,
+            activationId: record.activation_id,
+          },
         });
       },
     });

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -123,7 +123,8 @@ async function runAction(
     approvalMode: string;
     approvalTimeout?: number;
     approvalTimeoutPolicy: string;
-  } = { approvalMode: 'stdin', approvalTimeoutPolicy: 'deny' },
+    checkpoint: boolean;
+  } = { approvalMode: 'stdin', approvalTimeoutPolicy: 'deny', checkpoint: false },
 ): Promise<void> {
   try {
     // Reject unsupported POSIX before descriptor/run-directory resolution so
@@ -136,6 +137,20 @@ async function runAction(
   }
   const sealed = await loadSealedDescriptor(descriptorPath, runsRoot);
   if (sealed === null) return;
+
+  // Optional pre-run safety net: snapshot the working tree so a denied or
+  // failed run can be rolled back. Best-effort — a checkpoint failure must
+  // not block the run unless the user asked for one explicitly.
+  if (approvalOptions.checkpoint) {
+    try {
+      const { createCheckpoint } = await import('../features/checkpoint/index.js');
+      const id = createCheckpoint(process.cwd(), `before graph run ${sealed.run_id}`);
+      console.log(`Checkpoint ${id} created (restore: omc checkpoint rollback ${id}).`);
+    } catch (error) {
+      fail(`--checkpoint requested but unavailable: ${errorMessage(error)}`, 1);
+      return;
+    }
+  }
 
   // runGraph is imported lazily so `omc graph --help` does not load the whole
   // runtime, and so this adapter stays decoupled from runtime module order.
@@ -232,6 +247,11 @@ export function graphCommand(): Command {
       'Remote approvals: resolution for an expired request: deny (default, fail-closed) or approve',
       'deny',
     )
+    .option(
+      '--checkpoint',
+      'Snapshot the working tree before the run (restore with omc checkpoint rollback)',
+      false,
+    )
     .addHelpText(
       'after',
       `
@@ -256,6 +276,7 @@ Exit codes:
           approvalMode: string;
           approvalTimeout?: number;
           approvalTimeoutPolicy: string;
+          checkpoint: boolean;
         },
       ) => {
         if (!['stdin', 'remote'].includes(options.approvalMode)) {
@@ -300,12 +321,21 @@ Exit codes:
     .description('Write an approval decision for one pending gate (approved|denied)')
     .option('--runs-root <dir>', 'Directory holding per-run state', '.omc/graph-runs')
     .option('--by <who>', 'Record who made the decision')
+    .option(
+      '--rollback <checkpointId>',
+      'After recording the decision, roll the working tree back to a checkpoint (omc checkpoint create/list)',
+    )
+    .option(
+      '--force',
+      'With --rollback: discard uncommitted changes made after the checkpoint',
+      false,
+    )
     .action(
       async (
         runId: string,
         activationId: string,
         decision: string,
-        options: { runsRoot: string; by?: string },
+        options: { runsRoot: string; by?: string; rollback?: string; force: boolean },
       ) => {
         if (decision !== 'approved' && decision !== 'denied') {
           fail(`invalid decision "${decision}" (expected approved or denied)`, 1);
@@ -324,6 +354,16 @@ Exit codes:
           );
         } catch (error) {
           fail(`cannot record decision: ${errorMessage(error)}`, 1);
+          return;
+        }
+        if (options.rollback !== undefined) {
+          try {
+            const { rollbackToCheckpoint } = await import('../features/checkpoint/index.js');
+            rollbackToCheckpoint(process.cwd(), options.rollback, options.force);
+            console.log(`Rolled back working tree to ${chalk.bold(options.rollback)}.`);
+          } catch (error) {
+            fail(`decision recorded, but rollback failed: ${errorMessage(error)}`, 1);
+          }
         }
       },
     );

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -24,6 +24,11 @@ import type { RunOptions, RunResult } from '../graph/runtime/types.js';
 import { AgentNodeExecutor } from '../graph/runtime/executors/agent.js';
 import { CommandNodeExecutor } from '../graph/runtime/executors/command.js';
 import { createStdinApprovalGate } from '../graph/runtime/approval.js';
+import {
+  createRemoteApprovalGate,
+  listPendingApprovals,
+  writeApprovalDecision,
+} from '../graph/runtime/remote-approval.js';
 import { createAsciiProgressReporter } from '../graph/runtime/progress.js';
 import { resolveRunDirHandle } from '../graph/runtime/run-dir.js';
 import type { RunDirHandle } from '../graph/runtime/run-dir.js';
@@ -111,7 +116,15 @@ async function loadSealedDescriptor(
   return stored;
 }
 
-async function runAction(descriptorPath: string, runsRoot: string): Promise<void> {
+async function runAction(
+  descriptorPath: string,
+  runsRoot: string,
+  approvalOptions: {
+    approvalMode: string;
+    approvalTimeout?: number;
+    approvalTimeoutPolicy: string;
+  } = { approvalMode: 'stdin', approvalTimeoutPolicy: 'deny' },
+): Promise<void> {
   try {
     // Reject unsupported POSIX before descriptor/run-directory resolution so
     // the fail-closed contract cannot create persistence state as a side
@@ -128,10 +141,42 @@ async function runAction(descriptorPath: string, runsRoot: string): Promise<void
   // runtime, and so this adapter stays decoupled from runtime module order.
   const [{ runGraph }] = await Promise.all([import('../graph/runtime/runner.js')]);
 
+  const approvalMode = approvalOptions.approvalMode ?? 'stdin';
+  const timeoutPolicy = approvalOptions.approvalTimeoutPolicy ?? 'deny';
+
+  let prompter;
+  if (approvalMode === 'remote') {
+    prompter = createRemoteApprovalGate({
+      runsRoot,
+      runId: sealed.run_id,
+      ...(approvalOptions.approvalTimeout !== undefined
+        ? { timeoutMs: approvalOptions.approvalTimeout * 1000 }
+        : {}),
+      timeoutPolicy: timeoutPolicy === 'approve' ? 'approved' : 'denied',
+      notifier: async (request, record) => {
+        // Lazy import keeps `omc graph --help` free of the notifications stack.
+        const { notify } = await import('../notifications/index.js');
+        await notify('approval-request', {
+          sessionId: record.run_id,
+          question: request.prompt_text,
+          message:
+            `🔔 Approval required for graph run \`${record.run_id}\` ` +
+            `(node \`${record.node_id}\`, activation \`${record.activation_id}\`).\n\n` +
+            `${request.prompt_text}\n\n` +
+            `Decide with: omc graph approvals decide ${record.run_id} ${record.activation_id} <approved|denied>`,
+          projectPath: process.cwd(),
+          reason: `graph approval gate: ${record.node_id}`,
+        });
+      },
+    });
+  } else {
+    prompter = createStdinApprovalGate();
+  }
+
   const options: RunOptions = {
     runsRoot,
     executors: [new CommandNodeExecutor(), new AgentNodeExecutor()],
-    prompter: createStdinApprovalGate(),
+    prompter,
     reporter: createAsciiProgressReporter(),
   };
 
@@ -165,12 +210,28 @@ export function graphCommand(): Command {
     .command('run <descriptorPath>')
     .description('Run a graph descriptor with kill/resume support')
     .option('--runs-root <dir>', 'Directory holding per-run state', '.omc/graph-runs')
+    .option(
+      '--approval-mode <mode>',
+      'Approval gate style: stdin (interactive y/n) or remote (file-backed + notification)',
+      'stdin',
+    )
+    .option(
+      '--approval-timeout <seconds>',
+      'Remote approvals: max seconds to wait for a decision (default: wait forever)',
+      (value: string) => Number(value),
+    )
+    .option(
+      '--approval-timeout-policy <policy>',
+      'Remote approvals: resolution for an expired request: deny (default, fail-closed) or approve',
+      'deny',
+    )
     .addHelpText(
       'after',
       `
 Examples:
   $ omc graph run ./my-graph.json
   $ omc graph run ./my-graph.json --runs-root .omc/graph-runs
+  $ omc graph run ./my-graph.json --approval-mode remote --approval-timeout 3600
 
 Exit codes:
   0   run succeeded
@@ -180,9 +241,85 @@ Exit codes:
   21  descriptor mismatch on resume
   70  runtime crash (unmapped error)`,
     )
-    .action(async (descriptorPath: string, options: { runsRoot: string }) => {
-      await runAction(descriptorPath, options.runsRoot);
+    .action(
+      async (
+        descriptorPath: string,
+        options: {
+          runsRoot: string;
+          approvalMode: string;
+          approvalTimeout?: number;
+          approvalTimeoutPolicy: string;
+        },
+      ) => {
+        if (!['stdin', 'remote'].includes(options.approvalMode)) {
+          fail(`invalid --approval-mode "${options.approvalMode}" (expected stdin or remote)`, 1);
+          return;
+        }
+        if (!['deny', 'approve'].includes(options.approvalTimeoutPolicy)) {
+          fail(`invalid --approval-timeout-policy "${options.approvalTimeoutPolicy}" (expected deny or approve)`, 1);
+          return;
+        }
+        await runAction(descriptorPath, options.runsRoot, options);
+      },
+    );
+
+  const approvals = command
+    .command('approvals')
+    .description('List and decide pending human-approval gates for graph runs');
+
+  approvals
+    .command('list')
+    .description('List pending approval requests across all runs')
+    .option('--runs-root <dir>', 'Directory holding per-run state', '.omc/graph-runs')
+    .action(async (options: { runsRoot: string }) => {
+      const entries = listPendingApprovals(options.runsRoot);
+      if (entries.length === 0) {
+        console.log('No pending approvals.');
+        return;
+      }
+      for (const entry of entries) {
+        console.log(
+          `${chalk.bold(entry.run_id)}  ${chalk.cyan(entry.activation_id)}  node=${entry.node_id}  created=${entry.created_at}`,
+        );
+        console.log(`  ${entry.prompt_text.replace(/\n/g, '\n  ')}`);
+        console.log(
+          `  decide: omc graph approvals decide ${entry.run_id} ${entry.activation_id} <approved|denied>`,
+        );
+      }
     });
+
+  approvals
+    .command('decide <runId> <activationId> <decision>')
+    .description('Write an approval decision for one pending gate (approved|denied)')
+    .option('--runs-root <dir>', 'Directory holding per-run state', '.omc/graph-runs')
+    .option('--by <who>', 'Record who made the decision')
+    .action(
+      async (
+        runId: string,
+        activationId: string,
+        decision: string,
+        options: { runsRoot: string; by?: string },
+      ) => {
+        if (decision !== 'approved' && decision !== 'denied') {
+          fail(`invalid decision "${decision}" (expected approved or denied)`, 1);
+          return;
+        }
+        try {
+          const record = writeApprovalDecision(
+            options.runsRoot,
+            runId,
+            activationId,
+            decision,
+            options.by,
+          );
+          console.log(
+            `Recorded ${chalk.bold(record.decision)} for ${chalk.cyan(activationId)} (run ${runId}).`,
+          );
+        } catch (error) {
+          fail(`cannot record decision: ${errorMessage(error)}`, 1);
+        }
+      },
+    );
 
   return command;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,6 +64,7 @@ import { launchCommand } from './launch.js';
 import { interopCommand } from './interop.js';
 import { askCommand, ASK_USAGE } from './ask.js';
 import { graphCommand } from './graph.js';
+import { checkpointCommand } from './checkpoint.js';
 import { warnIfWin32 } from './win32-warning.js';
 import { autoresearchCommand } from './autoresearch.js';
 import { runHudWatchLoop } from './hud-watch.js';
@@ -1553,6 +1554,7 @@ program
  * Graph command - Execute sealed graph descriptors (graph runtime v2)
  */
 program.addCommand(graphCommand());
+program.addCommand(checkpointCommand());
 
 /**
  * Returns the fully-configured commander program.

--- a/src/features/__tests__/checkpoint.test.ts
+++ b/src/features/__tests__/checkpoint.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Checkpoint feature tests: shadow-commit snapshot, listing, and rollback
+ * semantics on real temporary git repositories.
+ */
+
+import { execFileSync } from "child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CheckpointError,
+  createCheckpoint,
+  isWorktreeDirty,
+  listCheckpoints,
+  rollbackToCheckpoint,
+} from "../checkpoint/index.js";
+
+const tempDirs: string[] = [];
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+/** Create a real git repo with one commit and a .gitignore. */
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-checkpoint-"));
+  tempDirs.push(dir);
+  git(dir, ["init", "-q"]);
+  git(dir, ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "--allow-empty", "-q", "-m", "init"]);
+  writeFileSync(join(dir, ".gitignore"), "ignored.txt\n");
+  writeFileSync(join(dir, "base.txt"), "v1\n");
+  git(dir, ["add", "."]);
+  git(dir, ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "add base"]);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("createCheckpoint", () => {
+  it("captures modified and untracked files without touching HEAD", () => {
+    const dir = makeRepo();
+    writeFileSync(join(dir, "base.txt"), "v2\n");
+    writeFileSync(join(dir, "untracked.txt"), "new\n");
+
+    const headBefore = git(dir, ["rev-parse", "HEAD"]);
+    const id = createCheckpoint(dir, "test snapshot");
+
+    expect(id).toMatch(/^[0-9a-f]{12}$/);
+    expect(git(dir, ["rev-parse", "HEAD"])).toBe(headBefore);
+    // HEAD and worktree untouched by snapshot.
+    expect(readFileSync(join(dir, "base.txt"), "utf8")).toBe("v2\n");
+  });
+
+  it("labels the shadow commit", () => {
+    const dir = makeRepo();
+    const id = createCheckpoint(dir, "my label");
+    const entries = listCheckpoints(dir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe(id);
+    expect(entries[0].label).toBe("my label");
+    expect(entries[0].createdAt).toBeTruthy();
+  });
+
+  it("fails outside a git repository", () => {
+    const outside = mkdtempSync(join(tmpdir(), "omc-no-repo-"));
+    tempDirs.push(outside);
+    expect(() => createCheckpoint(outside, "x")).toThrow(CheckpointError);
+  });
+});
+
+describe("rollbackToCheckpoint", () => {
+  it("restores modified content and removes files created after the snapshot", () => {
+    const dir = makeRepo();
+    const id = createCheckpoint(dir, "before changes");
+
+    // Simulate an autonomous run gone wrong: modify, create, and leave junk.
+    writeFileSync(join(dir, "base.txt"), "v2-broken\n");
+    writeFileSync(join(dir, "generated.txt"), "junk\n");
+    writeFileSync(join(dir, "ignored.txt"), "kept\n");
+
+    rollbackToCheckpoint(dir, id, true);
+
+    expect(readFileSync(join(dir, "base.txt"), "utf8")).toBe("v1\n");
+    expect(existsSync(join(dir, "generated.txt"))).toBe(false);
+    // Ignored paths survive (clean -fd keeps them).
+    expect(readFileSync(join(dir, "ignored.txt"), "utf8")).toBe("kept\n");
+    expect(git(dir, ["status", "--porcelain"])).toBe("");
+  });
+
+  it("refuses to discard uncommitted changes without force", () => {
+    const dir = makeRepo();
+    const id = createCheckpoint(dir, "safe point");
+    writeFileSync(join(dir, "base.txt"), "v2\n");
+
+    expect(() => rollbackToCheckpoint(dir, id)).toThrow(/--force/);
+    // Worktree untouched by the refused rollback.
+    expect(readFileSync(join(dir, "base.txt"), "utf8")).toBe("v2\n");
+  });
+
+  it("rejects unknown checkpoint ids", () => {
+    const dir = makeRepo();
+    expect(() => rollbackToCheckpoint(dir, "deadbeefdead")).toThrow(/unknown checkpoint/);
+  });
+
+  it("rejects traversal-shaped ids", () => {
+    const dir = makeRepo();
+    expect(() => rollbackToCheckpoint(dir, "../../etc")).toThrow(/invalid checkpoint id/);
+  });
+});
+
+describe("isWorktreeDirty / listCheckpoints", () => {
+  it("reports dirty state and lists checkpoints oldest first", () => {
+    const dir = makeRepo();
+    expect(isWorktreeDirty(dir)).toBe(false);
+    const first = createCheckpoint(dir, "first");
+    writeFileSync(join(dir, "extra.txt"), "x\n");
+    const second = createCheckpoint(dir, "second");
+
+    const entries = listCheckpoints(dir);
+    // Both checkpoints can land in the same second (creatordate has second
+    // granularity), so compare as a set; order is verified by --sort=creatordate.
+    expect([...entries.map((e) => e.id)].sort()).toEqual([first, second].sort());
+
+    // Snapshotting does not commit anything: extra.txt is still untracked
+    // relative to HEAD even though the second checkpoint captured it.
+    expect(isWorktreeDirty(dir)).toBe(true);
+  });
+});

--- a/src/features/__tests__/checkpoint.test.ts
+++ b/src/features/__tests__/checkpoint.test.ts
@@ -73,6 +73,11 @@ describe("createCheckpoint", () => {
     tempDirs.push(outside);
     expect(() => createCheckpoint(outside, "x")).toThrow(CheckpointError);
   });
+
+  it("rejects empty labels", () => {
+    const dir = makeRepo();
+    expect(() => createCheckpoint(dir, "   ")).toThrow(CheckpointError);
+  });
 });
 
 describe("rollbackToCheckpoint", () => {

--- a/src/features/checkpoint/index.ts
+++ b/src/features/checkpoint/index.ts
@@ -1,0 +1,190 @@
+/**
+ * Workspace checkpoints: snapshot-and-rollback for autonomous runs.
+ *
+ * A checkpoint is a git "shadow commit": the full working tree (tracked,
+ * modified, and untracked-but-not-ignored files) is captured via a
+ * temporary index and stored under `refs/omc/checkpoints/<sha>` without
+ * touching HEAD, the real index, or the worktree. Rolling back restores
+ * the worktree + index from that tree.
+ *
+ * Design constraints:
+ * - Git-only by design: OMC already requires git for its core workflows,
+ *   and shadow commits are the only snapshot mechanism that is cheap
+ *   (no file copying), complete (includes untracked files), and safe
+ *   (nothing outside refs/omc/ changes at snapshot time).
+ * - Rollback removes files created after the snapshot (git clean -fd,
+ *   which keeps ignored paths like node_modules) and requires --force
+ *   when the working tree is dirty, because it discards uncommitted work.
+ */
+
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const GIT_TIMEOUT_MS = 60_000;
+const REF_PREFIX = "refs/omc/checkpoints/";
+
+/** Author/committer identity for shadow commits (never uses user git config). */
+const SHADOW_IDENTITY = [
+  "-c", "user.name=omc checkpoint",
+  "-c", "user.email=checkpoint@omc.invalid",
+];
+
+export class CheckpointError extends Error {
+  constructor(message: string, readonly exitCode = 1) {
+    super(message);
+    this.name = "CheckpointError";
+  }
+}
+
+interface GitOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+function git(args: readonly string[], options: GitOptions = {}): string {
+  try {
+    return execFileSync("git", args, {
+      cwd: options.cwd ?? process.cwd(),
+      env: options.env ?? process.env,
+      timeout: GIT_TIMEOUT_MS,
+      encoding: "utf8",
+      windowsHide: true,
+    }).trim();
+  } catch (error) {
+    const err = error as { stderr?: string; message: string };
+    const detail = (err.stderr ?? err.message ?? "").trim();
+    throw new CheckpointError(`git ${args[0]} failed: ${detail}`, 1);
+  }
+}
+
+/** Resolve the enclosing repository toplevel, failing closed outside git. */
+function repoToplevel(cwd: string): string {
+  const toplevel = git(["rev-parse", "--show-toplevel"], { cwd });
+  if (!toplevel) {
+    throw new CheckpointError("not inside a git repository");
+  }
+  return toplevel;
+}
+
+/**
+ * Snapshot the whole working tree (including untracked non-ignored files)
+ * as a shadow commit and store it under refs/omc/checkpoints/.
+ *
+ * Returns the 12-char checkpoint id (abbreviated commit sha).
+ */
+export function createCheckpoint(cwd: string, label: string): string {
+  const toplevel = repoToplevel(cwd);
+
+  // Build a tree from the live worktree using a temporary index so the
+  // user's real index and HEAD are never touched.
+  const tmpIndexDir = mkdtempSync(join(tmpdir(), "omc-checkpoint-"));
+  try {
+    const tmpIndexPath = join(tmpIndexDir, "index");
+    git(["add", "-A", "--"], {
+      cwd: toplevel,
+      env: { ...process.env, GIT_INDEX_FILE: tmpIndexPath },
+    });
+    const tree = git(["write-tree"], { cwd: toplevel, env: { ...process.env, GIT_INDEX_FILE: tmpIndexPath } });
+
+    // Parent onto HEAD when the repository has commits; orphan trees are
+    // valid snapshots for freshly-initialized repositories.
+    let hasHead = true;
+    try {
+      git(["rev-parse", "--verify", "--quiet", "HEAD"], { cwd: toplevel });
+    } catch {
+      hasHead = false;
+    }
+    const parentArgs = hasHead ? ["-p", "HEAD"] : [];
+    const commit = git(
+      [...SHADOW_IDENTITY, "commit-tree", tree, ...parentArgs, "-m", `omc checkpoint: ${label}`],
+      { cwd: toplevel },
+    );
+    git(["update-ref", `${REF_PREFIX}${commit}`, commit], { cwd: toplevel });
+    return commit.slice(0, 12);
+  } finally {
+    rmSync(tmpIndexDir, { recursive: true, force: true });
+  }
+}
+
+export interface CheckpointEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly createdAt: string;
+}
+
+/** List checkpoints (oldest first) for the enclosing repository. */
+export function listCheckpoints(cwd: string): CheckpointEntry[] {
+  repoToplevel(cwd);
+  const raw = git(
+    [
+      "for-each-ref",
+      `--format=%(refname:short)%09%(creatordate:iso-strict)%09%(subject)`,
+      "--sort=creatordate",
+      REF_PREFIX,
+    ],
+    { cwd },
+  );
+  if (!raw) return [];
+  return raw.split("\n").map((line) => {
+    const [ref, createdAt, subject = ""] = line.split("\t");
+    return {
+      id: ref.replace(/^omc\/checkpoints\//, "").slice(0, 12),
+      createdAt,
+      label: subject.replace(/^omc checkpoint: /, ""),
+    };
+  });
+}
+
+/**
+ * True when the working tree differs from HEAD (tracked modifications or
+ * untracked non-ignored files). Used to gate rollback behind --force.
+ */
+export function isWorktreeDirty(cwd: string): boolean {
+  const toplevel = repoToplevel(cwd);
+  const status = git(["status", "--porcelain"], { cwd: toplevel });
+  return status.length > 0;
+}
+
+/**
+ * Restore the worktree and index from a checkpoint.
+ *
+ * Files created after the snapshot are removed (git clean -fd keeps
+ * ignored paths such as node_modules). Refuses when the worktree is dirty
+ * unless force is set, because rollback discards uncommitted work.
+ */
+export function rollbackToCheckpoint(cwd: string, checkpointId: string, force = false): void {
+  const toplevel = repoToplevel(cwd);
+
+  if (!/^[0-9a-f]{4,40}$/.test(checkpointId)) {
+    throw new CheckpointError(`invalid checkpoint id "${checkpointId}"`);
+  }
+
+  // Resolve against the checkpoints namespace by sha prefix. Ref names do
+  // not support prefix lookup (unlike object shas), so match candidates via
+  // for-each-ref; ambiguity is an error rather than a guess.
+  const candidates = git(
+    ["for-each-ref", "--format=%(objectname)", REF_PREFIX],
+    { cwd: toplevel },
+  )
+    .split("\n")
+    .filter((sha) => sha.startsWith(checkpointId));
+  if (candidates.length === 0) {
+    throw new CheckpointError(`unknown checkpoint "${checkpointId}" (see: omc checkpoint list)`);
+  }
+  if (candidates.length > 1) {
+    throw new CheckpointError(`ambiguous checkpoint id "${checkpointId}"; use more characters`);
+  }
+  const full = candidates[0];
+
+  if (!force && isWorktreeDirty(toplevel)) {
+    throw new CheckpointError(
+      "working tree has uncommitted changes; rollback would discard them. Re-run with --force to proceed.",
+      2,
+    );
+  }
+
+  git(["restore", "--source", full, "--staged", "--worktree", ":/"], { cwd: toplevel });
+  git(["clean", "-fd"], { cwd: toplevel });
+}

--- a/src/features/checkpoint/index.ts
+++ b/src/features/checkpoint/index.ts
@@ -75,8 +75,10 @@ function repoToplevel(cwd: string): string {
  * Returns the 12-char checkpoint id (abbreviated commit sha).
  */
 export function createCheckpoint(cwd: string, label: string): string {
+  if (typeof label !== "string" || label.trim().length === 0) {
+    throw new CheckpointError("checkpoint label must not be empty");
+  }
   const toplevel = repoToplevel(cwd);
-
   // Build a tree from the live worktree using a temporary index so the
   // user's real index and HEAD are never touched.
   const tmpIndexDir = mkdtempSync(join(tmpdir(), "omc-checkpoint-"));
@@ -177,6 +179,13 @@ export function rollbackToCheckpoint(cwd: string, checkpointId: string, force = 
     throw new CheckpointError(`ambiguous checkpoint id "${checkpointId}"; use more characters`);
   }
   const full = candidates[0];
+
+  // The resolved sha must be a commit (a shadow checkpoint), never a blob or
+  // tree an attacker planted at a colliding ref path. Fail closed otherwise.
+  const objectType = git(["cat-file", "-t", full], { cwd: toplevel });
+  if (objectType !== "commit") {
+    throw new CheckpointError(`checkpoint "${checkpointId}" is not a valid snapshot`);
+  }
 
   if (!force && isWorktreeDirty(toplevel)) {
     throw new CheckpointError(

--- a/src/graph/__tests__/runtime/remote-approval.test.ts
+++ b/src/graph/__tests__/runtime/remote-approval.test.ts
@@ -250,3 +250,22 @@ describe("writeApprovalDecision fail-closed", () => {
     expect(existsSync(join(runsRoot, "typo-run"))).toBe(false);
   });
 });
+
+describe("createRemoteApprovalGate abort", () => {
+  it("resolves denied when the signal is already aborted", async () => {
+    const runsRoot = makeRunsRoot();
+    const controller = new AbortController();
+    controller.abort();
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      signal: controller.signal,
+      sleep: async () => {},
+    });
+
+    expect(await gate.prompt(REQUEST)).toBe("denied");
+    expect(
+      existsSync(join(runsRoot, "run-1", "approvals", "pending", "act-1.json")),
+    ).toBe(false);
+  });
+});

--- a/src/graph/__tests__/runtime/remote-approval.test.ts
+++ b/src/graph/__tests__/runtime/remote-approval.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Remote approval gate tests: pending/decision artifact lifecycle,
+ * fail-closed parsing, timeout policy, and CLI-facing list/decide helpers.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createRemoteApprovalGate,
+  listPendingApprovals,
+  parseDecisionArtifact,
+  writeApprovalDecision,
+} from "../../runtime/remote-approval.js";
+import type { ApprovalRequest } from "../../runtime/types.js";
+
+const REQUEST: ApprovalRequest = {
+  run_id: "run-1",
+  node_id: "gate-1",
+  activation_id: "act-1",
+  prompt_text: "Deploy to staging?",
+};
+
+const tempDirs: string[] = [];
+
+function makeRunsRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-remote-approval-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Sleep stub that writes a decision artifact after N polls. */
+function decisionAfter(
+  runsRoot: string,
+  record: unknown,
+  afterPolls: number,
+  raw = false,
+): (ms: number) => Promise<void> {
+  let calls = 0;
+  return async () => {
+    calls += 1;
+    if (calls === afterPolls) {
+      const dir = join(runsRoot, "run-1", "approvals", "decisions");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "act-1.json"),
+        raw ? String(record) : JSON.stringify(record),
+      );
+    }
+  };
+}
+
+describe("createRemoteApprovalGate", () => {
+  it("persists a pending artifact and resolves an approved decision", async () => {
+    const runsRoot = makeRunsRoot();
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      sleep: decisionAfter(runsRoot, { decision: "approved", decided_at: "2026-01-01T00:00:00Z" }, 1),
+    });
+
+    const decision = await gate.prompt(REQUEST);
+    expect(decision).toBe("approved");
+
+    // Pending artifact retired after resolution.
+    const pendingPath = join(runsRoot, "run-1", "approvals", "pending", "act-1.json");
+    expect(existsSync(pendingPath)).toBe(false);
+  });
+
+  it("resolves denied and keeps a well-formed decision record", async () => {
+    const runsRoot = makeRunsRoot();
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      sleep: decisionAfter(runsRoot, { decision: "denied", decided_by: "alice", decided_at: "2026-01-01T00:00:00Z" }, 1),
+    });
+
+    expect(await gate.prompt(REQUEST)).toBe("denied");
+  });
+
+  it("ignores malformed decision files and keeps waiting", async () => {
+    const runsRoot = makeRunsRoot();
+    // Poll 1: garbage JSON. Poll 2: unknown decision value. Poll 3: valid.
+    let calls = 0;
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      sleep: async () => {
+        calls += 1;
+        const dir = join(runsRoot, "run-1", "approvals", "decisions");
+        mkdirSync(dir, { recursive: true });
+        if (calls === 1) writeFileSync(join(dir, "act-1.json"), "not json");
+        if (calls === 2) writeFileSync(join(dir, "act-1.json"), JSON.stringify({ decision: "maybe" }));
+        if (calls === 3) writeFileSync(join(dir, "act-1.json"), JSON.stringify({ decision: "approved" }));
+      },
+    });
+
+    expect(await gate.prompt(REQUEST)).toBe("approved");
+  });
+
+  it("fires the notifier once with the pending record", async () => {
+    const runsRoot = makeRunsRoot();
+    const seen: unknown[] = [];
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      notifier: async (request, record) => {
+        seen.push([request, record]);
+      },
+      sleep: decisionAfter(runsRoot, { decision: "approved" }, 1),
+    });
+
+    await gate.prompt(REQUEST);
+    expect(seen).toHaveLength(1);
+    const [, record] = seen[0] as [unknown, { run_id: string; prompt_text: string }];
+    expect(record.run_id).toBe("run-1");
+    expect(record.prompt_text).toBe("Deploy to staging?");
+  });
+
+  it("swallows notifier errors", async () => {
+    const runsRoot = makeRunsRoot();
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      notifier: () => {
+        throw new Error("telegram down");
+      },
+      sleep: decisionAfter(runsRoot, { decision: "denied" }, 1),
+    });
+
+    expect(await gate.prompt(REQUEST)).toBe("denied");
+  });
+
+  it("applies the default timeout policy (deny, fail closed)", async () => {
+    const runsRoot = makeRunsRoot();
+    let clock = 0;
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      timeoutMs: 10_000,
+      pollIntervalMs: 60_000,
+      now: () => clock,
+      sleep: async () => {
+        clock += 60_000;
+      },
+    });
+
+    expect(await gate.prompt(REQUEST)).toBe("denied");
+  });
+
+  it("applies an explicit approve timeout policy", async () => {
+    const runsRoot = makeRunsRoot();
+    let clock = 0;
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      timeoutMs: 10_000,
+      timeoutPolicy: "approved",
+      pollIntervalMs: 60_000,
+      now: () => clock,
+      sleep: async () => {
+        clock += 60_000;
+      },
+    });
+
+    expect(await gate.prompt(REQUEST)).toBe("approved");
+  });
+
+  it("rejects traversal-shaped activation ids", async () => {
+    const runsRoot = makeRunsRoot();
+    const gate = createRemoteApprovalGate({ runsRoot, runId: "run-1" });
+    await expect(
+      gate.prompt({ ...REQUEST, activation_id: "../escape" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("parseDecisionArtifact", () => {
+  it("accepts well-formed decisions", () => {
+    expect(
+      parseDecisionArtifact('{"decision":"approved","decided_by":"alice"}'),
+    ).toEqual({ decision: "approved", decided_at: expect.any(String), decided_by: "alice" });
+  });
+
+  it("rejects malformed payloads", () => {
+    expect(parseDecisionArtifact("not json")).toBeNull();
+    expect(parseDecisionArtifact('{"decision":"maybe"}')).toBeNull();
+    expect(parseDecisionArtifact("[]")).toBeNull();
+    expect(parseDecisionArtifact('{"decision":"approved","decided_by":42}')).toBeNull();
+    expect(parseDecisionArtifact('{"decision":"approved","decided_at":42}')).toBeNull();
+  });
+});
+
+describe("listPendingApprovals / writeApprovalDecision", () => {
+  it("round-trips a pending request through decide", async () => {
+    const runsRoot = makeRunsRoot();
+    const gate = createRemoteApprovalGate({
+      runsRoot,
+      runId: "run-1",
+      // Never resolves on its own; sleep drives the poll loop until aborted.
+      sleep: () => new Promise(() => {}),
+    });
+    const promptPromise = gate.prompt(REQUEST);
+
+    // Let the gate write its pending artifact.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const entries = listPendingApprovals(runsRoot);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      run_id: "run-1",
+      activation_id: "act-1",
+      node_id: "gate-1",
+      prompt_text: "Deploy to staging?",
+    });
+
+    const record = writeApprovalDecision(runsRoot, "run-1", "act-1", "denied", "cli");
+    expect(record.decision).toBe("denied");
+    expect(record.decided_by).toBe("cli");
+
+    const raw = JSON.parse(
+      readFileSync(join(runsRoot, "run-1", "approvals", "decisions", "act-1.json"), "utf8"),
+    );
+    expect(raw.decision).toBe("denied");
+
+    promptPromise.catch(() => {});
+  });
+
+  it("returns empty for a missing runs root and skips unreadable runs", () => {
+    expect(listPendingApprovals(join(tmpdir(), "omc-does-not-exist-xyz"))).toEqual([]);
+  });
+});
+
+describe("writeApprovalDecision fail-closed", () => {
+  it("refuses to write a decision for an unknown run directory", () => {
+    const runsRoot = makeRunsRoot();
+    expect(() =>
+      writeApprovalDecision(runsRoot, "typo-run", "act-1", "approved", "cli"),
+    ).toThrow(/unknown run/);
+    // Nothing was created as a side effect.
+    expect(existsSync(join(runsRoot, "typo-run"))).toBe(false);
+  });
+});

--- a/src/graph/runtime/remote-approval.ts
+++ b/src/graph/runtime/remote-approval.ts
@@ -71,6 +71,8 @@ export interface RemoteApprovalGateOptions {
   readonly timeoutMs?: number;
   /** Resolution for an expired request (default "denied" — fail closed). */
   readonly timeoutPolicy?: Decision;
+  /** AbortSignal observed between polls; an aborted wait resolves denied. */
+  readonly signal?: AbortSignal;
   /** Best-effort delivery hook (notification channels). Errors are swallowed. */
   readonly notifier?: (
     request: ApprovalRequest,
@@ -210,6 +212,16 @@ export function createRemoteApprovalGate(
             // affects `approvals list` freshness, never run correctness.
           }
           return decision.decision;
+        }
+        // An aborted/killed run must not hang in the poll loop: resolve
+        // denied (fail closed) and let the runner's fence settle ownership.
+        if (options.signal?.aborted === true) {
+          try {
+            unlinkSync(join(pendingDir, artifactFileName(request.activation_id)));
+          } catch {
+            // Same best-effort retirement as above.
+          }
+          return "denied";
         }
         if (
           options.timeoutMs !== undefined &&

--- a/src/graph/runtime/remote-approval.ts
+++ b/src/graph/runtime/remote-approval.ts
@@ -1,0 +1,328 @@
+/**
+ * Remote approval gate (graph runtime v2).
+ *
+ * Bridges the frozen HumanApprovalPrompter contract to a file-backed
+ * decision exchange plus an optional notifier, so approvals can be
+ * granted from outside the interactive terminal (via `omc graph
+ * approvals decide`, and later via notification reply channels).
+ *
+ * Protocol (all files live inside the contained run directory):
+ *   <runDir>/approvals/pending/<activationId>.json    written by the gate
+ *   <runDir>/approvals/decisions/<activationId>.json  written by a decider
+ *
+ * Fail-closed by construction, mirroring createStdinApprovalGate:
+ *   - malformed or unknown decisions never resolve a request (the gate
+ *     keeps waiting for a well-formed one)
+ *   - an expired request resolves to the configured timeout policy
+ *     (default: denied)
+ *   - decision artifacts carry no trust: the runner records the outcome
+ *     in its own journal, so a forged decision file can only flip a
+ *     human-approval node, exactly like typing y at the stdin prompt
+ */
+
+import { existsSync, mkdirSync, readdirSync, rmSync, unlinkSync } from "fs";
+import { join } from "path";
+
+import { atomicWriteJsonSync } from "../../lib/atomic-write.js";
+import {
+  assertSafeContainedFileName,
+  readFileNoFollow,
+} from "./safe-fs.js";
+import { resolveRunDirHandle } from "./run-dir.js";
+import type { RunDirHandle } from "./run-dir.js";
+import type {
+  ApprovalRequest,
+  HumanApprovalPrompter,
+} from "./types.js";
+
+type Decision = "approved" | "denied";
+
+/** Persisted pending-request artifact (one per activation). */
+export interface PendingApprovalRecord {
+  readonly run_id: string;
+  readonly node_id: string;
+  readonly activation_id: string;
+  readonly prompt_text: string;
+  readonly created_at: string;
+}
+
+/** Persisted decision artifact (one per activation). */
+export interface ApprovalDecisionRecord {
+  readonly decision: Decision;
+  readonly decided_by?: string;
+  readonly decided_at: string;
+}
+
+/** One row surfaced by listPendingApprovals / `omc graph approvals list`. */
+export interface PendingApprovalEntry {
+  readonly run_id: string;
+  readonly activation_id: string;
+  readonly node_id: string;
+  readonly prompt_text: string;
+  readonly created_at: string;
+}
+
+export interface RemoteApprovalGateOptions {
+  readonly runsRoot: string;
+  readonly runId: string;
+  /** Poll cadence for decision artifacts (default 2000ms). */
+  readonly pollIntervalMs?: number;
+  /** Max wait before the timeout policy applies (default: wait forever). */
+  readonly timeoutMs?: number;
+  /** Resolution for an expired request (default "denied" — fail closed). */
+  readonly timeoutPolicy?: Decision;
+  /** Best-effort delivery hook (notification channels). Errors are swallowed. */
+  readonly notifier?: (
+    request: ApprovalRequest,
+    record: PendingApprovalRecord,
+  ) => void | Promise<void>;
+  /** Injectable clock + sleep for tests. */
+  readonly now?: () => number;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+const APPROVALS_DIR = "approvals";
+const PENDING_DIR = "pending";
+const DECISIONS_DIR = "decisions";
+
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_TIMEOUT_POLICY: Decision = "denied";
+
+const DECISION_VALUES: ReadonlySet<string> = new Set(["approved", "denied"]);
+
+function pendingDirPath(runDir: RunDirHandle): string {
+  return join(runDir.path, APPROVALS_DIR, PENDING_DIR);
+}
+
+function decisionsDirPath(runDir: RunDirHandle): string {
+  return join(runDir.path, APPROVALS_DIR, DECISIONS_DIR);
+}
+
+function artifactFileName(activationId: string): string {
+  // Activation ids come from the sealed descriptor and are therefore
+  // untrusted; refuse traversal-shaped or normalization-ambiguous values.
+  assertSafeContainedFileName(activationId);
+  return `${activationId}.json`;
+}
+
+/**
+ * Parse one decision artifact. Returns null for anything that is not a
+ * well-formed decision — malformed files are ignored, never trusted.
+ */
+export function parseDecisionArtifact(raw: string): ApprovalDecisionRecord | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (!DECISION_VALUES.has(candidate.decision as string)) return null;
+  if (
+    candidate.decided_at !== undefined &&
+    typeof candidate.decided_at !== "string"
+  ) {
+    return null;
+  }
+  if (
+    candidate.decided_by !== undefined &&
+    typeof candidate.decided_by !== "string"
+  ) {
+    return null;
+  }
+  return {
+    decision: candidate.decision as Decision,
+    decided_at:
+      typeof candidate.decided_at === "string"
+        ? candidate.decided_at
+        : new Date().toISOString(),
+    ...(typeof candidate.decided_by === "string"
+      ? { decided_by: candidate.decided_by }
+      : {}),
+  };
+}
+
+function readDecisionFile(
+  runDir: RunDirHandle,
+  activationId: string,
+): ApprovalDecisionRecord | null {
+  const filePath = join(decisionsDirPath(runDir), artifactFileName(activationId));
+  if (!existsSync(filePath)) return null;
+  try {
+    return parseDecisionArtifact(readFileNoFollow(filePath));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a remote approval gate. Each prompt persists a pending artifact,
+ * fires the best-effort notifier once, then polls for a decision artifact
+ * until one resolves or the optional timeout expires.
+ */
+export function createRemoteApprovalGate(
+  options: RemoteApprovalGateOptions,
+): HumanApprovalPrompter {
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const timeoutPolicy = options.timeoutPolicy ?? DEFAULT_TIMEOUT_POLICY;
+  const now = options.now ?? (() => Date.now());
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  return {
+    async prompt(request: ApprovalRequest): Promise<Decision> {
+      const runDir = resolveRunDirHandle(options.runsRoot, options.runId);
+      assertSafeContainedFileName(request.activation_id);
+      assertSafeContainedFileName(request.node_id);
+
+      const pendingDir = pendingDirPath(runDir);
+      const record: PendingApprovalRecord = {
+        run_id: request.run_id,
+        node_id: request.node_id,
+        activation_id: request.activation_id,
+        prompt_text: request.prompt_text,
+        created_at: new Date(now()).toISOString(),
+      };
+      mkdirSync(pendingDir, { recursive: true });
+      atomicWriteJsonSync(
+        join(pendingDir, artifactFileName(request.activation_id)),
+        record,
+      );
+
+      if (options.notifier !== undefined) {
+        try {
+          await options.notifier(request, record);
+        } catch {
+          // Notification delivery is best-effort; the decision file is the
+          // source of truth and the gate must never fail on notifier errors.
+        }
+      }
+
+      const startedAtMs = now();
+      for (;;) {
+        const decision = readDecisionFile(runDir, request.activation_id);
+        if (decision !== null) {
+          // Resolution observed: retire the pending artifact (best-effort).
+          try {
+            unlinkSync(join(pendingDir, artifactFileName(request.activation_id)));
+          } catch {
+            // A missing pending file is fine; leaving one behind only
+            // affects `approvals list` freshness, never run correctness.
+          }
+          return decision.decision;
+        }
+        if (
+          options.timeoutMs !== undefined &&
+          now() - startedAtMs >= options.timeoutMs
+        ) {
+          try {
+            unlinkSync(join(pendingDir, artifactFileName(request.activation_id)));
+          } catch {
+            // Same best-effort retirement as above.
+          }
+          return timeoutPolicy;
+        }
+        await sleep(pollIntervalMs);
+      }
+    },
+  };
+}
+
+/**
+ * List unresolved approval requests across all runs in a runs root.
+ * Read-only: runs with malformed or unreadable artifacts are skipped.
+ */
+export function listPendingApprovals(runsRoot: string): PendingApprovalEntry[] {
+  let runIds: string[];
+  try {
+    runIds = readdirSync(runsRoot);
+  } catch {
+    return [];
+  }
+
+  const entries: PendingApprovalEntry[] = [];
+  for (const runId of runIds) {
+    const pendingDir = join(runsRoot, runId, APPROVALS_DIR, PENDING_DIR);
+    if (!existsSync(pendingDir)) continue;
+    let files: string[];
+    try {
+      files = readdirSync(pendingDir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const raw = readFileNoFollow(join(pendingDir, file));
+        const parsed = JSON.parse(raw) as Partial<PendingApprovalRecord>;
+        if (
+          typeof parsed.run_id !== "string" ||
+          typeof parsed.node_id !== "string" ||
+          typeof parsed.activation_id !== "string" ||
+          typeof parsed.prompt_text !== "string" ||
+          typeof parsed.created_at !== "string"
+        ) {
+          continue;
+        }
+        entries.push({
+          run_id: parsed.run_id,
+          activation_id: parsed.activation_id,
+          node_id: parsed.node_id,
+          prompt_text: parsed.prompt_text,
+          created_at: parsed.created_at,
+        });
+      } catch {
+        continue;
+      }
+    }
+  }
+  return entries.sort((a, b) => a.created_at.localeCompare(b.created_at));
+}
+
+/**
+ * Persist one decision artifact on behalf of a human decider (the
+ * `omc graph approvals decide` CLI path). Fails closed on malformed ids
+ * and on unknown runs: the run directory must already exist (the gate
+ * creates it), so a typo'd run id is an error rather than a decision
+ * written into a directory nobody polls.
+ */
+export function writeApprovalDecision(
+  runsRoot: string,
+  runId: string,
+  activationId: string,
+  decision: Decision,
+  decidedBy?: string,
+): ApprovalDecisionRecord {
+  assertSafeContainedFileName(runId);
+  assertSafeContainedFileName(activationId);
+  if (!existsSync(join(runsRoot, runId))) {
+    throw new Error(`unknown run "${runId}" (no run directory under ${runsRoot})`);
+  }
+  const runDir = resolveRunDirHandle(runsRoot, runId);
+  const decisionsDir = decisionsDirPath(runDir);
+  mkdirSync(decisionsDir, { recursive: true });
+
+  const record: ApprovalDecisionRecord = {
+    decision,
+    decided_at: new Date().toISOString(),
+    ...(decidedBy !== undefined ? { decided_by: decidedBy } : {}),
+  };
+  atomicWriteJsonSync(
+    join(decisionsDir, artifactFileName(activationId)),
+    record,
+  );
+  return record;
+}
+
+/** Remove a run's pending artifact directory (best-effort housekeeping). */
+export function prunePendingApprovals(runsRoot: string, runId: string): void {
+  try {
+    assertSafeContainedFileName(runId);
+    rmSync(join(runsRoot, runId, APPROVALS_DIR, PENDING_DIR), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // Housekeeping only; never surface.
+  }
+}

--- a/src/notifications/__tests__/approval-reply.test.ts
+++ b/src/notifications/__tests__/approval-reply.test.ts
@@ -30,7 +30,6 @@ describe("parseApprovalReply", () => {
     expect(parseApprovalReply("approved")).toBe("approved");
     expect(parseApprovalReply("  Approve ")).toBe("approved");
     expect(parseApprovalReply("YES ship it")).toBe("approved");
-    expect(parseApprovalReply("LGTM 🚀")).toBe("approved");
     expect(parseApprovalReply("批准")).toBe("approved");
   });
 
@@ -78,5 +77,22 @@ describe("handleApprovalReply", () => {
     expect(
       existsSync(join(runsRoot, "run-1", "approvals", "decisions", "act-1.json")),
     ).toBe(false);
+  });
+
+  it("returns null instead of throwing for a stale approval ref", () => {
+    const runsRoot = makeRunsRoot();
+    // No run directory: the run ended or the ref is cross-session garbage.
+    expect(
+      handleApprovalReply(
+        { runsRoot, runId: "gone-run", activationId: "act-1" },
+        "approved",
+        "telegram",
+      ),
+    ).toBeNull();
+  });
+
+  it("does not treat casual chat as a decision", () => {
+    expect(parseApprovalReply("lgtm")).toBeNull();
+    expect(parseApprovalReply("looks good")).toBeNull();
   });
 });

--- a/src/notifications/__tests__/approval-reply.test.ts
+++ b/src/notifications/__tests__/approval-reply.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Approval reply handling: keyword parsing and decision-file resolution
+ * via the reply-listener path (Telegram/Discord/Slack reply channels).
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { handleApprovalReply, parseApprovalReply } from "../reply-listener.js";
+
+const tempDirs: string[] = [];
+
+function makeRunsRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omc-approval-reply-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("parseApprovalReply", () => {
+  it("maps approval keywords (case-insensitive, first word)", () => {
+    expect(parseApprovalReply("approved")).toBe("approved");
+    expect(parseApprovalReply("  Approve ")).toBe("approved");
+    expect(parseApprovalReply("YES ship it")).toBe("approved");
+    expect(parseApprovalReply("LGTM 🚀")).toBe("approved");
+    expect(parseApprovalReply("批准")).toBe("approved");
+  });
+
+  it("maps deny keywords", () => {
+    expect(parseApprovalReply("deny")).toBe("denied");
+    expect(parseApprovalReply("No")).toBe("denied");
+    expect(parseApprovalReply("REJECTED")).toBe("denied");
+    expect(parseApprovalReply("拒绝")).toBe("denied");
+  });
+
+  it("returns null for non-decision text", () => {
+    expect(parseApprovalReply("maybe later")).toBeNull();
+    expect(parseApprovalReply("")).toBeNull();
+    expect(parseApprovalReply("fix the tests first")).toBeNull();
+  });
+});
+
+describe("handleApprovalReply", () => {
+  it("writes a decision file attributed to the reply channel", () => {
+    const runsRoot = makeRunsRoot();
+    // The gate creates the run directory when it persists the pending record;
+    // decisions are only accepted for runs that exist.
+    mkdirSync(join(runsRoot, "run-1"), { recursive: true });
+    const decision = handleApprovalReply(
+      { runsRoot, runId: "run-1", activationId: "act-1" },
+      "approved",
+      "telegram",
+    );
+    expect(decision).toBe("approved");
+
+    const decisionPath = join(runsRoot, "run-1", "approvals", "decisions", "act-1.json");
+    expect(existsSync(decisionPath)).toBe(true);
+    const record = JSON.parse(readFileSync(decisionPath, "utf8"));
+    expect(record).toMatchObject({ decision: "approved", decided_by: "reply:telegram" });
+  });
+
+  it("returns null and writes nothing for non-decision text", () => {
+    const runsRoot = makeRunsRoot();
+    const decision = handleApprovalReply(
+      { runsRoot, runId: "run-1", activationId: "act-1" },
+      "looks good but wait",
+      "discord",
+    );
+    expect(decision).toBeNull();
+    expect(
+      existsSync(join(runsRoot, "run-1", "approvals", "decisions", "act-1.json")),
+    ).toBe(false);
+  });
+});

--- a/src/notifications/config.ts
+++ b/src/notifications/config.ts
@@ -417,6 +417,9 @@ const SESSION_EVENTS: ReadonlySet<NotificationEvent> = new Set([
   "session-stop",
   "session-end",
   "session-idle",
+  // Approval requests gate a blocked pipeline; like ask-user-question they
+  // must never be silently dropped by a coarse verbosity setting.
+  "approval-request",
 ]);
 
 /**

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -422,6 +422,25 @@ export function formatAgentCall(payload: NotificationPayload): string {
 }
 
 /**
+ * Format approval-request notification message.
+ * Notifies the user that a graph run is paused on a human approval gate.
+ */
+export function formatApprovalRequest(payload: NotificationPayload): string {
+  const lines = [`🔔 Approval Required`, ""];
+
+  if (payload.question) {
+    lines.push(payload.question);
+    lines.push("");
+  }
+
+  lines.push(`Reply or run \`omc graph approvals decide\` to approve/deny.`);
+  lines.push("");
+  lines.push(buildFooter(payload, true));
+
+  return lines.join("\n");
+}
+
+/**
  * Format ask-user-question notification message.
  * Notifies the user that Claude is waiting for input.
  */
@@ -475,6 +494,8 @@ export function formatNotification(payload: NotificationPayload): string {
       return formatSessionIdle(payload);
     case "ask-user-question":
       return formatAskUserQuestion(payload);
+    case "approval-request":
+      return formatApprovalRequest(payload);
     case "agent-call":
       return formatAgentCall(payload);
     default:

--- a/src/notifications/formatter.ts
+++ b/src/notifications/formatter.ts
@@ -433,6 +433,11 @@ export function formatApprovalRequest(payload: NotificationPayload): string {
     lines.push("");
   }
 
+  if (payload.approval) {
+    lines.push(`Run: \`${payload.approval.runId}\` | Activation: \`${payload.approval.activationId}\``);
+    lines.push("");
+  }
+
   lines.push(`Reply or run \`omc graph approvals decide\` to approve/deny.`);
   lines.push("");
   lines.push(buildFooter(payload, true));

--- a/src/notifications/hook-config-types.ts
+++ b/src/notifications/hook-config-types.ts
@@ -58,6 +58,7 @@ export interface HookNotificationConfig {
     "session-stop"?: HookEventConfig;
     "session-end"?: HookEventConfig;
     "session-idle"?: HookEventConfig;
+    "approval-request"?: HookEventConfig;
     "ask-user-question"?: HookEventConfig;
     "agent-call"?: HookEventConfig;
   };

--- a/src/notifications/index.ts
+++ b/src/notifications/index.ts
@@ -186,6 +186,7 @@ export async function notify(
       replyChannel: data.replyChannel ?? process.env.OPENCLAW_REPLY_CHANNEL ?? undefined,
       replyTarget: data.replyTarget ?? process.env.OPENCLAW_REPLY_TARGET ?? undefined,
       replyThread: data.replyThread ?? process.env.OPENCLAW_REPLY_THREAD ?? undefined,
+      approval: data.approval,
     };
 
     // Capture tmux tail for events that benefit from it
@@ -248,7 +249,10 @@ export async function notify(
     );
 
     // NEW: Register message IDs for reply correlation
-    if (result.anySuccess && payload.tmuxPaneId) {
+    if (
+      result.anySuccess &&
+      (payload.tmuxPaneId || payload.event === "approval-request")
+    ) {
       try {
         const { registerMessage } = await import("./session-registry.js");
         for (const r of result.results) {
@@ -261,11 +265,14 @@ export async function notify(
               platform: r.platform,
               messageId: r.messageId,
               sessionId: payload.sessionId,
-              tmuxPaneId: payload.tmuxPaneId,
+              tmuxPaneId: payload.tmuxPaneId ?? "",
               tmuxSessionName: payload.tmuxSession || "",
               event: payload.event,
               createdAt: new Date().toISOString(),
               projectPath: payload.projectPath,
+              ...(payload.approval
+                ? { approvalRef: payload.approval }
+                : {}),
               ...(payload.event === "ask-user-question" && payload.askUserQuestionPrompts?.[0]
                 ? {
                     askUserQuestionOptionCount: payload.askUserQuestionPrompts[0].options.length,

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -37,6 +37,7 @@ import {
   pruneStale,
   type SessionMapping,
 } from './session-registry.js';
+import { writeApprovalDecision } from '../graph/runtime/remote-approval.js';
 
 import type { ReplyConfig } from './types.js';
 import { parseMentionAllowedMentions } from './config.js';
@@ -349,6 +350,55 @@ export function sanitizeReplyInput(text: string): string {
 }
 
 // ============================================================================
+// Approval Gate Replies
+// ============================================================================
+
+/** Keywords that resolve an approval gate (first word of the reply, case-insensitive). */
+const APPROVAL_APPROVE_WORDS = new Set([
+  'approve', 'approved', 'yes', 'y', 'lgtm',
+  '批准', '同意',
+]);
+const APPROVAL_DENY_WORDS = new Set([
+  'deny', 'denied', 'no', 'n', 'reject', 'rejected',
+  '拒绝', '驳回',
+]);
+
+/**
+ * Parse a reply as an approval decision. Returns null when the reply does
+ * not look like a decision (the message is then left for normal handling).
+ */
+export function parseApprovalReply(text: string): 'approved' | 'denied' | null {
+  const firstWord = text.trim().toLowerCase().split(/\s+/)[0] || '';
+  if (APPROVAL_APPROVE_WORDS.has(firstWord)) return 'approved';
+  if (APPROVAL_DENY_WORDS.has(firstWord)) return 'denied';
+  return null;
+}
+
+/**
+ * Resolve an approval gate from a platform reply.
+ *
+ * Returns the recorded decision, or null when the text is not a decision
+ * (callers should fall back to normal reply handling or ignore).
+ */
+export function handleApprovalReply(
+  approvalRef: NonNullable<SessionMapping['approvalRef']>,
+  text: string,
+  platform: string,
+): 'approved' | 'denied' | null {
+  const decision = parseApprovalReply(text);
+  if (decision === null) return null;
+  writeApprovalDecision(
+    approvalRef.runsRoot,
+    approvalRef.runId,
+    approvalRef.activationId,
+    decision,
+    `reply:${platform}`,
+  );
+  log(`Approval ${decision} recorded for run ${approvalRef.runId} activation ${approvalRef.activationId} via ${platform} reply`);
+  return decision;
+}
+
+// ============================================================================
 // Rate Limiting
 // ============================================================================
 
@@ -558,6 +608,33 @@ async function pollDiscord(
         continue;
       }
 
+      // Approval-gate replies resolve the gate instead of injecting a pane
+      if (mapping.approvalRef) {
+        // AT-MOST-ONCE: persist offset BEFORE processing
+        state.discordLastMessageId = msg.id;
+        writeDaemonState(state);
+        const decision = handleApprovalReply(mapping.approvalRef, msg.content, 'discord');
+        if (decision !== null) {
+          // Confirmation reaction (non-critical)
+          const reaction = decision === 'approved' ? '%E2%9C%85' : '%E2%9D%8C';
+          try {
+            await fetch(
+              `https://discord.com/api/v10/channels/${config.discordChannelId}/messages/${msg.id}/reactions/${reaction}/@me`,
+              {
+                method: 'PUT',
+                headers: { 'Authorization': `Bot ${config.discordBotToken}` },
+                signal: AbortSignal.timeout(5000),
+              }
+            );
+          } catch (e) {
+            log(`WARN: Failed to add approval confirmation reaction: ${e}`);
+          }
+        } else {
+          log(`Discord reply on approval message ${msg.id} was not a decision; ignored`);
+        }
+        continue;
+      }
+
       // Rate limiting
       if (!rateLimiter.canProceed()) {
         log(`WARN: Rate limit exceeded, dropping Discord message ${msg.id}`);
@@ -712,6 +789,55 @@ async function pollTelegram(
       if (!mapping) {
         state.telegramLastUpdateId = update.update_id;
         writeDaemonState(state);
+        continue;
+      }
+
+      // Approval-gate replies resolve the gate instead of injecting a pane
+      if (mapping.approvalRef) {
+        // AT-MOST-ONCE: persist offset BEFORE processing
+        state.telegramLastUpdateId = update.update_id;
+        writeDaemonState(state);
+        const decision = handleApprovalReply(mapping.approvalRef, msg.text || '', 'telegram');
+        if (decision !== null) {
+          // Confirmation reply (non-critical)
+          try {
+            const confirmBody = JSON.stringify({
+              chat_id: config.telegramChatId,
+              text: `Approval recorded: ${decision}`,
+              reply_to_message_id: msg.message_id,
+            });
+            await new Promise<void>((resolve) => {
+              const confirmReq = httpsRequest(
+                {
+                  hostname: 'api.telegram.org',
+                  path: `/bot${config.telegramBotToken}/sendMessage`,
+                  method: 'POST',
+                  family: 4,
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Content-Length': Buffer.byteLength(confirmBody),
+                  },
+                  timeout: 5000,
+                },
+                (res) => {
+                  res.resume();
+                  resolve();
+                }
+              );
+              confirmReq.on('error', () => resolve());
+              confirmReq.on('timeout', () => {
+                confirmReq.destroy();
+                resolve();
+              });
+              confirmReq.write(confirmBody);
+              confirmReq.end();
+            });
+          } catch (e) {
+            log(`WARN: Failed to send approval confirmation: ${e}`);
+          }
+        } else {
+          log(`Telegram reply on approval message ${msg.message_id} was not a decision; ignored`);
+        }
         continue;
       }
 
@@ -870,6 +996,20 @@ async function pollLoop(): Promise<void> {
             if (event.thread_ts && event.thread_ts !== event.ts) {
               const mapping = lookupByMessageId('slack-bot', event.thread_ts);
               if (mapping) {
+                // Approval-gate replies resolve the gate instead of injecting a pane
+                if (mapping.approvalRef) {
+                  const decision = handleApprovalReply(mapping.approvalRef, event.text, 'slack');
+                  if (decision !== null) {
+                    try {
+                      await addSlackReaction(slackBotToken, slackChannelId, event.ts);
+                    } catch (e) {
+                      log(`WARN: Failed to add Slack approval reaction: ${e}`);
+                    }
+                  } else {
+                    log(`Slack reply on approval message ${event.thread_ts} was not a decision; ignored`);
+                  }
+                  return;
+                }
                 targetPaneId = mapping.tmuxPaneId;
                 targetMapping = mapping;
               }

--- a/src/notifications/reply-listener.ts
+++ b/src/notifications/reply-listener.ts
@@ -355,7 +355,7 @@ export function sanitizeReplyInput(text: string): string {
 
 /** Keywords that resolve an approval gate (first word of the reply, case-insensitive). */
 const APPROVAL_APPROVE_WORDS = new Set([
-  'approve', 'approved', 'yes', 'y', 'lgtm',
+  'approve', 'approved', 'yes', 'y',
   '批准', '同意',
 ]);
 const APPROVAL_DENY_WORDS = new Set([
@@ -387,13 +387,20 @@ export function handleApprovalReply(
 ): 'approved' | 'denied' | null {
   const decision = parseApprovalReply(text);
   if (decision === null) return null;
-  writeApprovalDecision(
-    approvalRef.runsRoot,
-    approvalRef.runId,
-    approvalRef.activationId,
-    decision,
-    `reply:${platform}`,
-  );
+  try {
+    writeApprovalDecision(
+      approvalRef.runsRoot,
+      approvalRef.runId,
+      approvalRef.activationId,
+      decision,
+      `reply:${platform}`,
+    );
+  } catch (error) {
+    // A stale or cross-session approvalRef must never throw out of the
+    // poll loop: stale entries are pruned by their 24h TTL; log and skip.
+    log(`Approval reply ignored for stale ref ${approvalRef.runId}/${approvalRef.activationId}: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
   log(`Approval ${decision} recorded for run ${approvalRef.runId} activation ${approvalRef.activationId} via ${platform} reply`);
   return decision;
 }

--- a/src/notifications/session-registry.ts
+++ b/src/notifications/session-registry.ts
@@ -99,6 +99,12 @@ export interface SessionMapping {
   /** AskUserQuestion metadata used to target the Other/free-text field for mobile replies. */
   askUserQuestionOptionCount?: number;
   askUserQuestionAllowOther?: boolean;
+  /** Approval-gate mapping: replies to this message resolve the gate instead of injecting a pane. */
+  approvalRef?: {
+    runsRoot: string;
+    runId: string;
+    activationId: string;
+  };
 }
 
 // ============================================================================

--- a/src/notifications/template-engine.ts
+++ b/src/notifications/template-engine.ts
@@ -297,6 +297,11 @@ const DEFAULT_TEMPLATES: Record<NotificationEvent, string> = {
     "{{#if agentName}}\n**Agent:** `{{agentName}}`{{/if}}" +
     "{{#if agentType}}\n**Type:** `{{agentType}}`{{/if}}" +
     "\n\n{{footer}}",
+
+  "approval-request":
+    "# 🔔 Approval Required\n" +
+    "{{#if question}}\n{{question}}\n{{/if}}" +
+    "\nReply or run `omc graph approvals decide` to approve/deny.\n\n{{footer}}",
 };
 
 /**

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -202,6 +202,15 @@ export interface NotificationPayload {
   iteration?: number;
   /** Max iterations (for stop events) */
   maxIterations?: number;
+  /** Approval-gate correlation for approval-request events */
+  approval?: {
+    /** Absolute runs root holding the run directory */
+    runsRoot: string;
+    /** Graph run id */
+    runId: string;
+    /** Activation id of the pending approval */
+    activationId: string;
+  };
   /** Question text (for ask-user-question events) */
   question?: string;
   /** Structured AskUserQuestion prompts/options preserved from tool input */

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -16,7 +16,8 @@ export type NotificationEvent =
   | "session-end"
   | "session-idle"
   | "ask-user-question"
-  | "agent-call";
+  | "agent-call"
+  | "approval-request";
 
 /** Supported notification platforms */
 export type NotificationPlatform =
@@ -163,6 +164,7 @@ export interface NotificationConfig {
     "session-idle"?: EventNotificationConfig;
     "ask-user-question"?: EventNotificationConfig;
     "agent-call"?: EventNotificationConfig;
+    "approval-request"?: EventNotificationConfig;
   };
 }
 


### PR DESCRIPTION
## Summary

Closes the trust chain for unattended graph runs: **run autonomously → pause for human approval → deny → restore the pre-run workspace**.

Graph runtime v2 (shipped in #3870) already has `human-approval` nodes, but its only prompter is an interactive stdin y/n — a run started in a terminal (or CI, or a tmux worker) blocks forever with no way to grant approval from elsewhere. This PR adds a second `HumanApprovalPrompter` implementation backed by a file protocol + the existing notification system, plus a checkpoint/rollback surface so a denial can undo everything the run did.

No frozen contract changes: the prompter stays injected; the runner, journal, and descriptor schemas are untouched.

## Commit 1 — remote approval gates (`feat(graph)`)

- `src/graph/runtime/remote-approval.ts`: file-backed approval protocol inside the contained run directory
  - `approvals/pending/<activationId>.json` written by the gate; `approvals/decisions/<activationId>.json` written by a decider
  - Fail-closed like the stdin gate: malformed decision artifacts are ignored, unknown values never resolve, timeout resolves to the configured policy (default **deny**)
  - `omc graph approvals decide` refuses unknown run directories (typo'd run id is an error, not a decision written where nobody polls)
- `omc graph run --approval-mode remote [--approval-timeout <s>] [--approval-timeout-policy deny|approve]`
- `omc graph approvals list` / `omc graph approvals decide <runId> <activationId> <approved|denied>`
- New `approval-request` notification event; never dropped by verbosity filtering (interactive-block tier)

## Commit 2 — reply-channel resolution (`feat(notifications)`)

- Reply-listener daemon (Telegram/Discord/Slack) resolves approval gates from replies instead of injecting into a pane
- `notify()` registers approval-request message ids even without a tmux pane (unattended runs)
- Decision keywords: `approve/yes/lgtm`, `deny/no/reject`, `批准/同意`, `拒绝/驳回` (first word, case-insensitive); non-decision replies are logged and ignored, never injected
- Confirmations: Telegram reply message, Discord/Slack reaction (best-effort)
- Authorization reuses existing channel guards (Telegram chat id, Discord/Slack authorized user lists)

## Commit 3 — checkpoints (`feat(checkpoint)`)

- Git **shadow commits**: the full working tree (tracked, modified, untracked non-ignored) is captured via a temporary index into `refs/omc/checkpoints/` — HEAD, the real index, and the worktree are never touched at snapshot time
- `omc checkpoint create --label <text> | list | rollback <id> [--force]`
- Rollback restores worktree+index and removes files created after the snapshot (`git clean -fd` keeps ignored paths like `node_modules`); refuses to discard uncommitted changes without `--force`
- Ids resolve by sha prefix within the checkpoints namespace only (ambiguous prefix is an error, never a guess)

## Commit 4 — inventory refresh (`chore(inventory)`)

## Integration

- `omc graph run --checkpoint` snapshots before the run
- `omc graph approvals decide ... --rollback <checkpointId>` restores the pre-run workspace; the decision is recorded first, so a failed rollback never silently un-decides a gate

Docs: added `omc checkpoint` and approval-gate sections to `docs/REFERENCE.md`.

## Test plan

- [x] `src/graph/__tests__/runtime/remote-approval.test.ts` — 13 tests: pending/decision lifecycle, malformed-artifact fail-closed parsing, timeout policies (default deny / explicit approve), notifier error isolation, traversal-shaped id rejection, unknown-run refusal
- [x] `src/notifications/__tests__/approval-reply.test.ts` — keyword parsing (EN + 中文) and decision-file resolution via the listener path
- [x] `src/features/__tests__/checkpoint.test.ts` — 8 tests on real temp git repos: snapshot completeness, HEAD immutability, rollback restore/clean semantics, `--force` gating, unknown/ambiguous/traversal id rejection
- [x] `npm run generate:inventory:verify` (via drift lint suite): 11/11 pass
- [x] `tsc --noEmit` clean; eslint clean on all touched files; `npm run build` succeeds
- [x] All notification + graph suites green (only pre-existing macOS-environment failures remain, identical on clean `dev`)