### PR TITLE
perf(hud): scope git path memoization per render

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "e3f200d8f6e1d4cefbc5fecf3dee02b3a1f28837",
-    "sourceSha256": "40af9be9d4dae728c2b3e06caf729259bdfbb08bb1397907a1f59d9452a7cff1",
+    "head": "ec4b5790cc9d72841bd59c507a21f69226b0d024",
+    "sourceSha256": "00a5796b53cc050b0843a44c6d673151f3c2d3da17d04cdb9fa362e4edd0da56",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "e3f200d8f6e1d4cefbc5fecf3dee02b3a1f28837",
-  "sourceSha256": "40af9be9d4dae728c2b3e06caf729259bdfbb08bb1397907a1f59d9452a7cff1",
+  "head": "ec4b5790cc9d72841bd59c507a21f69226b0d024",
+  "sourceSha256": "00a5796b53cc050b0843a44c6d673151f3c2d3da17d04cdb9fa362e4edd0da56",
   "counts": {
     "public": {
       "skills": 35,
@@ -32334,6 +32334,11 @@
         "id": "external:net",
         "kind": "external",
         "path": "net"
+      },
+      {
+        "id": "external:node:async_hooks",
+        "kind": "external",
+        "path": "node:async_hooks"
       },
       {
         "id": "external:node:child_process",
@@ -65259,6 +65264,11 @@
       },
       {
         "from": "src/lib/worktree-paths.ts",
+        "to": "external:node:async_hooks",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/worktree-paths.ts",
         "to": "external:os",
         "kind": "imports"
       },
@@ -77289,12 +77299,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6863,
-      "edgeCount": 7336,
-      "importEdgeCount": 6039,
+      "nodeCount": 6864,
+      "edgeCount": 7337,
+      "importEdgeCount": 6040,
       "registerEdgeCount": 56
     }
   },
   "inventorySha256": "48902e0c27f95a38180e82912e230183cb1cacfa1231dbdd635f91b772bafea2",
-  "manifestSha256": "8dd6d0062a5e44b4cdafab228ec4f9dce012e6cd63f03aa6f1b53ce2f9ce647e"
+  "manifestSha256": "8f006d1bcf77821df98a0a15d169a2c8ac5f3fda9061c448786195e00aa931d5"
 }

