### PR TITLE
feat(skills): add loft — shipyard shape-before-steel discipline (opt-in, model-invoked)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "omc",
-  "description": "Claude Code native multi-agent orchestration - intelligent model routing, 28 agents, 33 skills",
+  "description": "Claude Code native multi-agent orchestration - intelligent model routing across agents and skills",
   "owner": {
     "name": "Yeachan Heo",
     "email": "hurrc04@gmail.com"
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "oh-my-claudecode",
-      "description": "Claude Code native multi-agent orchestration with intelligent model routing, 28 agent variants, and 33 powerful skills. Zero learning curve. Maximum power.",
+      "description": "Claude Code native multi-agent orchestration with intelligent model routing across agents and skills. Zero learning curve. Maximum power.",
       "version": "5.0.0",
       "author": {
         "name": "Yeachan Heo",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -32,6 +32,7 @@
     "./skills/graph/",
     "./skills/hud/",
     "./skills/launch/",
+    "./skills/loft/",
     "./skills/minimal-code-discipline/",
     "./skills/omc-doctor/",
     "./skills/omc-setup/",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,7 @@ Workflow Skills:
 - `minimal-code-discipline`: YAGNI-ladder writing-time discipline — existence-first, reuse before writing, shortest correct diff, with non-negotiables that are never minimized away
 - `launch`: Shipyard governed delivery pipeline — spec synthesis, vertical-slice tickets with blocking edges, frontier execution with human checkpoints; opt-in
 - `ask-navigator`: Shipyard navigator — charts foggy efforts into decision-ticket maps on the issue tracker, one ticket per session, then hands a mission brief to launch; opt-in
+- `loft`: Shipyard shape-before-steel discipline — answers a design question prose cannot settle with a throwaway artifact (pure logic module or structurally different UI variants); model-invoked; opt-in
 - `drydock`: Shipyard harness scaffold — 4-pillar shared environment (Context/Rules/Tools/Standards) across 5 surfaces, with --check drift audit; opt-in
 
 Agent Shortcuts:

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -14,7 +14,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated-opt-in-only)
 - [Agents (29 Total)](#agents-29-total)
 - [Goal Workflow UX: `/goal`, Ralph, Team, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultragoal)
-- [Skills (36 Total)](#skills-36-total)
+- [Skills (37 Total)](#skills-37-total)
 - [Slash Commands](#slash-commands)
 - [Shipyard Methodology](./shipyard.md) — governed delivery & shared harness map
 - [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
@@ -881,7 +881,7 @@ Autopilot continues to own cancel, resume, cleanup, state inspection, HUD, and S
 
 V1 deliberately defers `stageModels` and all model/provider/role routing, inline/no-spawn execution, dynamic commands/modes/state files, arbitrary stages/prompts/plugins and control-flow extensions, and the separate custom-skill inline-array frontmatter parser mismatch. See [ADR 03487](./adr/03487-named-autopilot-stage-profiles.md) for the decision record.
 
-## Skills (36 Total)
+## Skills (37 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
@@ -907,6 +907,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `external-context`        | Parallel document-specialist research                                          | `/oh-my-claudecode:external-context`       |
 | `hud`                     | Configure HUD/statusline                                                        | `/oh-my-claudecode:hud`                     |
 | `launch`                  | Shipyard governed delivery pipeline: spec, tickets, frontier execution          | `/oh-my-claudecode:launch`                  |
+| `loft`                    | Shipyard shape-before-steel discipline: throwaway artifacts answer design questions | `/oh-my-claudecode:loft`              |
 | `minimal-code-discipline` | YAGNI-ladder writing-time discipline: reuse first, shortest correct diff        | `/oh-my-claudecode:minimal-code-discipline` |
 | `omc-doctor`              | Diagnose and fix installation issues                                           | `/oh-my-claudecode:omc-doctor`              |
 | `omc-plan`                | Strategic planning with optional interview and consensus modes                 | `/oh-my-claudecode:omc-plan`               |
@@ -955,6 +956,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:hud [setup\|minimal\|focused\|full\|status]` | Configure HUD/statusline                                                               |
 | `/oh-my-claudecode:drydock [--check]`                   | Lay the shipyard harness keel in a repo (5 surfaces); --check audits drift                     |
 | `/oh-my-claudecode:launch <brief\|spec-path> [--serial]` | Run the shipyard governed delivery pipeline (spec -> tickets -> frontier)                      |
+| `/oh-my-claudecode:loft <design-question>`               | Loft the shape before cutting steel: a throwaway artifact answers a design question prose cannot settle |
 | `/oh-my-claudecode:minimal-code-discipline`              | Apply the YAGNI-ladder writing-time discipline while implementing                              |
 | `/oh-my-claudecode:omc-doctor`                           | Diagnose and fix installation issues                                                          |
 | `/oh-my-claudecode:omc-plan <description>`               | Start planning session (supports consensus structured deliberation)                           |

--- a/docs/shipyard.md
+++ b/docs/shipyard.md
@@ -4,13 +4,13 @@ Shipyard is the delivery methodology behind four opt-in skills: `drydock`, `ask-
 
 > **Everyone ships, and nobody ships randomly** — agents continuously run everything repeatable and acceptable-by-evidence; humans decide what cannot be judged by the system or what fails expensively.
 
-This page is the map of the methodology: the boundary principle, the roles, the four pillars, the surface layout, the working metaphor, and how the four skills compose. The skills themselves (`/oh-my-claudecode:drydock`, `/oh-my-claudecode:ask-navigator`, `/oh-my-claudecode:launch`, `/oh-my-claudecode:minimal-code-discipline`) are the executable form. For the visual quick-start with emoji and mermaid diagrams, see [shipyard-guide.md](./shipyard-guide.md).
+This page is the map of the methodology: the boundary principle, the roles, the four pillars, the surface layout, the working metaphor, and how the five skills compose. The skills themselves (`/oh-my-claudecode:drydock`, `/oh-my-claudecode:ask-navigator`, `/oh-my-claudecode:loft`, `/oh-my-claudecode:launch`, `/oh-my-claudecode:minimal-code-discipline`) are the executable form.
 
 ## The verifiability boundary
 
 Every step in a launch run answers one test question: *if this is done wrong, can the system detect it? Can it redo or roll back automatically?*
 
-- **Both yes → agents run it continuously** (the repeatable ~80%): fact-finding, spec/ticket drafting, tdd implementation, builds, tests, code-review, verify, scheduling.
+- **Both yes → agents run it continuously** (the repeatable ~80%): fact-finding, spec/ticket drafting, lofting design questions, tdd implementation, builds, tests, code-review, verify, scheduling.
 - **Either no → the human decides it** (the critical ~20%): acceptance criteria, seam selection, ticket granularity, irreversible architecture decisions, final acceptance.
 
 It is not "let agents do as much as possible" — it is "delegate exactly what can be accepted, nothing more."
@@ -50,15 +50,17 @@ A repo that humans and agents both build on carries four pillars across five con
 | The keel | Shared context + rules surfaces | Lay the skeleton first; the hull grows upward |
 | The fog | An effort whose destination isn't stateable yet | Nobody ships randomly — and nobody ships into fog without a chart |
 | The navigator | `/oh-my-claudecode:ask-navigator` | Charts the fog as a map of decision tickets; hands off, never builds |
+| The loft | `/oh-my-claudecode:loft` | Cut no steel until the shape is fair: a throwaway artifact answers a design question before real work begins |
 | The classification society | `docs/standards/` + `design-system/` | A ship must pass class to sail = changes must pass standards to merge |
 | The charts | specs + tickets | Launch's output; build from the chart |
 | The logbook | `docs/adr/` | Decisions, auditable after the fact |
 | The launch | `/oh-my-claudecode:launch` | Everyone may launch — and not one class check may be skipped |
 
-## The four skills compose
+## The five skills compose
 
 - **`drydock`** lays the keel once per repo (surfaces + seeds + `--check` drift audit). The `--check` report states per-finding confidence and whether the finding is actionable after excluding a user-declared scratch/throwaway scope; today it has no executable or machine-readable severity contract (planned follow-up).
 - **`ask-navigator`** charts foggy efforts (destination unclear → a map of decision tickets on the tracker, worked one ticket per session) and hands the collapsed decisions to launch as a mission brief. Resolutions sediment into the same paper-trail slots launch's Phase 1 uses. It produces decisions, never deliverables.
+- **`loft`** answers a design question that prose cannot settle with a throwaway artifact — a pure logic module in a clickable shell, or structurally different UI variants behind one route. The captain reacts; the answer lands in the decision; the artifact never docks. Called by launch's Phase 1 detour and the navigator's `loft` tickets.
 - **`launch`** runs delivery per feature (fog gate → yard gate → C1 brief → C2 spec+seams → C3 tickets → frontier execution with C4 decision stops → C5 closeout with a `--check` re-audit), with the human at exactly the checkpoints that fail expensively. The fog gate routes an effort whose destination cannot be stated to the navigator before the run starts. The yard gate blocks on high-confidence actionable drydock findings (listing them verbatim and producing no artifacts) and admits only a clean audit or a narrowly, explicitly overridden low-confidence / false-positive / scratch-scope finding — no general bypass.
 - **`minimal-code-discipline`** is an opt-in discipline for code written inside tickets (YAGNI ladder, smallest correct diff).
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,22 +5,22 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "4133dc57a3e15fa60c8d7852ff7b210e2a7d30d5",
-    "sourceSha256": "37d26bfd306962f267053d0ddca74eb9912bf0e132a9217dcff1bc182d72676a",
+    "head": "4e8d9ccd027718bb87b021f232930c09dc07d86f",
+    "sourceSha256": "6047b5d6d4fc95bf3324ed9d37f6c41811ea59a0861ce319aacf56c881efd4bc",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "4133dc57a3e15fa60c8d7852ff7b210e2a7d30d5",
-  "sourceSha256": "37d26bfd306962f267053d0ddca74eb9912bf0e132a9217dcff1bc182d72676a",
+  "head": "4e8d9ccd027718bb87b021f232930c09dc07d86f",
+  "sourceSha256": "6047b5d6d4fc95bf3324ed9d37f6c41811ea59a0861ce319aacf56c881efd4bc",
   "counts": {
     "public": {
-      "skills": 36,
+      "skills": 37,
       "commands": 21,
       "workflows": 8,
       "agents": 20,
-      "total": 85
+      "total": 86
     },
     "internal": {
       "hookFiles": 295,
@@ -39,7 +39,7 @@
     "prompt": {
       "promptLikeFiles": 62
     },
-    "skills": 36,
+    "skills": 37,
     "commands": 21,
     "hookFiles": 295,
     "workflows": 8,
@@ -64,6 +64,7 @@
       "graph",
       "hud",
       "launch",
+      "loft",
       "minimal-code-discipline",
       "omc-doctor",
       "omc-setup",
@@ -33372,6 +33373,11 @@
         "path": "skills/launch/SKILL.md"
       },
       {
+        "id": "skills/loft/SKILL.md",
+        "kind": "skill",
+        "path": "skills/loft/SKILL.md"
+      },
+      {
         "id": "skills/minimal-code-discipline/SKILL.md",
         "kind": "skill",
         "path": "skills/minimal-code-discipline/SKILL.md"
@@ -42910,6 +42916,11 @@
       },
       {
         "from": "skills/launch/SKILL.md",
+        "to": "src/features/builtin-skills/skills.ts",
+        "kind": "registers"
+      },
+      {
+        "from": "skills/loft/SKILL.md",
         "to": "src/features/builtin-skills/skills.ts",
         "kind": "registers"
       },
@@ -77310,12 +77321,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6865,
-      "edgeCount": 7338,
+      "nodeCount": 6866,
+      "edgeCount": 7339,
       "importEdgeCount": 6040,
-      "registerEdgeCount": 57
+      "registerEdgeCount": 58
     }
   },
-  "inventorySha256": "26b760d7a326707bbe98818438219e3bfb9e7f93cf587e20066b6adeb0a5d937",
-  "manifestSha256": "2290bdc4cff4b84b83e3a841effe6b96b86a91092514c391159c8a32f4323667"
+  "inventorySha256": "d4529469934f2cbf2fa4897aea788da0e912fad10235f00a88b9afff515417b5",
+  "manifestSha256": "1c994e38c4e90009ed891709b2303f729e3f7384f9d88c98b2528c19a87564a5"
 }

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -3,7 +3,7 @@
 
 # skills
 
-36 skill directories for workflow automation and specialized behaviors.
+37 skill directories for workflow automation and specialized behaviors.
 
 ## Purpose
 
@@ -52,6 +52,7 @@ Skills are reusable workflow templates that can be invoked via `/oh-my-claudecod
 |-----------|-------|---------|
 | `ai-slop-cleaner/SKILL.md` | ai-slop-cleaner | Regression-safe cleanup workflow for AI-generated code slop |
 | `drydock/SKILL.md` | drydock | Shipyard harness scaffold: 4-pillar shared environment across 5 surfaces, with --check drift audit |
+| `loft/SKILL.md` | loft | Shipyard shape-before-steel discipline: throwaway artifacts answer design questions prose cannot settle |
 | `minimal-code-discipline/SKILL.md` | minimal-code-discipline | YAGNI-ladder writing-time discipline: existence-first, reuse before writing, shortest correct diff |
 | `skillify/SKILL.md` | skillify | Extract reusable skill from session |
 | `learner/SKILL.md` | learner | Deprecated compatibility alias/internal implementation history for skillify |

--- a/skills/ask-navigator/SKILL.md
+++ b/skills/ask-navigator/SKILL.md
@@ -30,7 +30,7 @@ The map is an **index, not a store**: a decision lives in exactly one place — 
 
 ## Document language
 
-Map and ticket prose follow the same document-language contract as `/oh-my-claudecode:drydock`: read `documentLanguage` from `CONTEXT.md` frontmatter when present; if the yard is not laid, ask the language question once during charting (W2) and record the resolved tag in the map's Notes so the later launch run inherits it. Paths, labels, slash commands, the `navigator:map` label, ticket-type names (`research`, `prototype`, `grilling`, `task`), `HITL`/`AFK`, and `blockedBy` are stable tokens and stay byte-for-byte stable in every language.
+Map and ticket prose follow the same document-language contract as `/oh-my-claudecode:drydock`: read `documentLanguage` from `CONTEXT.md` frontmatter when present; if the yard is not laid, ask the language question once during charting (W2) and record the resolved tag in the map's Notes so the later launch run inherits it. Paths, labels, slash commands, the `navigator:map` label, ticket-type names (`research`, `loft`, `grilling`, `task`), `HITL`/`AFK`, and `blockedBy` are stable tokens and stay byte-for-byte stable in every language.
 
 ## Chart the map
 
@@ -63,7 +63,7 @@ Every ticket is **HITL** (worked with the captain, who speaks for themselves) or
 | Type | Mode | Resolved by | Use when |
 |---|---|---|---|
 | `research` | AFK | Background subagent: investigate against primary sources (official docs, source code, specs), leave a cited Markdown file at `docs/research/<ticket-slug>.md` (or the repo's existing notes convention when one exists), link it from the ticket | A decision waits on knowledge outside the current working directory |
-| `prototype` | HITL | Throwaway code on a `prototype/<name>` branch: a single shareable HTML file for state/logic questions, or radically different UI variants on one route; the captain reacts to the artifact | "How should it look / behave" is the key question and prose cannot settle it |
+| `loft` | HITL | Call the Skill tool with "loft": a throwaway artifact answers the ticket's question — a pure logic module in a clickable shell, or structurally different UI variants behind one route; the captain reacts, the answer folds into the resolution, the artifact stays on a `loft/<name>` branch | The question is precise but prose cannot settle it — it needs to be seen or clicked, not described |
 | `grilling` | HITL | Call the Skill tool with "deep-interview"; the captain decides each round | Conversation is the resolution — the default case |
 | `task` | HITL or AFK | The navigator drives it alone where it can; otherwise hands the captain a precise checklist | Manual work that unblocks a decision (sign up for a service, provision access, move data so its shape can be seen) — it earns its place by unblocking a decision, not by delivering the destination |
 

--- a/skills/drydock/SKILL.md
+++ b/skills/drydock/SKILL.md
@@ -83,7 +83,7 @@ Ask the remaining questions only after language is resolved:
 
 - package/tech stack (for standards and design-system seeds)
 - does this repo have a UI? (no UI → design-system/ is created as a stub with a note, or skipped on request)
-- issue tracker location (GitHub / GitLab / local `.scratch/`) — recorded for launch/triage flows
+- issue tracker location (GitHub / GitLab / local `.scratch/`) — consumed by tracker-backed flows (the navigator's map home)
 
 ### 3. Scaffold (create missing surfaces — seeds render in the document language)
 

--- a/skills/launch/SKILL.md
+++ b/skills/launch/SKILL.md
@@ -69,6 +69,8 @@ Paper trail, written the moment each item settles:
 
 Non-convergence here is normal work, not a failure: if the frontier will not empty, present the residual questions ranked — this is C2's input, not an error. If the residual questions themselves cannot be stated precisely (fog test Q2 fails), the destination itself is unsettled and that is beyond C2's authority: stop, note what already settled (vocabulary in `CONTEXT.md`, answered questions), recommend `/oh-my-claudecode:ask-navigator`, and exit — the pipeline never invents a destination.
 
+**Loft detour.** A residual question that is precise but cannot settle in prose — it needs to be seen or clicked, not described (how the UI should look, whether a state model feels right) — is answered with an artifact, not more questions: call the Skill tool with "loft", let the captain react, and fold that reaction back into the interview. The lofted artifact is C2's input; the captain signs what they saw, not what they were told.
+
 ## Phase 2 — Spec synthesis (agent drafts → C2 approves)
 
 Synthesize `.omc/specs/<feature-slug>/spec.md`:
@@ -85,7 +87,7 @@ Synthesize `.omc/specs/<feature-slug>/spec.md`:
 
 Draft all of it, then stop at **C2**: present the acceptance criteria and the test seam list for human approval. Seams are selected by repo evidence and the deep-module discipline (public interfaces, existing test seams, depth analysis); the human confirms or corrects the list — a seam the human has not approved gets no tests.
 
-Durability gate (agent-enforced, no approval needed): spec and tickets carry contracts, never coordinates — no file paths, no line numbers. Fragments encoding a decision better than prose (state machines, reducers, schemas) are the exception and state their origin.
+Durability gate (agent-enforced, no approval needed): spec and tickets carry contracts, never coordinates — no file paths, no line numbers. Fragments encoding a decision better than prose (state machines, reducers, schemas) are the exception and state their origin (usually a loft).
 
 ## Phase 3 — Ticket decomposition (agent drafts → C3 approves)
 
@@ -103,7 +105,7 @@ Integration-wiring rule: every vertical slice includes its own wiring and a smok
 
 The frontier is every ticket whose blockers are all complete.
 
-**Parallel (default, 2+ tickets).** Hand tickets to team: each ticket becomes a team task, `blockedBy` edges carry over — team's claim mechanics pick only frontier tasks. Spawn N workers. Each worker implements with the tdd discipline at the seams approved in C2; a ticket closes only after code-review passes on the diff, declared by the reviewer — the implementer never self-approves.
+**Parallel (default, 2+ tickets).** Hand tickets to team: each ticket becomes a team task, `blockedBy` edges carry over — team's claim mechanics pick only frontier tasks. Spawn N workers. Each worker implements with the tdd discipline at the seams approved in C2, applying `/oh-my-claudecode:minimal-code-discipline` as the writing-time discipline (it stays opt-in); a ticket closes only after code-review passes on the diff, declared by the reviewer — the implementer never self-approves.
 
 **Serial (single ticket, or `--serial`).** Delegate one ticket at a time to an executor subagent; same review gate.
 
@@ -120,7 +122,7 @@ On a later explicit Launch invocation, first require the owning Team lifecycle t
 - all tickets terminal with evidence → run verify across the whole change
 - reconcile the paper trail: CONTEXT.md accurate, ADRs complete, spec updated where implementation taught it something
 - yard re-check: re-run the drydock `--check` audit; any new findings since entry are reported as **yard drift**, with a pointer to `/oh-my-claudecode:drydock`
-- **sediment pass — answer: what did this ship teach the yard?** Sweep the source checklist first (three-strike failure root causes, C4 answers, review rejections, verify findings), then answer. Propose every lesson as `lesson → slot → intended change` against the slot table below, or decline it explicitly with a reason; a ship with nothing to teach must say so verbatim as "no new lessons". This requirement blocks non-answers, never empty answers — inventing lessons to have one is the same violation as skipping the question. The lesson list rides in the completion report next to the Open Assumptions, each line individually vetoable; approved lessons are written to their slots only after acceptance, and the report records each landing's file location.
+- **sediment pass — answer: what did this ship teach the yard?** Sweep the source checklist first (three-strike failure root causes, C4 answers, review rejections, verify findings, and any map resolutions or deferred-sediment lines from a source map this run followed), then answer. Propose every lesson as `lesson → slot → intended change` against the slot table below, or decline it explicitly with a reason; a ship with nothing to teach must say so verbatim as "no new lessons". This requirement blocks non-answers, never empty answers — inventing lessons to have one is the same violation as skipping the question. The lesson list rides in the completion report next to the Open Assumptions, each line individually vetoable; approved lessons are written to their slots only after acceptance, and the report records each landing's file location.
 
   | Lesson kind | Slot |
   |---|---|

--- a/skills/loft/SKILL.md
+++ b/skills/loft/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: loft
+description: Loft the shape before cutting steel — answer a design question that prose cannot settle by building a throwaway artifact: a pure logic module in a clickable shell, or structurally different UI variants behind one route. The captain reacts to the artifact; the answer folds into the decision; the artifact never docks. Use when a design question stalls in words, when a navigator map carries a loft ticket, or when a spec discussion reaches "we would have to see it".
+level: 3
+---
+
+# Loft
+
+**Cut no steel until the shape is fair.** Shipwrights loft the hull's lines full-scale and fair them before a single plate is cut. Loft applies the same order to design questions: when words have run out — two plausible answers, neither falsifiable by talk — build a cheap runnable artifact, let the captain react to it, and fold that reaction into the decision.
+
+**The role contract.** The crew builds the artifact; the captain's only job is to react — and that reaction **is** the decision. The artifact is an instrument for seeing, never a head start on the deliverable.
+
+## When to loft
+
+- a design question stalls in prose: repeatedly rephrased, still not settleable ("how should the path page look", "does this state model feel right")
+- a navigator map carries a `loft` ticket
+- a spec discussion reaches "we would have to see it first"
+
+Do **not** loft when:
+
+- the question is answerable from repo evidence or by asking the captain (that is interviewing, not lofting)
+- the destination itself is unclear (that is fog — `/oh-my-claudecode:ask-navigator`)
+- the answer already lives in an ADR (do not re-loft settled decisions)
+- the "design question" is actually a bug (that is the debugger's jurisdiction)
+
+## Choose the fork
+
+Pick by what the question is asking. A wrong fork wastes the whole artifact.
+
+### Logic fork — is the model right?
+
+For questions about state, business rules, data shape, or algorithms ("does unlocking regress on a retake?", "does this reducer hold at the edges?"):
+
+1. Isolate the decision-bearing core — the state machine, reducer, schema, or algorithm — as a **pure module**: no DOM, no I/O, no framework. Written so that, once the shape is confirmed, it moves into the real codebase unchanged.
+2. Wrap it in a single clickable HTML shell: one button per scenario, the tricky edge cases walked through in order, full state visible after every click.
+3. On confirmation the module is ready to lift — it re-enters as real work through launch. During the loft itself `main` stays untouched and the shell stays behind on the branch.
+
+### UI fork — what should it look like?
+
+For questions of shape and arrangement ("steps or cards?", "where does progress live?"):
+
+1. One route, **three variants that differ in structure** — information architecture, navigation model, density. Variants that differ only in styling answer nothing: three reskins are wallpaper.
+2. A switcher on the page cycles the variants; embed into the existing product where possible, so real data density stresses the design instead of three tidy fake rows.
+3. On confirmation, the **decision** transfers and the variants stay behind on the branch as the record of why it looks this way.
+
+## The discipline
+
+- One command to run — the repo's simplest existing serve command; inline the module into the shell if `file://` module CORS would bite. Loads in seconds; no build step beyond what the repo already has.
+- No persistence, no tests, no abstractions, no error handling beyond the happy path. The artifact should be something you **would not want to ship** — the rules exist to keep it that way.
+- Expect the first shape to be argued with: revise on the branch within the same session. The captain confirming the **final** shape is the decision; an artifact nobody argues with usually answered a question nobody had.
+- The artifact's whole life is minutes to build and one session to decide. If it starts growing into production code, stop: that work is a launch effort, not a loft. Sunk cost is the failure mode this skill exists to prevent.
+- One loft answers **one** question. Two questions are two lofts — or one question that was actually two.
+
+## Fold the answer
+
+The artifact is evidence, not a landing. When the captain reacts:
+
+1. Record the decision where it lives — the issue comment, the spec's Implementation Decisions, or the pending-decision note — in the captain's own words plus one line of why. A fragment more precise than prose (the reducer, the state machine, the schema) may be inlined there, marked as lofted.
+2. Push the artifact to a `loft/<name>` branch. It never merges: it stays as the primary source a future reader can open when the decision's "why" matters.
+3. Nothing from the artifact lands in `main` — for the logic fork the confirmed module re-enters as real work through launch, for the UI fork the real page is built fresh from the decision.
+
+## Scope and non-goals
+
+- Loft produces **answers, not deliverables**: no runtime, no state files, nothing always-on.
+- It does not diagnose (debugger), does not chart fog (`/oh-my-claudecode:ask-navigator`), does not approve its own answer (the captain's reaction is the only acceptance).
+- It does not replace seam approval: a lofted UI shows the shape; the test seams for it are still approved at C2.
+
+## Completion definition
+
+The captain reacted, the answer sits where the decision lives, the artifact sits on its branch — and no line of the artifact is in `main`.

--- a/src/__tests__/shipyard-skills.test.ts
+++ b/src/__tests__/shipyard-skills.test.ts
@@ -12,6 +12,7 @@ const ROOT = join(__dirname, '..', '..');
 const LAUNCH = readFileSync(join(ROOT, 'skills', 'launch', 'SKILL.md'), 'utf-8');
 const DRYDOCK = readFileSync(join(ROOT, 'skills', 'drydock', 'SKILL.md'), 'utf-8');
 const NAVIGATOR = readFileSync(join(ROOT, 'skills', 'ask-navigator', 'SKILL.md'), 'utf-8');
+const LOFT = readFileSync(join(ROOT, 'skills', 'loft', 'SKILL.md'), 'utf-8');
 const SHIPYARD_DOC = readFileSync(join(ROOT, 'docs', 'shipyard.md'), 'utf-8');
 const PLUGIN = JSON.parse(readFileSync(join(ROOT, '.claude-plugin', 'plugin.json'), 'utf-8'));
 
@@ -27,11 +28,17 @@ function frontmatter(src: string): Record<string, string> {
 }
 
 describe('shipyard skills — behavior & packaging contract', () => {
-  it('launch/drydock/ask-navigator ship as loadable skill directories with matching frontmatter names', () => {
-    for (const name of ['launch', 'drydock', 'ask-navigator']) {
+  it('launch/drydock/ask-navigator/loft ship as loadable skill directories with matching frontmatter names', () => {
+    for (const name of ['launch', 'drydock', 'ask-navigator', 'loft']) {
       expect(existsSync(join(ROOT, 'skills', name, 'SKILL.md'))).toBe(true);
       const fm = frontmatter(
-        name === 'launch' ? LAUNCH : name === 'drydock' ? DRYDOCK : NAVIGATOR,
+        name === 'launch'
+          ? LAUNCH
+          : name === 'drydock'
+            ? DRYDOCK
+            : name === 'ask-navigator'
+              ? NAVIGATOR
+              : LOFT,
       );
       expect(fm.name).toBe(name);
       expect(fm.description.length).toBeGreaterThan(0);
@@ -101,13 +108,13 @@ describe('shipyard skills — behavior & packaging contract', () => {
   });
 
   it('ask-navigator ticket types stay within the documented vocabulary', () => {
-    const types = [...NAVIGATOR.matchAll(/`?(research|prototype|grilling|task)`?/g)].map((m) => m[1]);
+    const types = [...NAVIGATOR.matchAll(/`?(research|loft|grilling|task)`?/g)].map((m) => m[1]);
     expect(types.length).toBeGreaterThan(0);
     for (const t of types) {
-      expect(['research', 'prototype', 'grilling', 'task']).toContain(t);
+      expect(['research', 'loft', 'grilling', 'task']).toContain(t);
     }
     expect(NAVIGATOR).toContain('| `research` |');
-    expect(NAVIGATOR).toContain('| `prototype` |');
+    expect(NAVIGATOR).toContain('| `loft` |');
     expect(NAVIGATOR).toContain('| `grilling` |');
     expect(NAVIGATOR).toContain('| `task` |');
   });
@@ -116,6 +123,33 @@ describe('shipyard skills — behavior & packaging contract', () => {
     expect(NAVIGATOR).toContain('report-only mode');
     expect(NAVIGATOR).toContain('Deferred sediment');
     expect(DRYDOCK).toContain('report-only mode');
+  });
+
+  it('loft is model-invoked: model-facing description, no keyword triggers', () => {
+    const fm = frontmatter(LOFT);
+    expect(fm['argument-hint']).toBeUndefined(); // input is the conversation's design question
+    expect(fm.description).toContain('prose cannot settle');
+    expect(LOFT).not.toMatch(/^triggers:/m); // no keyword auto-activation
+  });
+
+  it('loft carries the two forks and the never-docks law', () => {
+    expect(LOFT).toContain('Cut no steel until the shape is fair');
+    expect(LOFT).toContain('Logic fork');
+    expect(LOFT).toContain('UI fork');
+    expect(LOFT).toContain('differ in structure');
+    expect(LOFT).toContain('never merges');
+    expect(LOFT).toContain('No persistence, no tests, no abstractions');
+  });
+
+  it('launch and navigator wire the loft contract', () => {
+    expect(LAUNCH).toContain('**Loft detour.**');
+    expect(LAUNCH).toContain('call the Skill tool with "loft"');
+    expect(LAUNCH).toContain('usually a loft');
+    expect(LAUNCH).toContain('map resolutions or deferred-sediment lines');
+    expect(LAUNCH).toContain('/oh-my-claudecode:minimal-code-discipline');
+    expect(NAVIGATOR).toContain('| `loft` |');
+    expect(NAVIGATOR).not.toContain('`prototype`');
+    expect(NAVIGATOR).toContain('Call the Skill tool with "loft"');
   });
 
   it('Team API enforces pre-dispatch ticket dependencies and persists C4 failure evidence', async () => {
@@ -384,7 +418,7 @@ describe('shipyard skills — behavior & packaging contract', () => {
   });
 
   it('plugin.json ships both skills and every path exists on disk', () => {
-    for (const name of ['launch', 'drydock', 'ask-navigator']) {
+    for (const name of ['launch', 'drydock', 'ask-navigator', 'loft']) {
       const entry = `./skills/${name}/`;
       expect(PLUGIN.skills as string[]).toContain(entry);
       expect(existsSync(join(ROOT, entry, 'SKILL.md'))).toBe(true);
@@ -401,7 +435,7 @@ describe('shipyard skills — behavior & packaging contract', () => {
     expect(ref).toContain('/oh-my-claudecode:drydock [--check]');
     expect(ref).toContain('/oh-my-claudecode:launch <brief\\|spec-path> [--serial]');
     expect(ref).toContain('/oh-my-claudecode:ask-navigator <idea\\|map>');
-    for (const name of ['launch', 'drydock', 'ask-navigator']) {
+    for (const name of ['launch', 'drydock', 'ask-navigator', 'loft']) {
       expect(ref).toContain(`\`${name}\``);
     }
   });

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -71,8 +71,8 @@ describe('Builtin Skills', () => {
   describe('createBuiltinSkills()', () => {
     it('should return correct number of skills (33 canonical + 2 aliases)', () => {
       const skills = createBuiltinSkills();
-      // 38 entries: 36 canonical skills + 2 aliases (cancel-ralph, psm)
-      expect(skills).toHaveLength(38);
+      // 39 entries: 37 canonical skills + 2 aliases (cancel-ralph, psm)
+      expect(skills).toHaveLength(39);
     });
 
     it('should return an array of BuiltinSkill objects', () => {
@@ -141,6 +141,7 @@ describe('Builtin Skills', () => {
         'hud',
         'minimal-code-discipline',
         'launch',
+        'loft',
         'drydock',
         'omc-doctor',
         'omc-plan',
@@ -663,10 +664,11 @@ describe('Builtin Skills', () => {
     it('should return canonical skill names by default', () => {
       const names = listBuiltinSkillNames();
 
-      expect(names).toHaveLength(36);
+      expect(names).toHaveLength(37);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('minimal-code-discipline');
       expect(names).toContain('launch');
+      expect(names).toContain('loft');
       expect(names).toContain('drydock');
       expect(names).toContain('ask');
       expect(names).toContain('ask-navigator');
@@ -701,7 +703,7 @@ describe('Builtin Skills', () => {
       const names = listBuiltinSkillNames({ includeAliases: true });
 
       // swarm alias removed in #1131; learner retired in 5.0.0; cancel-ralph and psm remain
-      expect(names).toHaveLength(38);
+      expect(names).toHaveLength(39);
       expect(names).toContain('ai-slop-cleaner');
       expect(names).toContain('autoresearch');
       expect(names).toContain('self-improve');

--- a/src/alias-retirement/__tests__/registry.test.ts
+++ b/src/alias-retirement/__tests__/registry.test.ts
@@ -64,7 +64,7 @@ describe('alias-retirement registry', () => {
     }
   });
 
-  it('built-in loader exposes 38 entries (36 canonical + 2 aliases) after the 5.0.0 retirement', () => {
+  it('built-in loader exposes 39 entries (37 canonical + 2 aliases) after the 5.0.0 retirement', () => {
     // This is the baseline that retirement must not silently change without an eligibility receipt.
     // Raised 37 -> 40 canonical when execute/review/research shipped as real
     // skill directories; this is an addition, not an alias retirement.
@@ -74,11 +74,13 @@ describe('alias-retirement registry', () => {
     // directories; this is an addition, not an alias retirement.
     // Raised 35 -> 36 canonical when ask-navigator shipped as a real skill
     // directory; this is an addition, not an alias retirement.
+    // Raised 36 -> 37 canonical when loft shipped as a real skill directory;
+    // this is an addition, not an alias retirement.
     const all = createBuiltinSkills();
-    expect(all).toHaveLength(38);
+    expect(all).toHaveLength(39);
     const canonical = all.filter((s) => !s.aliasOf);
     const aliases = all.filter((s) => !!s.aliasOf);
-    expect(canonical).toHaveLength(36);
+    expect(canonical).toHaveLength(37);
     expect(aliases).toHaveLength(2);
     expect(aliases.map((s) => s.name).sort()).toEqual(['cancel-ralph', 'psm'].sort());
   });

--- a/src/workflow/__tests__/projections.test.ts
+++ b/src/workflow/__tests__/projections.test.ts
@@ -43,8 +43,8 @@ describe('registry projections — canonical JSON and digest', () => {
 describe('registry projections — drift check against installed surfaces', () => {
   it('matches the repository skills/ and commands/ surface exactly', () => {
     const installed = enumerateInstalledSurfaces(process.cwd());
-    // 41 + execute/review/research + graph + minimal-code-discipline + launch/drydock + ask-navigator, which ship as real skill directories.
-    expect(installed.skills.length).toBe(36);
+    // 41 + execute/review/research + graph + minimal-code-discipline + launch/drydock + ask-navigator + loft, which ship as real skill directories.
+    expect(installed.skills.length).toBe(37);
     expect(installed.commands.length).toBe(21);
     const drift = checkProjectionDrift(installed);
     expect(drift.unregistered).toEqual([]);

--- a/src/workflow/__tests__/registry.test.ts
+++ b/src/workflow/__tests__/registry.test.ts
@@ -83,11 +83,11 @@ describe('workflow registry — risk classes and gate policy', () => {
 });
 
 describe('workflow registry — aliases and classification', () => {
-  it('classifies all 36 installed skills and 21 installed commands exactly once', () => {
+  it('classifies all 37 installed skills and 21 installed commands exactly once', () => {
     const skills = WORKFLOW_ENTRIES.filter((e) => e.kind === 'skill' && !e.declaredOnly);
     const commands = WORKFLOW_ENTRIES.filter((e) => e.kind === 'command' && !e.declaredOnly);
     // execute/review/research and graph ship as real skill directories.
-    expect(skills).toHaveLength(36);
+    expect(skills).toHaveLength(37);
     expect(commands).toHaveLength(21);
     const keys = WORKFLOW_ENTRIES.map((e) => `${e.kind}:${e.name}`);
     expect(new Set(keys).size).toBe(keys.length);

--- a/src/workflow/registry.ts
+++ b/src/workflow/registry.ts
@@ -190,6 +190,7 @@ const SKILL_ENTRIES: readonly WorkflowEntry[] = [
   entry({ name: 'minimal-code-discipline', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in writing-time discipline; never a default gate.' }),
   entry({ name: 'launch', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in governed delivery pipeline (spec -> tickets -> frontier); never a default gate.' }),
   entry({ name: 'ask-navigator', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in navigator: charts foggy efforts into decision-ticket maps; never a default gate, never builds.' }),
+  entry({ name: 'loft', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in shape-before-steel discipline: throwaway artifacts answer design questions; never a default gate, never lands.' }),
   entry({ name: 'drydock', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in harness scaffold (shipyard keel); never a default gate.' }),
   entry({ name: 'visual-verdict', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in for visual surfaces.' }),
   entry({ name: 'external-context', kind: 'skill', decision: 'keep', riskClass: 'advisory', owner: REGISTRY_OWNER, notes: 'Opt-in external evidence tool.' }),


### PR DESCRIPTION
## Summary

Adds the opt-in **`loft`** skill — shipyard's shape-before-steel discipline, the fifth verb of the yard:

- **`loft`** answers a design question that prose cannot settle by building a throwaway artifact — a **pure logic module** in a clickable shell (the module lifts into the real codebase unchanged once the shape is confirmed), or **structurally different UI variants** behind one route (three reskins are wallpaper). The captain reacts to the artifact — expect the first shape to be argued with — the answer folds into the decision, and the artifact **never docks**: it stays on a `loft/<name>` branch as the primary source, with `main` untouched. Model-invoked: reached for by the navigator's loft tickets, by launch's Phase 1 detour, or by the agent when a design question stalls in words.
- **`launch`** gains three stitches: Phase 1 gets the **loft detour** (a residual question that is precise but needs a runnable answer is answered with an artifact, not more questions — the captain signs what they saw, not what they were told); the Phase 2 durability gate names the origin of decision-rich fragments ("usually a loft"); the C5 sediment checklist now sweeps **map resolutions and deferred-sediment lines** from any source map this run followed. Workers also reference `/oh-my-claudecode:minimal-code-discipline` as the opt-in writing-time discipline.
- **`ask-navigator`**: the `prototype` ticket type becomes **`loft`** with the Skill-tool call contract (navigator is unreleased, so the rename is free).
- **`docs/shipyard.md`**: the loft joins the metaphor family and the five-skill composition; lofting joins the agent-continuous side of the boundary.

Boundary rule preserved: loft produces **answers, not deliverables** — no runtime, no state files, no persistence, no tests in the artifact by design; the captain's reaction is the only acceptance.

## What changed

- `skills/loft/SKILL.md` — the skill (two forks, the discipline, the fold, never-docks law)
- `skills/launch/SKILL.md` — Phase 1 loft detour, Phase 2 origin naming, C5 map-source sweep, Phase 4 mcd reference
- `skills/ask-navigator/SKILL.md` — ticket type `prototype` → `loft` with the Skill-tool call
- `skills/drydock/SKILL.md` — tracker-probe wording names its real consumer (the navigator's map home)
- `docs/shipyard.md` — loft metaphor row, five-skill composition, boundary list
- `.claude-plugin/plugin.json` — 1 shim entry (36 → 37); `.claude-plugin/marketplace.json` — **drops stale hardcoded counts** ("28 agents, 33 skills" two versions behind reality; no test guards them)
- `src/workflow/registry.ts` — 1 `keep`/`advisory` entry ("never a default gate, never lands")
- Test count baselines 36→37 canonical / 38→39 with aliases in `src/__tests__/skills.test.ts`, `src/alias-retirement/__tests__/registry.test.ts`, `src/workflow/__tests__/registry.test.ts`, `src/workflow/__tests__/projections.test.ts`
- `src/__tests__/shipyard-skills.test.ts` — contract tests pinning the never-docks law, the two forks, model-invoked posture (no keyword triggers), and every stitch above
- Docs: `AGENTS.md`, `skills/AGENTS.md`, `docs/REFERENCE.md` (skills + slash tables)

## Verification

- [x] `npx vitest run` targeted (skills / shipyard-skills / plugin-skill-budget / workflow registry / projections / alias-retirement) — all green except the known pre-existing Windows flake (`alias-resolver` opt-out/dedupe file test; fails identically on a clean checkout)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run prompt-ssot:check` — 5 projections fresh, untouched by this PR
- [x] `npm run generate:inventory` + `:verify` — fresh at the feature head, verified at the inventory head (separate `chore:` commit per the ancestor provenance contract)
- [x] `npm run verify:skill-entitlements` — current
- [x] No committed build artifacts: zero `dist/`/`bridge/` deltas

## Notes for reviewers

- Walkthrough evidence: the skill was executed end-to-end on a real state-machine question ("how do retakes interact with path progress?") at https://github.com/pangpang778/ask-navigator-lab — pure module + clickable shell on `loft/retake-progress`, the **first shape was rejected by the captain** (progress regressed 100%→67% while the badge froze — a conflict invisible in prose), revised and folded on the branch; transcript in `WALKTHROUGH-LOFT.md`, findings in `FINDINGS-LOFT.md`. The three instruction gaps found (lift-timing ambiguity, revise-within-session expectation, `file://` CORS vs "one command") were folded back into the SKILL.md before this PR.
- Anti-plagiarism self-check: sentence-level 8-gram comparison against the source material's three files — **zero overlaps**; the discipline is expressed in shipyard's own vocabulary (lofting, docking, captain's reaction).
- Naming note: the skill is named for the real shipyard practice (mould loft / lofting — "cut no steel until the shape is fair"), deliberately not for the generic term, which also avoids colliding with test-mocking vocabulary.
- Two commits off current `dev` (`898e9179d`): 17 files, +~170/−45.