### PR TITLE
perf: batch Windows cache occupancy identity checks

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "4e8d9ccd027718bb87b021f232930c09dc07d86f",
-    "sourceSha256": "6047b5d6d4fc95bf3324ed9d37f6c41811ea59a0861ce319aacf56c881efd4bc",
+    "head": "b556e3eed2c4a5afcaaf129cfa22cefd77c1e2e6",
+    "sourceSha256": "835ddd79d06ce2c8867a05b91d41b719b9005bbd0a110aa64f124227fd6d8fcf",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "4e8d9ccd027718bb87b021f232930c09dc07d86f",
-  "sourceSha256": "6047b5d6d4fc95bf3324ed9d37f6c41811ea59a0861ce319aacf56c881efd4bc",
+  "head": "b556e3eed2c4a5afcaaf129cfa22cefd77c1e2e6",
+  "sourceSha256": "835ddd79d06ce2c8867a05b91d41b719b9005bbd0a110aa64f124227fd6d8fcf",
   "counts": {
     "public": {
       "skills": 37,
@@ -77328,5 +77328,5 @@
     }
   },
   "inventorySha256": "d4529469934f2cbf2fa4897aea788da0e912fad10235f00a88b9afff515417b5",
-  "manifestSha256": "1c994e38c4e90009ed891709b2303f729e3f7384f9d88c98b2528c19a87564a5"
+  "manifestSha256": "a274e4f133a5b464f840b478e1f6b05f9585f8c88220f9a8be0d7807a11dc789"
 }

--- a/scripts/lib/cache-occupancy.mjs
+++ b/scripts/lib/cache-occupancy.mjs
@@ -37,6 +37,24 @@ function identity(pid) {
   }
   return null;
 }
+
+function identities(pids) {
+  if (process.platform !== 'win32') return new Map();
+  const validPids = [...new Set(pids.filter(pid => Number.isSafeInteger(pid) && pid > 0))];
+  if (validPids.length === 0) return new Map();
+  try {
+    const filter = validPids.join(',');
+    const command = `$items=Get-Process -Id ${filter} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
+    const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', timeout: 3000, windowsHide: true });
+    if (result.status !== 0) return new Map();
+    const parsed = JSON.parse(result.stdout?.trim() || 'null');
+    const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+    return new Map(items
+      .map(item => [Number(item?.Id), String(item?.StartTicks || '')])
+      .filter(([pid, ticks]) => validPids.includes(pid) && /^\d+$/.test(ticks))
+      .map(([pid, ticks]) => [pid, `ticks:${ticks}`]));
+  } catch { return new Map(); }
+}
 function alive(pid) {
   try { process.kill(pid, 0); return true; }
   catch (error) { return error?.code === 'EPERM'; }
@@ -63,15 +81,25 @@ export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid)
 export function readOccupiedPluginRoots(configDir) {
   const dir = registryDir(configDir);
   let names;
-  try { names = readdirSync(dir).filter(name => NAME.test(name)); } catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
+  try { names = readdirSync(dir).filter(name => NAME.test(name)); }
+  catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
   const roots = new Set();
+  const records = [];
   for (const name of names) {
     const path = join(dir, name);
     let record;
     try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch {} continue; }
     const age = Date.now() - Date.parse(record?.updatedAt);
-    const current = identity(record?.pid);
-    if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid) || (current && current !== record.processStartIdentity)) {
+    if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid)) {
+      try { unlinkSync(path); } catch {}
+      continue;
+    }
+    records.push({ path, record });
+  }
+  const currentIdentities = identities(records.map(({ record }) => record.pid));
+  for (const { path, record } of records) {
+    const current = process.platform === 'win32' ? currentIdentities.get(record.pid) : identity(record.pid);
+    if (current && current !== record.processStartIdentity) {
       try { unlinkSync(path); } catch {}
       continue;
     }

--- a/src/utils/__tests__/cache-occupancy.test.ts
+++ b/src/utils/__tests__/cache-occupancy.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { publishCacheOccupancy, readOccupiedPluginRoots } from '../cache-occupancy.js';
+import { processStartIdentities, publishCacheOccupancy, readOccupiedPluginRoots } from '../cache-occupancy.js';
 
 describe('cache occupancy registry', () => {
   let dir: string;
@@ -27,5 +27,28 @@ describe('cache occupancy registry', () => {
     writeFileSync(join(registry, `${'a'.repeat(64)}.json`), '{broken');
     expect(readOccupiedPluginRoots(dir).roots.size).toBe(0);
     expect(readdirSync(registry)).toEqual([]);
+  });
+
+  it('resolves Windows process identities in one PowerShell call', () => {
+    const originalPlatform = process.platform;
+    const exec = vi.fn(() => JSON.stringify([
+      { Id: 41, StartTicks: 1001 },
+      { Id: 42, StartTicks: 1002 },
+    ])) as unknown as Parameters<typeof processStartIdentities>[1];
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      expect(processStartIdentities([41, 42, 41], exec)).toEqual(new Map([
+        [41, 'ticks:1001'],
+        [42, 'ticks:1002'],
+      ]));
+      expect(exec).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledWith(
+        'powershell',
+        ['-NoProfile', '-NonInteractive', '-Command', expect.stringContaining('Get-Process -Id 41,42')],
+        { encoding: 'utf8', windowsHide: true },
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
   });
 });

--- a/src/utils/cache-occupancy.ts
+++ b/src/utils/cache-occupancy.ts
@@ -38,6 +38,24 @@ function processStartIdentity(pid: number): string | null {
   return null;
 }
 
+export function processStartIdentities(pids: number[], exec: typeof execFileSync = execFileSync): Map<number, string> {
+  if (process.platform !== 'win32') return new Map();
+  const validPids = [...new Set(pids.filter((pid) => Number.isSafeInteger(pid) && pid > 0))];
+  if (validPids.length === 0) return new Map();
+  try {
+    const command = `$items=Get-Process -Id ${validPids.join(',')} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
+    const output = exec('powershell', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', windowsHide: true });
+    const parsed: unknown = JSON.parse(output.trim() || 'null');
+    const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+    return new Map(items
+      .map((item) => [Number((item as { Id?: unknown })?.Id), String((item as { StartTicks?: unknown })?.StartTicks || '')] as const)
+      .filter(([pid, ticks]) => validPids.includes(pid) && /^\d+$/.test(ticks))
+      .map(([pid, ticks]) => [pid, `ticks:${ticks}`] as const));
+  } catch {
+    return new Map();
+  }
+}
+
 function processAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; }
   catch (error) { return (error as NodeJS.ErrnoException).code === 'EPERM'; }
