### PR TITLE
fix(worktree-paths): force LC_ALL=C on git probe spawns

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "2116310a3b0dfd2ea5a3e34ec9db6f98f8c384e9",
-    "sourceSha256": "505d96fe861071d1dae8c0787934bb6260798ba7491aed35387d626ea31a33fd",
+    "head": "84306c0a06311132ce05abac6fabbf8ec411ec20",
+    "sourceSha256": "b788593f0244a1aaa4d10a77f3021531c789239bd7eb3441f7ea25fb3f7aa37f",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "2116310a3b0dfd2ea5a3e34ec9db6f98f8c384e9",
-  "sourceSha256": "505d96fe861071d1dae8c0787934bb6260798ba7491aed35387d626ea31a33fd",
+  "head": "84306c0a06311132ce05abac6fabbf8ec411ec20",
+  "sourceSha256": "b788593f0244a1aaa4d10a77f3021531c789239bd7eb3441f7ea25fb3f7aa37f",
   "counts": {
     "public": {
       "skills": 37,
@@ -26,10 +26,10 @@
       "hookFiles": 295,
       "featureFiles": 71,
       "toolFiles": 61,
-      "libFiles": 40,
+      "libFiles": 41,
       "templateHooks": 21,
-      "srcFiles": 1332,
-      "total": 1353
+      "srcFiles": 1333,
+      "total": 1354
     },
     "generated": {
       "distFiles": 4986,
@@ -589,6 +589,7 @@
       "src/lib/__tests__/worktree-cleanup-safety.test.ts",
       "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
       "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts",
+      "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
       "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
       "src/lib/__tests__/worktree-paths-nongit-anchor.test.ts",
       "src/lib/__tests__/worktree-paths-split-warning.test.ts",
@@ -38389,6 +38390,11 @@
         "path": "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths-git-timeout.test.ts"
@@ -65076,6 +65082,31 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths-git-timeout.test.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -77557,12 +77588,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6897,
-      "edgeCount": 7349,
-      "importEdgeCount": 6047,
+      "nodeCount": 6898,
+      "edgeCount": 7354,
+      "importEdgeCount": 6052,
       "registerEdgeCount": 58
     }
   },
-  "inventorySha256": "d4529469934f2cbf2fa4897aea788da0e912fad10235f00a88b9afff515417b5",
-  "manifestSha256": "9fa3d6aa06dc61c1934a866fcb7def0741d555b98f4fbe80e54e2b7ef503f883"
+  "inventorySha256": "583f179d4fdbbaead6ed6d536ba1a05dbafb052238a87f4248775a0abfb749a3",
+  "manifestSha256": "2669576f363dee390dc9fc32d4e9d3cea2940ba238a9588f2347543f82be7f13"
 }

