### PR TITLE
fix(hooks): preserve stderr after early protocol stdout close (#3963)

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "ec4b5790cc9d72841bd59c507a21f69226b0d024",
-    "sourceSha256": "00a5796b53cc050b0843a44c6d673151f3c2d3da17d04cdb9fa362e4edd0da56",
+    "head": "7644c857048327f8d370aaa97caddf586ea13dbe",
+    "sourceSha256": "dc0a267711786dbce71fcbba68d4b598f1d45f8e8d6657d886fab11a136a1be1",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "ec4b5790cc9d72841bd59c507a21f69226b0d024",
-  "sourceSha256": "00a5796b53cc050b0843a44c6d673151f3c2d3da17d04cdb9fa362e4edd0da56",
+  "head": "7644c857048327f8d370aaa97caddf586ea13dbe",
+  "sourceSha256": "dc0a267711786dbce71fcbba68d4b598f1d45f8e8d6657d886fab11a136a1be1",
   "counts": {
     "public": {
       "skills": 35,
@@ -77306,5 +77306,5 @@
     }
   },
   "inventorySha256": "48902e0c27f95a38180e82912e230183cb1cacfa1231dbdd635f91b772bafea2",
-  "manifestSha256": "8f006d1bcf77821df98a0a15d169a2c8ac5f3fda9061c448786195e00aa931d5"
+  "manifestSha256": "67608092a6e6843ffab24a72aa3b69071d78f1a41da68d9f1fe42e5b09e6ecfb"
 }

--- a/scripts/run.cjs
+++ b/scripts/run.cjs
@@ -411,6 +411,7 @@ function createProtocolSink(hooks = {}) {
   const discarded = { stdout: false, stderr: false };
   const closedDest = { stdout: false, stderr: false };
   const bindings = { stdout: [], stderr: [] };
+  const discardedSources = { stdout: [], stderr: [] };
   let installed = false;
   let pendingWrites = 0;
   let uninstallRequested = false;
@@ -433,10 +434,38 @@ function createProtocolSink(hooks = {}) {
     }
   }
 