@@ -106,6 +124,7 @@ export function readOccupiedPluginRoots(configDir = getClaudeConfigDir()): { roo
   }
 
   const roots = new Set<string>();
+  const records: Array<{ path: string; record: CacheOccupancyRecord }> = [];
   const now = Date.now();
   for (const name of names) {
     const path = join(directory, name);
@@ -115,7 +134,13 @@ export function readOccupiedPluginRoots(configDir = getClaudeConfigDir()): { roo
     const age = now - Date.parse(record.updatedAt);
     if (age < -5 * 60 * 1000) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
     if (!processAlive(record.pid)) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
-    const currentIdentity = processStartIdentity(record.pid);
+    records.push({ path, record });
+  }
+  const currentIdentities = processStartIdentities(records.map(({ record }) => record.pid));
+  for (const { path, record } of records) {
+    const currentIdentity = process.platform === 'win32'
+      ? currentIdentities.get(record.pid)
+      : processStartIdentity(record.pid);
     if (currentIdentity && currentIdentity !== record.processStartIdentity) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
     // A live process whose identity cannot be read (including EPERM) is retained
     // conservatively; only a proven-dead PID or proven mismatch self-invalidates.

--- a/templates/hooks/lib/cache-occupancy.mjs
+++ b/templates/hooks/lib/cache-occupancy.mjs
@@ -17,6 +17,19 @@ function identity(pid) {
   if (process.platform === 'win32') { try { const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', `$p=Get-Process -Id ${pid} -ErrorAction Stop; $p.StartTime.ToUniversalTime().Ticks`], { encoding: 'utf8', timeout: 3000, windowsHide: true }); const ticks = result.stdout?.trim().match(/^\d+$/)?.[0]; return ticks ? `ticks:${ticks}` : null; } catch { return null; } }
   return null;
 }
+function identities(pids) {
+  if (process.platform !== 'win32') return new Map();
+  const validPids = [...new Set(pids.filter(pid => Number.isSafeInteger(pid) && pid > 0))];
+  if (validPids.length === 0) return new Map();
+  try {
+    const command = `$items=Get-Process -Id ${validPids.join(',')} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
+    const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', timeout: 3000, windowsHide: true });
+    if (result.status !== 0) return new Map();
+    const parsed = JSON.parse(result.stdout?.trim() || 'null');
+    const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+    return new Map(items.map(item => [Number(item?.Id), String(item?.StartTicks || '')]).filter(([pid, ticks]) => validPids.includes(pid) && /^\d+$/.test(ticks)).map(([pid, ticks]) => [pid, `ticks:${ticks}`]));
+  } catch { return new Map(); }
+}
 function alive(pid) {
   try { process.kill(pid, 0); return true; }
   catch (error) { return error?.code === 'EPERM'; }
@@ -32,7 +45,9 @@ export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid)
 export function readOccupiedPluginRoots(configDir) {
   const dir = registryDir(configDir); let names;
   try { names = readdirSync(dir).filter(name => typeof name === 'string' && NAME.test(name)); } catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
-  const roots = new Set();
-  for (const name of names) { const path = join(dir, name); let record; try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch {} continue; } const age = Date.now() - Date.parse(record?.updatedAt); const current = identity(record?.pid); if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid) || (current && current !== record.processStartIdentity)) { try { unlinkSync(path); } catch {} continue; } roots.add(pathIdentity(record.pluginRoot)); }
+  const roots = new Set(); const records = [];
+  for (const name of names) { const path = join(dir, name); let record; try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch {} continue; } const age = Date.now() - Date.parse(record?.updatedAt); if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid)) { try { unlinkSync(path); } catch {} continue; } records.push({ path, record }); }
+  const currentIdentities = identities(records.map(({ record }) => record.pid));
+  for (const { path, record } of records) { const current = process.platform === 'win32' ? currentIdentities.get(record.pid) : identity(record.pid); if (current && current !== record.processStartIdentity) { try { unlinkSync(path); } catch {} continue; } roots.add(pathIdentity(record.pluginRoot)); }
   return { roots, unavailable: false };
 }


### PR DESCRIPTION
Closes #3972

## Evidence
- Current dev at 9495037d3797bea7ea7a03911808d0872bd4acf3 was refreshed before implementation.
- Linux isolated smoke reproduced the occupancy registry path and retained live PID identity records while removing corrupt records.
- Focused Vitest: 13 tests passed across cache occupancy and SessionStart cleanup.
- TypeScript validation passed; ESLint completed with 0 errors and existing warnings only.
- Windows measurements are not claimed: batching is covered by a deterministic simulated-platform regression test; reporter hardware confirmation remains follow-up evidence.

## Scope
This is the smallest safe fix: Windows process-start identities are resolved in one PowerShell call per occupancy scan. Missing identity output retains live records conservatively, preserving PID reuse and cleanup safety. No registry redesign or skip-guard changes are included.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*