### PR TITLE
fix: preserve Windows occupancy tick precision

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b556e3eed2c4a5afcaaf129cfa22cefd77c1e2e6",
-    "sourceSha256": "835ddd79d06ce2c8867a05b91d41b719b9005bbd0a110aa64f124227fd6d8fcf",
+    "head": "44065f8723ef324feabe8a63ea0d8e1593e9a857",
+    "sourceSha256": "9b406acbd88d6e30831cce20e0835a5bdc29ddd7f8ffe05e1bc623d00d134ea4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b556e3eed2c4a5afcaaf129cfa22cefd77c1e2e6",
-  "sourceSha256": "835ddd79d06ce2c8867a05b91d41b719b9005bbd0a110aa64f124227fd6d8fcf",
+  "head": "44065f8723ef324feabe8a63ea0d8e1593e9a857",
+  "sourceSha256": "9b406acbd88d6e30831cce20e0835a5bdc29ddd7f8ffe05e1bc623d00d134ea4",
   "counts": {
     "public": {
       "skills": 37,
@@ -77328,5 +77328,5 @@
     }
   },
   "inventorySha256": "d4529469934f2cbf2fa4897aea788da0e912fad10235f00a88b9afff515417b5",
-  "manifestSha256": "a274e4f133a5b464f840b478e1f6b05f9585f8c88220f9a8be0d7807a11dc789"
+  "manifestSha256": "c9906578713266d6c244fb6aa7e4a4e6d43ac60bcee137bda895811c1c159bd0"
 }