+  function discardChannel(name) {
+    discarded[name] = true;
+    const snapshot = bindings[name];
+    bindings[name] = [];
+    for (const binding of snapshot) {
+      try { binding.source.unpipe(binding.tap); } catch { /* already unpiped */ }
+      try { binding.tap.unpipe(binding.writer); } catch { /* already unpiped */ }
+      try { binding.tap.destroy(); } catch { /* already destroyed */ }
+      try { binding.writer.destroy(); } catch { /* already destroyed */ }
+      discardedSources[name].push(binding.source);
+      try { binding.source.resume(); } catch { /* already flowing or destroyed */ }
+    }
+  }
+
+  function destroyDiscardedSources() {
+    for (const name of ['stdout', 'stderr']) {
+      const sources = discardedSources[name];
+      discardedSources[name] = [];
+      for (const source of sources) {
+        try { source.destroy(); } catch { /* already destroyed */ }
+      }
+    }
+  }
+
   function handleDestError(name, dest, error) {
     if (discarded[name]) return;
     if (isClosedDestinationError(error)) closedDest[name] = true;
-    teardownChannel(name);
+    // Close only the failed protocol channel first. Keep its child pipe
+    // draining while the sibling channel remains available; reaping here can
+    // race sibling bytes that the hook has not written yet.
+    discardChannel(name);
+    if (typeof hooks.onDestinationClose === 'function') hooks.onDestinationClose(name);
     if (!isClosedDestinationError(error) && name === 'stdout') {
       void write(process.stderr, Buffer.from(`[run.cjs] protocol stream error: ${error.code || error.message}\n`));
     }
@@ -467,6 +496,7 @@ function createProtocolSink(hooks = {}) {
   function abandonOutputs() {
     teardownChannel('stdout');
     teardownChannel('stderr');
+    destroyDiscardedSources();
   }
 
   function closeDestinations() {
@@ -572,7 +602,7 @@ function createProtocolSink(hooks = {}) {
     bind(child.stderr, process.stderr, 'stderr');
   }
 
-  function settleOutputs(timeoutMs, idleMs = PROTOCOL_SOURCE_IDLE_MS) {
+  function settleOutputs(timeoutMs, idleMs = PROTOCOL_SOURCE_IDLE_MS, reapIdleSources = true) {
     const active = [...bindings.stdout, ...bindings.stderr];
     if (active.length === 0) return Promise.resolve(true);
     const deadline = Date.now() + Math.max(1, timeoutMs);
@@ -594,6 +624,7 @@ function createProtocolSink(hooks = {}) {
           finish(true);
           return;
         }
+        if (!reapIdleSources) return;
         const now = Date.now();
         for (const binding of active) {
           if (binding.completed || binding.writer.destroyed) continue;
@@ -694,8 +725,14 @@ function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
     reaped = true;
     reapTree(child, childIdentity);
   };
+  let destinationClosed = false;
+  let startClosedDestinationCleanup = () => {};
   const sink = createProtocolSink({
     beforeSourceDestroy: reapOnce,
+    onDestinationClose: () => {
+      destinationClosed = true;
+      startClosedDestinationCleanup();
+    },
   });
   sink.install();
   return new Promise(resolve => {
@@ -703,9 +740,46 @@ function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
     let terminal = false;
     let settling = false;
     let timer;
+    let closeCleanupStarted = false;
+    let closeCleanupTimer;
+    const closeGraceMs = Math.min(timeoutMs, WINDOWS_GENERIC_STARTUP_MS + PROTOCOL_STDIO_SETTLE_MS);
+    let detachHandlers = () => {};
     const finish = (status) => {
+      if (closeCleanupTimer) {
+        clearTimeout(closeCleanupTimer);
+        closeCleanupTimer = undefined;
+      }
       sink.uninstall();
       resolve(status);
+    };
+    const finishClosedDestination = () => {
+      if (terminal) return;
+      terminal = true;
+      settling = false;
+      if (closeCleanupTimer) {
+        clearTimeout(closeCleanupTimer);
+        closeCleanupTimer = undefined;
+      }
+      detachHandlers();
+      reapOnce();
+      sink.abandonOutputs();
+      detachProtocolStdio(child);
+      releaseGenericChild(child);
+      finish(0);
+    };
+    startClosedDestinationCleanup = () => {
+      if (closeCleanupStarted || terminal) return;
+      closeCleanupStarted = true;
+      closeCleanupTimer = setTimeout(finishClosedDestination, closeGraceMs);
+      if (settling) return;
+      settling = true;
+      // Do not apply the leaked-descendant idle heuristic while the leader may
+      // still be cold-starting. The close timer provides the bounded fallback;
+      // normal post-exit settling retains the 80ms orphan detection.
+      void sink.settleOutputs(closeGraceMs, PROTOCOL_SOURCE_IDLE_MS, false).then(() => {
+        settling = false;
+        finishClosedDestination();
+      });
     };
     child = spawn(process.execPath, resolveGenericChildCommand(targetPath, extraArgs), {
       stdio: resolveGenericChildStdio(),
@@ -723,7 +797,7 @@ function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
     // runner is terminated or cancelled BEFORE the inner timer fires (outer
     // hooks.json timeout, Ctrl-C, parent kill), reap the tree so the detached
     // hook cannot be orphaned — the exact failure class #3493 must not leave open.
-    const detachHandlers = () => {
+    detachHandlers = () => {
       clearTimeout(timer);
       for (const signal of RUNNER_TERMINATION_SIGNALS) process.off(signal, onRunnerSignal);
       process.off('exit', onRunnerExit);
@@ -766,7 +840,7 @@ function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
 
     child.once('exit', (code) => {
       if (terminal) return;
-      terminal = true;
+      if (destinationClosed) return;
       settling = true;
       clearTimeout(timer);
       // Drain then close even on a clean hook exit. A detached descendant that
@@ -776,7 +850,13 @@ function runGenericChild(targetPath, extraArgs, timeoutMs, manifestHook) {
       const remainingProtocolMs = Math.max(1, protocolDeadline - Date.now());
       void sink.settleOutputs(remainingProtocolMs).then((complete) => {
         settling = false;
+        if (terminal) return;
+        if (destinationClosed) {
+          finishClosedDestination();
+          return;
+        }
         detachHandlers();
+        reapOnce();
         if (!complete && require.main === module) {
           sink.closeDestinations();
           releaseGenericChild(child);

--- a/src/__tests__/run-cjs-windows-stdio-contract.test.ts
+++ b/src/__tests__/run-cjs-windows-stdio-contract.test.ts
@@ -442,20 +442,37 @@ describe('run.cjs Windows/protocol stdio contract (#3920)', () => {
 
   it('fail-opens when the protocol stdout consumer closes early', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'omc-stdio-closed-out-'));
+    let runner: ReturnType<typeof spawn> | undefined;
     try {
+      const readyFile = join(directory, 'hook-ready');
+      const goFile = join(directory, 'hook-go');
       const fixture = join(directory, 'write-hook.cjs');
-      writeFileSync(fixture, 'process.stdout.write("OUT-BYTES"); process.stderr.write("ERR-BYTES");');
-      const runner = spawn(process.execPath, [RUN_CJS_PATH, fixture], {
+      writeFileSync(fixture, `
+const { existsSync, writeFileSync } = require('node:fs');
+writeFileSync(process.env.OMC_READY_FILE, 'ready');
+const writeOutput = () => {
+  if (!existsSync(process.env.OMC_GO_FILE)) return setTimeout(writeOutput, 1);
+  process.stdout.write('OUT-BYTES');
+  const pause = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(pause, 0, 0, 25);
+  process.stderr.write('ERR-BYTES');
+};
+writeOutput();
+`);
+      const child = runner = spawn(process.execPath, [RUN_CJS_PATH, fixture], {
         stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, OMC_READY_FILE: readyFile, OMC_GO_FILE: goFile },
         windowsHide: true,
       });
       let stderr = '';
-      runner.stderr.setEncoding('utf8');
-      runner.stderr.on('data', chunk => { stderr += chunk; });
-      runner.stdout.destroy();
+      child.stderr!.setEncoding('utf8');
+      child.stderr!.on('data', chunk => { stderr += chunk; });
+      await waitForFile(readyFile);
+      child.stdout!.destroy();
+      writeFileSync(goFile, 'go');
       const code = await new Promise<number | null>((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error('runner hung after stdout consumer close')), 5000);
-        runner.once('exit', status => {
+        child.once('exit', status => {
           clearTimeout(timer);
           resolve(status);
         });
@@ -464,6 +481,7 @@ describe('run.cjs Windows/protocol stdio contract (#3920)', () => {
       expect(stderr).toContain('ERR-BYTES');
       expect(stderr).not.toMatch(/EPIPE/);
     } finally {
+      try { runner?.kill('SIGKILL'); } catch { /* already gone */ }
       rmSync(directory, { recursive: true, force: true });
     }
   });
@@ -495,6 +513,50 @@ describe('run.cjs Windows/protocol stdio contract (#3920)', () => {
       rmSync(directory, { recursive: true, force: true });
     }
   });
+
+  it('bounds cleanup when a hook survives the closed stdout channel', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'omc-stdio-closed-out-survivor-'));
+    let runner: ReturnType<typeof spawn> | undefined;
+    try {
+      const readyFile = join(directory, 'hook-ready');
+      const goFile = join(directory, 'hook-go');
+      const pluginRoot = join(directory, 'plugin');
+      const target = writePluginHook(pluginRoot, 'surviving-hook.cjs', `
+const { existsSync, writeFileSync } = require('node:fs');
+process.stdout.on('error', () => {});
+writeFileSync(process.env.OMC_READY_FILE, 'ready');
+const start = () => {
+  if (!existsSync(process.env.OMC_GO_FILE)) return setTimeout(start, 1);
+  process.stdout.write('OUT-BYTES');
+  setInterval(() => {}, 1e9);
+};
+start();
+`, 5);
+      const startedAt = Date.now();
+      const child = runner = spawn(process.execPath, [RUN_CJS_PATH, target], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, CLAUDE_PLUGIN_ROOT: pluginRoot, OMC_READY_FILE: readyFile, OMC_GO_FILE: goFile },
+        windowsHide: true,
+      });
+      child.stderr!.resume();
+      await waitForFile(readyFile);
+      child.stdout!.destroy();
+      writeFileSync(goFile, 'go');
+      const code = await new Promise<number | null>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('runner waited for the inner timeout after stdout close')), 1500);
+        child.once('exit', status => {
+          clearTimeout(timer);
+          resolve(status);
+        });
+      });
+      expect(code).toBe(0);
+      expect(Date.now() - startedAt).toBeLessThan(1500);
+    } finally {
+      try { runner?.kill('SIGKILL'); } catch { /* already gone */ }
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('fail-opens a drain-aware noisy stdout hook when the consumer closes early', async () => {
     const directory = mkdtempSync(join(tmpdir(), 'omc-stdio-drain-out-'));
     try {


### PR DESCRIPTION
## Summary

Fix the generic `run.cjs` protocol-close race from #3963. A closed stdout destination now discards and drains only that channel, leaves the child alive long enough for the open stderr channel to flush, and then performs bounded tree cleanup before resolving fail-open.

The focused regression now synchronizes hook startup, closes stdout before the hook writes, delays the stderr marker, and asserts exit `0`, visible `ERR-BYTES`, and no `EPIPE`. A survivor case covers bounded cleanup without waiting for the generic inner timeout.

## Exact-head evidence

- Base: `origin/dev` / `7644c857048327f8d370aaa97caddf586ea13dbe`
- Candidate: `b78b7febe6c0b15b754f15cb9961f724e6bb180c`
- Reproduction: protocol stdout consumer closes; the prior `beforeSourceDestroy` reap killed the generic child before sibling stderr was observable. A 500-run pre-fix stress reproduced 5 missing stderr payloads; the patched stress reproduced 0.
- Scope: `scripts/run.cjs`, `src/__tests__/run-cjs-windows-stdio-contract.test.ts`, and the required inventory baseline only. #3947 SessionEnd code is unchanged.

## Verification

- Focused target repetition: 20/20 passed.
- Direct delayed-sibling stress: 100/100 passed, with 0 missing payloads, 0 nonzero exits, and no hangs.
- Full `run-cjs-windows-stdio-contract.test.ts`: 26/26 passed.
- Relevant concurrent runner shard: 91/91 passed.
- `npx tsc --noEmit`: passed.
- `npm run lint`: passed with the repository's existing 30 warnings and 0 errors.
- `node scripts/generate-inventory-graph.mjs --verify`: passed.
- One full functional suite: 13,749 passed, 16 skipped, 23 unrelated local environment/contention failures; the target stdio contract remained green. Failures were in Python sandbox timeouts, SessionEnd state timing, inventory provenance after generated test activity, tmux-unavailable cleanup, benchmark fixtures, and other pre-existing shared-state tests.

Fixes #3963

—  
*[repo owner's gaebal-gajae (clawdbot) 🦞]*