--- a/src/lib/__tests__/worktree-paths-git-probe-locale.test.ts
+++ b/src/lib/__tests__/worktree-paths-git-probe-locale.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, delimiter } from 'node:path';
+import { clearWorktreeCache, probeGitTopLevel, setGitShowToplevelProbeForTests } from '../../lib/worktree-paths.js';
+
+// A real (non-test-mode) git spawn that prints a *localized* "not a git
+// repository" message unless the caller forces LC_ALL=C, mirroring what
+// git's gettext layer does on a non-English system locale (e.g. Korean:
+// "깃 저장소가 아닙니다"). isNotAGitRepositoryError() only recognizes the
+// English string, so without forcing LC_ALL=C on the spawn, a plain "this
+// directory is not a git repository" answer is misclassified as
+// `probe_failed` instead of `not_a_repository` — which fails closed and
+// breaks every caller (e.g. the HUD statusline) in a non-git directory.
+function installLocaleAwareFakeGit(dir: string): string {
+  const bin = join(dir, 'fake-git-bin');
+  mkdirSync(bin, { recursive: true });
+  const gitPath = join(bin, 'git');
+  writeFileSync(
+    gitPath,
+    [
+      '#!/bin/sh',
+      'if [ "$LC_ALL" = "C" ]; then',
+      '  echo "fatal: not a git repository (or any of the parent directories): .git" 1>&2',
+      'else',
+      '  echo "fatal: (현재 폴더 또는 상위 폴더 중 일부가) 깃 저장소가 아닙니다: .git" 1>&2',
+      'fi',
+      'exit 128',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(gitPath, 0o755);
+  return bin;
+}
+
+describe('probeGitTopLevel locale independence', () => {
+  let tempDir: string;
+  let plainDir: string;
+  let originalPath: string | undefined;
+  let originalLcAll: string | undefined;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+    originalLcAll = process.env.LC_ALL;
+    // Simulate a session whose ambient locale is Korean, not English.
+    process.env.LC_ALL = 'ko_KR.UTF-8';
+    tempDir = mkdtempSync(join(tmpdir(), 'probe-locale-'));
+    plainDir = join(tempDir, 'plain-notes');
+    mkdirSync(plainDir, { recursive: true });
+    setGitShowToplevelProbeForTests(undefined);
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    if (originalLcAll === undefined) delete process.env.LC_ALL;
+    else process.env.LC_ALL = originalLcAll;
+    setGitShowToplevelProbeForTests(undefined);
+    clearWorktreeCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('classifies a localized "not a git repository" answer as not_a_repository, not probe_failed', () => {
+    if (process.platform === 'win32') return; // fake git is a POSIX shell script
+    const bin = installLocaleAwareFakeGit(tempDir);
+    process.env.PATH = `${bin}${delimiter}${originalPath ?? ''}`;
+
+    const result = probeGitTopLevel(plainDir);
+
+    expect(result.status).toBe('not_a_repository');
+  });
+});

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -234,6 +234,10 @@ function resolveSuperprojectRoot(cwd: string): string | null {
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
         timeout: 5000,
+        // Force English error text so isDefinitiveNonGitError's stderr match is
+        // locale-independent (localized git output otherwise fails to match
+        // and mis-classifies a plain "not a repository" as a generic failure).
+        env: { ...process.env, LC_ALL: 'C' },
       }).trim();
     } catch (error) {
       completed = depth === 0 && isDefinitiveNonGitError(error);
@@ -622,6 +626,11 @@ function runGitShowToplevel(cwd: string): string {
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true,
     timeout: 5000,
+    // Force English error text so isNotAGitRepositoryError's stderr match is
+    // locale-independent (localized git output otherwise fails to match and
+    // mis-classifies a plain "not a repository" as probe_failed, which then
+    // fails closed and breaks callers such as the HUD statusline).
+    env: { ...process.env, LC_ALL: 'C' },
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #3978: the HUD statusline (and any other caller that relies on git-repo detection) fails with a hard error when the working directory is not a git repository **and** the system locale is not English.

`isNotAGitRepositoryError()` / `isDefinitiveNonGitError()` in `src/lib/worktree-paths.ts` classify a `git rev-parse` failure as "not a repository" by matching the English stderr text (`/not a git repository/i`). Under a non-English locale, git's gettext layer localizes that message (e.g. Korean: `"깃 저장소가 아닙니다"`), the regex doesn't match, and the probe is misclassified as `probe_failed` instead of `not_a_repository`. That status is treated as an untrustworthy generic failure per the fail-closed contract from #3858/#3864, so `validateWorkingDirectory()` throws for what is really just an ordinary "not in a git repo" case.

## Fix

Force `LC_ALL=C` on the two git spawns whose stderr is parsed for this classification (`runGitShowToplevel` and the `--show-superproject-working-tree` probe in `resolveSuperprojectRoot`), so the canonical English string is always present regardless of the caller's locale. This does not touch the fail-closed contract itself — a genuinely untrustworthy/generic git failure still fails closed exactly as before; only the "this really is just not a repository" classification becomes locale-independent. The spread (`env: { ...process.env, LC_ALL: 'C' }`) inherits the same environment every other spawn in this file already gets — no new variables are exposed to the child process.

## Test plan

- [x] New regression test (`src/lib/__tests__/worktree-paths-git-probe-locale.test.ts`) installs a fake `git` on `PATH` that prints a localized "not a git repository" message unless invoked with `LC_ALL=C`, with the ambient `process.env.LC_ALL` set to `ko_KR.UTF-8` to simulate a non-English session. Asserts `probeGitTopLevel()` still returns `not_a_repository`. Verified it fails on unfixed `worktree-paths.ts` (reverse-applied this diff) and passes with it.
- [x] End-to-end repro on the actual built HUD entrypoint (`dist/hud/index.js`), piping a real Claude Code statusline payload from a non-git directory with `LC_ALL=ko_KR.UTF-8` set for the whole process: unfixed build prints `[OMC] HUD error - check stderr`, fixed build renders the normal statusline.
- [x] Regression check: a git repo whose path contains non-ASCII (Korean) characters still resolves normally (`status: 'ok'`) with `LC_ALL=C` forced on the probe — the fix doesn't affect path handling for legitimate repos.
- [x] `npx tsc --noEmit -p .` — clean.
- [x] `npm run build` succeeds.
- [x] Existing `worktree-paths-git-probe-failclosed.test.ts` / `worktree-paths-foreign-root.test.ts` / `worktree-paths-toplevel-cache.test.ts`: run individually, each file's pass/fail set is identical before and after this change. A handful fail in isolation due to an unrelated `/tmp` → `/private/tmp` macOS symlink mismatch, reproducible identically on unmodified `upstream/dev`. (Running several of these files together in one process showed occasional order-dependent flakiness in both directions — pre-existing shared-state test isolation issue, unrelated to this change.)

Not touching `dist/` in this PR — happy to rebuild if the maintainer wants generated output included, but CI's generated-artifact authorization gate suggests that's base-only.

Refs #3978