--- a/scripts/lib/cache-occupancy.mjs
+++ b/scripts/lib/cache-occupancy.mjs
@@ -44,14 +44,14 @@ function identities(pids) {
   if (validPids.length === 0) return new Map();
   try {
     const filter = validPids.join(',');
-    const command = `$items=Get-Process -Id ${filter} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
+    const command = `$items=Get-Process -Id ${filter} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={[string]$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
     const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', timeout: 3000, windowsHide: true });
     if (result.status !== 0) return new Map();
     const parsed = JSON.parse(result.stdout?.trim() || 'null');
     const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
     return new Map(items
-      .map(item => [Number(item?.Id), String(item?.StartTicks || '')])
-      .filter(([pid, ticks]) => validPids.includes(pid) && /^\d+$/.test(ticks))
+      .map(item => [Number(item?.Id), item?.StartTicks])
+      .filter(([pid, ticks]) => validPids.includes(pid) && typeof ticks === 'string' && /^\d+$/.test(ticks))
       .map(([pid, ticks]) => [pid, `ticks:${ticks}`]));
   } catch { return new Map(); }
 }

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -744,6 +744,16 @@ OMC Ultrawork = "특수부대 작전 반"
 });
 
 describe('pre-tool-use packaged artifacts', () => {
+  it('keeps Windows cache-occupancy tick parsing string-based in runtime and template helpers', () => {
+    for (const helperPath of [
+      join(packageRoot, 'scripts', 'lib', 'cache-occupancy.mjs'),
+      join(packageRoot, 'templates', 'hooks', 'lib', 'cache-occupancy.mjs'),
+      join(packageRoot, 'src', 'utils', 'cache-occupancy.ts'),
+    ]) {
+      expect(readFileSync(helperPath, 'utf8')).toContain('[string]$_.StartTime.ToUniversalTime().Ticks');
+    }
+  });
+
   it('keeps cache occupancy path identity aligned across template and runtime helpers', async () => {
     const helperPaths = [
       join(packageRoot, 'templates', 'hooks', 'lib', 'cache-occupancy.mjs'),

--- a/src/utils/__tests__/cache-occupancy.test.ts
+++ b/src/utils/__tests__/cache-occupancy.test.ts
@@ -32,21 +32,35 @@ describe('cache occupancy registry', () => {
   it('resolves Windows process identities in one PowerShell call', () => {
     const originalPlatform = process.platform;
     const exec = vi.fn(() => JSON.stringify([
-      { Id: 41, StartTicks: 1001 },
-      { Id: 42, StartTicks: 1002 },
+      { Id: 41, StartTicks: '638933184000000001' },
+      { Id: 42, StartTicks: '638933184000000002' },
     ])) as unknown as Parameters<typeof processStartIdentities>[1];
     try {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       expect(processStartIdentities([41, 42, 41], exec)).toEqual(new Map([
-        [41, 'ticks:1001'],
-        [42, 'ticks:1002'],
+        [41, 'ticks:638933184000000001'],
+        [42, 'ticks:638933184000000002'],
       ]));
       expect(exec).toHaveBeenCalledTimes(1);
       expect(exec).toHaveBeenCalledWith(
         'powershell',
-        ['-NoProfile', '-NonInteractive', '-Command', expect.stringContaining('Get-Process -Id 41,42')],
+        ['-NoProfile', '-NonInteractive', '-Command', expect.stringContaining("[string]$_.StartTime.ToUniversalTime().Ticks")],
         { encoding: 'utf8', windowsHide: true },
       );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it('accepts a single realistic Windows identity and rejects numeric precision loss', () => {
+    const originalPlatform = process.platform;
+    const exec = vi.fn(() => JSON.stringify({ Id: 41, StartTicks: '638933184000000001' })) as unknown as Parameters<typeof processStartIdentities>[1];
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      expect(processStartIdentities([41], exec)).toEqual(new Map([[41, 'ticks:638933184000000001']]));
+
+      const rounded = vi.fn(() => JSON.stringify({ Id: 41, StartTicks: 638933184000000001 })) as unknown as Parameters<typeof processStartIdentities>[1];
+      expect(processStartIdentities([41], rounded)).toEqual(new Map());
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     }

--- a/src/utils/__tests__/cache-occupancy.test.ts
+++ b/src/utils/__tests__/cache-occupancy.test.ts
@@ -59,7 +59,7 @@ describe('cache occupancy registry', () => {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       expect(processStartIdentities([41], exec)).toEqual(new Map([[41, 'ticks:638933184000000001']]));
 
-      const rounded = vi.fn(() => JSON.stringify({ Id: 41, StartTicks: 638933184000000001 })) as unknown as Parameters<typeof processStartIdentities>[1];
+      const rounded = vi.fn(() => JSON.stringify({ Id: 41, StartTicks: Number('638933184000000001') })) as unknown as Parameters<typeof processStartIdentities>[1];
       expect(processStartIdentities([41], rounded)).toEqual(new Map());
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });

--- a/src/utils/cache-occupancy.ts
+++ b/src/utils/cache-occupancy.ts
@@ -43,13 +43,13 @@ export function processStartIdentities(pids: number[], exec: typeof execFileSync
   const validPids = [...new Set(pids.filter((pid) => Number.isSafeInteger(pid) && pid > 0))];
   if (validPids.length === 0) return new Map();
   try {
-    const command = `$items=Get-Process -Id ${validPids.join(',')} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
+    const command = `$items=Get-Process -Id ${validPids.join(',')} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={[string]$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
     const output = exec('powershell', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', windowsHide: true });
     const parsed: unknown = JSON.parse(output.trim() || 'null');
     const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
     return new Map(items
-      .map((item) => [Number((item as { Id?: unknown })?.Id), String((item as { StartTicks?: unknown })?.StartTicks || '')] as const)
-      .filter(([pid, ticks]) => validPids.includes(pid) && /^\d+$/.test(ticks))
+      .map((item) => [Number((item as { Id?: unknown })?.Id), (item as { StartTicks?: unknown })?.StartTicks] as const)
+      .filter(([pid, ticks]): ticks is string => validPids.includes(pid) && typeof ticks === 'string' && /^\d+$/.test(ticks))
       .map(([pid, ticks]) => [pid, `ticks:${ticks}`] as const));
   } catch {
     return new Map();

--- a/src/utils/cache-occupancy.ts
+++ b/src/utils/cache-occupancy.ts
@@ -49,8 +49,9 @@ export function processStartIdentities(pids: number[], exec: typeof execFileSync
     const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
     return new Map(items
       .map((item) => [Number((item as { Id?: unknown })?.Id), (item as { StartTicks?: unknown })?.StartTicks] as const)
-      .filter(([pid, ticks]): ticks is string => validPids.includes(pid) && typeof ticks === 'string' && /^\d+$/.test(ticks))
-      .map(([pid, ticks]) => [pid, `ticks:${ticks}`] as const));
+      .flatMap(([pid, ticks]) => validPids.includes(pid) && typeof ticks === 'string' && /^\d+$/.test(ticks)
+        ? [[pid, `ticks:${ticks}`] as const]
+        : []));
   } catch {
     return new Map();
   }

--- a/templates/hooks/lib/cache-occupancy.mjs
+++ b/templates/hooks/lib/cache-occupancy.mjs
@@ -22,12 +22,12 @@ function identities(pids) {
   const validPids = [...new Set(pids.filter(pid => Number.isSafeInteger(pid) && pid > 0))];
   if (validPids.length === 0) return new Map();
   try {
-    const command = `$items=Get-Process -Id ${validPids.join(',')} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
+    const command = `$items=Get-Process -Id ${validPids.join(',')} -ErrorAction SilentlyContinue | Select-Object Id,@{Name='StartTicks';Expression={[string]$_.StartTime.ToUniversalTime().Ticks}}; $items | ConvertTo-Json -Compress`;
     const result = spawnSync('powershell', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', timeout: 3000, windowsHide: true });
     if (result.status !== 0) return new Map();
     const parsed = JSON.parse(result.stdout?.trim() || 'null');
     const items = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
-    return new Map(items.map(item => [Number(item?.Id), String(item?.StartTicks || '')]).filter(([pid, ticks]) => validPids.includes(pid) && /^\d+$/.test(ticks)).map(([pid, ticks]) => [pid, `ticks:${ticks}`]));
+    return new Map(items.map(item => [Number(item?.Id), item?.StartTicks]).filter(([pid, ticks]) => validPids.includes(pid) && typeof ticks === 'string' && /^\d+$/.test(ticks)).map(([pid, ticks]) => [pid, `ticks:${ticks}`]));
   } catch { return new Map(); }
 }
 function alive(pid) {


### PR DESCRIPTION
Fix-forward for #3972 and #3973 review findings.

The batched PowerShell helper must not serialize DateTime.Ticks as JSON numbers: Windows ticks are approximately 6e17 and exceed JavaScript safe integer precision. This patch emits ticks as PowerShell strings and validates string-form decimal ticks, preserving exact PID start-identity comparisons.

Focused coverage includes realistic tick values above 2^53, single-object PowerShell JSON, rounded numeric output rejection, runtime/template parity, and the existing cleanup regression suite.

Windows 11/Node 22 hardware timings remain unverified. No main/tag/release/publish action.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*