--- a/src/__tests__/hud/cli-diagnostic.test.ts
+++ b/src/__tests__/hud/cli-diagnostic.test.ts
@@ -91,6 +91,7 @@ describe('HUD CLI diagnostic (no stdin, no watch mode)', () => {
       resolveToWorktreeRoot: vi.fn((cwd?: string) => cwd ?? '/tmp'),
       resolveTranscriptPath: vi.fn((tp?: string) => tp),
       getOmcRoot: vi.fn(() => '/tmp/.omc'),
+      withWorktreePathRenderScope: vi.fn((callback: () => unknown) => callback()),
     }));
     vi.doMock('../../utils/config-dir.js', () => ({
       getClaudeConfigDir: vi.fn(() => overrides.configDir ?? tempConfigDir),

--- a/src/__tests__/hud/watch-mode-init.test.ts
+++ b/src/__tests__/hud/watch-mode-init.test.ts
@@ -137,6 +137,7 @@ describe('HUD watch mode initialization', () => {
       resolveToWorktreeRoot: vi.fn((cwd?: string) => cwd ?? '/tmp/worktree'),
       resolveTranscriptPath: vi.fn((transcriptPath?: string) => transcriptPath),
       getOmcRoot: vi.fn(() => '/tmp/worktree/.omc'),
+      withWorktreePathRenderScope: vi.fn((callback: () => unknown) => callback()),
     }));
 
     return import('../../hud/index.js');

--- a/src/hud/index.ts
+++ b/src/hud/index.ts
@@ -48,6 +48,7 @@ import { compareVersions } from "../features/auto-update.js";
 import {
   resolveToWorktreeRoot,
   resolveTranscriptPath,
+  withWorktreePathRenderScope,
 } from "../lib/worktree-paths.js";
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { access, readFile } from "fs/promises";
@@ -252,7 +253,7 @@ function showDiagnostic(): void {
  * Main HUD entry point
  * @param watchMode - true when called from the --watch polling loop (stdin is TTY)
  */
-async function main(watchMode = false, skipInit = false): Promise<void> {
+async function mainImpl(watchMode = false, skipInit = false): Promise<void> {
   try {
     // Read stdin from Claude Code
     const previousStdinCache = readStdinCache();
@@ -607,6 +608,10 @@ async function main(watchMode = false, skipInit = false): Promise<void> {
 }
 
 // Export for programmatic use (e.g., omc hud --watch loop)
+function main(watchMode = false, skipInit = false): Promise<void> {
+  return withWorktreePathRenderScope(() => mainImpl(watchMode, skipInit));
+}
+
 export { main };
 
 // Auto-run (unconditional so dynamic import() via omc-hud.mjs wrapper works correctly)

--- a/src/lib/__tests__/worktree-paths-toplevel-cache.test.ts
+++ b/src/lib/__tests__/worktree-paths-toplevel-cache.test.ts
@@ -23,11 +23,13 @@ import { execFileSync } from "child_process";
 import {
   clearWorktreeCache,
   getGitTopLevel,
+  getProjectIdentifier,
   getOmcRoot,
   getWorktreeRoot,
   probeGitTopLevel,
   setGitShowToplevelProbeForTests,
   validateWorkingDirectory,
+  withWorktreePathRenderScope,
 } from "../worktree-paths.js";
 
 const mockedExecFileSync = vi.mocked(execFileSync);
@@ -354,6 +356,162 @@ describe("git top-level memoization", () => {
     expect(probeGitTopLevel(repo).status).toBe("ok");
     expect(probeGitTopLevel(repo).status).toBe("ok");
     expect(showToplevelCalls()).toBe(2);
+  });
+
+  it("memoizes probes by canonical cwd only inside a render scope", () => {
+    const repo = join(tempDir, "repo");
+    const alias = join(tempDir, "repo-link");
+    initRepo(repo);
+
+    try {
+      symlinkSync(repo, alias, "dir");
+    } catch {
+      return;
+    }
+
+    let probeCalls = 0;
+    setGitShowToplevelProbeForTests(() => {
+      probeCalls++;
+      return `${repo}\n`;
+    });
+
+    withWorktreePathRenderScope(() => {
+      expect(probeGitTopLevel(repo).status).toBe("ok");
+      expect(probeGitTopLevel(alias).status).toBe("ok");
+    });
+    expect(probeCalls).toBe(1);
+
+    expect(probeGitTopLevel(repo).status).toBe("ok");
+    expect(probeGitTopLevel(repo).status).toBe("ok");
+    expect(probeCalls).toBe(3);
+  });
+
+  it("memoizes negative probe results only inside a render scope", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    let probeCalls = 0;
+    setGitShowToplevelProbeForTests(() => {
+      probeCalls++;
+      return "not-an-absolute-root\n";
+    });
+
+    withWorktreePathRenderScope(() => {
+      expect(probeGitTopLevel(repo).status).toBe("probe_failed");
+      expect(probeGitTopLevel(repo).status).toBe("probe_failed");
+    });
+
+    expect(probeCalls).toBe(1);
+    expect(probeGitTopLevel(repo).status).toBe("probe_failed");
+    expect(probeCalls).toBe(2);
+  });
+
+  it("memoizes project identifiers by canonical root within a render scope", () => {
+    const repo = join(tempDir, "repo");
+    const alias = join(tempDir, "repo-link");
+    initRepo(repo);
+
+    try {
+      symlinkSync(repo, alias, "dir");
+    } catch {
+      return;
+    }
+
+    const remoteCalls = () =>
+      mockedExecFileSync.mock.calls.filter(
+        ([command, args]) =>
+          command === "git" &&
+          Array.isArray(args) &&
+          args[0] === "remote" &&
+          args[1] === "get-url",
+      ).length;
+    const commonDirCalls = () =>
+      mockedExecFileSync.mock.calls.filter(
+        ([command, args]) =>
+          command === "git" &&
+          Array.isArray(args) &&
+          args[0] === "rev-parse" &&
+          args.includes("--git-common-dir"),
+      ).length;
+
+    withWorktreePathRenderScope(() => {
+      expect(getProjectIdentifier(repo)).toBe(getProjectIdentifier(alias));
+    });
+    expect(remoteCalls()).toBe(1);
+    expect(commonDirCalls()).toBe(1);
+  });
+
+  it("re-evaluates project identifiers in a fresh scope after remote metadata changes", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    git(repo, ["remote", "add", "origin", "https://example.test/first.git"]);
+
+    let firstIdentifier: string;
+    withWorktreePathRenderScope(() => {
+      firstIdentifier = getProjectIdentifier(repo);
+    });
+
+    git(repo, ["remote", "set-url", "origin", "https://example.test/second.git"]);
+
+    let secondIdentifier: string;
+    withWorktreePathRenderScope(() => {
+      secondIdentifier = getProjectIdentifier(repo);
+    });
+
+    expect(secondIdentifier!).not.toBe(firstIdentifier!);
+  });
+
+  it("keeps concurrent render scopes isolated", async () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    let probeCalls = 0;
+    setGitShowToplevelProbeForTests(() => {
+      probeCalls++;
+      return `${repo}\n`;
+    });
+
+    await Promise.all([
+      withWorktreePathRenderScope(async () => {
+        expect(probeGitTopLevel(repo).status).toBe("ok");
+        await Promise.resolve();
+        expect(probeGitTopLevel(repo).status).toBe("ok");
+      }),
+      withWorktreePathRenderScope(async () => {
+        expect(probeGitTopLevel(repo).status).toBe("ok");
+        await Promise.resolve();
+        expect(probeGitTopLevel(repo).status).toBe("ok");
+      }),
+    ]);
+
+    expect(probeCalls).toBe(2);
+  });
+
+  it("re-evaluates probes in a fresh scope after the environment changes", () => {
+    const repo = join(tempDir, "repo");
+    initRepo(repo);
+    let probeCalls = 0;
+    setGitShowToplevelProbeForTests(() => {
+      probeCalls++;
+      return `${repo}\n`;
+    });
+
+    withWorktreePathRenderScope(() => {
+      expect(probeGitTopLevel(repo).status).toBe("ok");
+      expect(probeGitTopLevel(repo).status).toBe("ok");
+    });
+
+    const previousPath = process.env.PATH;
+    try {
+      process.env.PATH = `${previousPath ?? ""}${process.platform === "win32" ? ";" : ":"}${tempDir}`;
+      withWorktreePathRenderScope(() => {
+        expect(probeGitTopLevel(repo).status).toBe("ok");
+        expect(probeGitTopLevel(repo).status).toBe("ok");
+      });
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+
+    expect(probeCalls).toBe(2);
   });
 
   it("fails closed when the validator sees a transient git probe failure", () => {

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -10,6 +10,7 @@
  */
 
 import { createHash } from 'crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { execFileSync } from 'child_process';
 import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readSync, realpathSync, readdirSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { homedir, tmpdir } from 'os';
@@ -374,6 +375,28 @@ type GitTopLevelProbe =
   | { status: 'git_missing' }
   | { status: 'probe_failed'; detail: string };
 
+interface WorktreePathRenderScope {
+  gitTopLevelProbes: Map<string, GitTopLevelProbe>;
+  projectIdentifiers: Map<string, string>;
+}
+
+const worktreePathRenderScope = new AsyncLocalStorage<WorktreePathRenderScope>();
+
+/**
+ * Run path lookups in an isolated render scope.
+ *
+ * The memo is intentionally opt-in and is discarded when the render settles.
+ * Direct callers that enforce security boundaries continue to receive fresh
+ * probes, while each HUD render gets a new scope that observes PATH and .git
+ * metadata changes made between renders.
+ */
+export function withWorktreePathRenderScope<T>(fn: () => T): T {
+  return worktreePathRenderScope.run(
+    { gitTopLevelProbes: new Map(), projectIdentifiers: new Map() },
+    fn,
+  );
+}
+
 /**
  * Injectable `git rev-parse --show-toplevel` runner for tests (#3858).
  * Throw to simulate spawn/exit failures; return stdout to simulate success.
@@ -603,13 +626,26 @@ function runGitShowToplevel(cwd: string): string {
 }
 
 export function probeGitTopLevel(cwd: string): GitTopLevelProbe {
-  // Never cache security decisions: PATH, the git executable, and .git
-  // metadata can change between calls in the same process.
-  try {
-    return classifyGitShowToplevelStdout(runGitShowToplevel(cwd), cwd);
-  } catch (error) {
-    return classifyGitShowToplevelError(error);
+  const scope = worktreePathRenderScope.getStore();
+  const scopeKey = scope ? canonicalizeExistingPath(cwd) ?? resolve(cwd) : null;
+  if (scope && scopeKey) {
+    const cached = scope.gitTopLevelProbes.get(scopeKey);
+    if (cached) return cached;
   }
+
+  // Outside an explicit render scope, never cache security decisions: PATH,
+  // the git executable, and .git metadata can change between calls in the same
+  // process. A HUD render scope is intentionally limited to one invocation.
+  let result: GitTopLevelProbe;
+  try {
+    result = classifyGitShowToplevelStdout(runGitShowToplevel(cwd), cwd);
+  } catch (error) {
+    result = classifyGitShowToplevelError(error);
+  }
+  if (scope && scopeKey) {
+    scope.gitTopLevelProbes.set(scopeKey, result);
+  }
+  return result;
 }
 
 function gitMetadataFileSignature(path: string): string {
@@ -1074,6 +1110,12 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
   // submodule still resolves the submodule's own identity, and findWorkspaceRoot
   // below sees the unclimbed root so an inner `.omc-workspace` marker is honored.
   const root = worktreeRoot || getGitTopLevel() || process.cwd();
+  const scope = worktreePathRenderScope.getStore();
+  const scopeKey = scope ? canonicalizeExistingPath(root) ?? resolve(root) : null;
+  if (scope && scopeKey) {
+    const cached = scope.projectIdentifiers.get(scopeKey);
+    if (cached !== undefined) return cached;
+  }
 
   // Workspace marker can supply a stable, user-controlled identifier.
   // This wins over git remote so multi-repo workspaces have one consistent ID.
@@ -1083,13 +1125,17 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
     if (cfg.id && typeof cfg.id === 'string' && cfg.id.trim()) {
       const safeId = cfg.id.trim().replace(/[^a-zA-Z0-9_-]/g, '_');
       const hash = createHash('sha256').update(safeId).digest('hex').slice(0, 16);
-      return `${safeId}-${hash}`;
+      const identifier = `${safeId}-${hash}`;
+      if (scope && scopeKey) scope.projectIdentifiers.set(scopeKey, identifier);
+      return identifier;
     }
     // No explicit id — derive a stable identifier from the workspace path so
     // sibling subrepos inside the same workspace share one ID.
     const hash = createHash('sha256').update(workspaceRoot).digest('hex').slice(0, 16);
     const dirName = basename(workspaceRoot).replace(/[^a-zA-Z0-9_-]/g, '_');
-    return `${dirName}-${hash}`;
+    const identifier = `${dirName}-${hash}`;
+    if (scope && scopeKey) scope.projectIdentifiers.set(scopeKey, identifier);
+    return identifier;
   }
 
   let remoteUrl = '';
@@ -1140,7 +1186,9 @@ export function getProjectIdentifier(worktreeRoot?: string): string {
   const source = remoteUrl || primaryRoot;
   const hash = createHash('sha256').update(source).digest('hex').slice(0, 16);
   const dirName = basename(primaryRoot).replace(/[^a-zA-Z0-9_-]/g, '_');
-  return `${dirName}-${hash}`;
+  const identifier = `${dirName}-${hash}`;
+  if (scope && scopeKey) scope.projectIdentifiers.set(scopeKey, identifier);
+  return identifier;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #3959 by giving each HUD `main()` invocation an isolated worktree-path render scope. Repeated canonical git probes and project-identifier lookups now reuse results only for that render; direct security-sensitive callers remain uncached outside an explicit scope.

## What changed

- Added an opt-in `AsyncLocalStorage` scope in `src/lib/worktree-paths.ts`.
- Canonicalized scope keys with `realpath` and resolved-path fallback.
- Memoized positive, negative, and failed `probeGitTopLevel()` results only inside the active render scope.
- Memoized `getProjectIdentifier()` by canonical root only inside the active render scope.
- Wrapped the exported HUD `main()` entry point in a fresh scope for every render, including watch-mode calls.
- Added regression coverage for canonical aliases, negative results, direct uncached probes, fresh-scope re-evaluation after environment and Git remote changes, and concurrent scope isolation.
- Updated the two HUD test module mocks and refreshed `inventory/inventory-graph.json`.

## Reproduction evidence

The reporter's `execFileSync` preload instrumentation was reproduced with a plain temporary repository (`git init`, one `origin` remote, no submodules, no linked worktrees), a local HUD configuration enabling the three git elements, and five runs per side. The baseline was executed from exact `origin/dev` `47b1e5f968710b07dc3922cac9a565657126e198`; the after measurement used this PR head.

| Build | Git spawns (each run) | Median render wall | Median git time | Median git share |
| --- | ---: | ---: | ---: | ---: |
| exact dev base `47b1e5f968710b07dc3922cac9a565657126e198` | 46 | 709.68 ms | 223.51 ms | 31.5% |
| PR head `73242b09b6015690d03d4c0b87bcea43067beab4` | 10 | 542.86 ms | 63.47 ms | 11.7% |

Before/after repeated command counts in the same fixture:

- `rev-parse --show-toplevel`: 14 → 2
- `remote get-url origin`: 14 → 2 (one state identity lookup and one visible git element)
- `rev-parse --path-format=absolute --git-common-dir`: 13 → 1
- The visible git element probes remain one each for branch, worktree git-dir/common-dir, and status; the multi-repo check remains one.

The absolute counts differ from the report's 44 because this focused Linux/Node 25 fixture exercises the current branch's exact configuration and current source path, but the repeated state-resolution commands collapse as expected.

## Correctness boundaries

- No process-wide TTL or stale global probe cache was added.
- A new HUD render gets a new memo, so PATH and `.git` metadata changes between renders/processes are observed.
- Direct `probeGitTopLevel()` calls remain fresh and fail-closed when no render scope is active.
- Canonical keys share symlink aliases while keeping distinct linked worktree roots distinct.
- Existing metadata-validated positive caches and submodule/worktree identity rules are unchanged.
- Windows-native path handling is preserved through Node's `realpath`/`resolve` behavior and the existing Windows test suites.

## Verification

- `npx vitest run src/lib/__tests__/worktree-paths-toplevel-cache.test.ts` — 24 passed
- Relevant worktree/state suites — 235 passed
- HUD suites covering `main()`/watch mode/state/git rendering — 81 passed
- `npx eslint` on changed TypeScript files — 0 errors
- `npm run lint --if-present` — 0 errors (existing warnings only)
- `npx tsc --noEmit --pretty false` — passed
- `npm run generate:inventory:verify` — passed
- `npm run plugin:shipping:verify` — passed
- `npm run verify:skill-entitlements` — passed

The full local non-performance suite was also exercised after a native `npm ci`; its remaining failures are unrelated pre-existing benchmark/context/session-end/environment contracts, while all targeted HUD/worktree suites pass.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*