### PR TITLE
feat(hooks): make the SessionStart context budget configurable via OMC_SESSION_START_CONTEXT_BUDGET

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -123,6 +123,7 @@ If both configurations exist, **project-scoped takes precedence** over global:
 | `OMC_DISABLE_MULTIREPO`    | _(unset)_            | Set to `1` to disable workspace-marker resolution and fall back to git-root + cwd resolution order. `OMC_STATE_DIR` is still honoured. See [Rollback / disable multi-repo](#rollback--disable-multi-repo-omc_disable_multirepo) below.                                       |
 | `DISABLE_OMC`              | _(unset)_            | Set to `1` or `true` to disable all OMC hooks |
 | `OMC_SKIP_HOOKS`           | _(unset)_            | Comma-separated list of hook names to skip                                                                                                                                                                                                                                  |
+| `OMC_SESSION_START_CONTEXT_BUDGET` | `6000`       | Character budget shared by everything the SessionStart hook injects (mode restores, notepad Priority Context, root `AGENTS.md`, pending tasks). Raise it when a large `AGENTS.md` arrives truncated; lower it to spend less context. Positive integer; other values fall back to the default |
 
 #### Centralized State with `OMC_STATE_DIR`
 

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "8d7d867f1a2119bec8f200e6edb949161edd18b0",
-    "sourceSha256": "2cc9c41ffd2b1e12f640dbcfaf492c3592553ffce139cf0ae6bcb87b8c708e56",
+    "head": "0c3d113b0f27c11f2b9d9af6d606f3987d75c3fb",
+    "sourceSha256": "1abdcff843a775bb147ee1ae29dd0d2de853e1d1a464ffcbc280813c7d56d7e8",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "8d7d867f1a2119bec8f200e6edb949161edd18b0",
-  "sourceSha256": "2cc9c41ffd2b1e12f640dbcfaf492c3592553ffce139cf0ae6bcb87b8c708e56",
+  "head": "0c3d113b0f27c11f2b9d9af6d606f3987d75c3fb",
+  "sourceSha256": "1abdcff843a775bb147ee1ae29dd0d2de853e1d1a464ffcbc280813c7d56d7e8",
   "counts": {
     "public": {
       "skills": 37,
@@ -28,8 +28,8 @@
       "toolFiles": 61,
       "libFiles": 41,
       "templateHooks": 21,
-      "srcFiles": 1333,
-      "total": 1354
+      "srcFiles": 1334,
+      "total": 1355
     },
     "generated": {
       "distFiles": 4986,
@@ -34975,6 +34975,11 @@
         "path": "src/__tests__/session-start-cache-cleanup.test.ts"
       },
       {
+        "id": "src/__tests__/session-start-context-budget.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/session-start-context-budget.test.ts"
+      },
+      {
         "id": "src/__tests__/session-start-precompact-restore.test.ts",
         "kind": "src",
         "path": "src/__tests__/session-start-precompact-restore.test.ts"
@@ -48344,6 +48349,36 @@
       {
         "from": "src/__tests__/session-start-cache-cleanup.test.ts",
         "to": "src/utils/paths.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-context-budget.test.ts",
+        "to": "external:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-context-budget.test.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-context-budget.test.ts",
+        "to": "external:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-context-budget.test.ts",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-context-budget.test.ts",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/session-start-context-budget.test.ts",
+        "to": "external:vitest",
         "kind": "imports"
       },
       {
@@ -77588,12 +77623,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6898,
-      "edgeCount": 7354,
-      "importEdgeCount": 6052,
+      "nodeCount": 6899,
+      "edgeCount": 7360,
+      "importEdgeCount": 6058,
       "registerEdgeCount": 58
     }
   },
-  "inventorySha256": "583f179d4fdbbaead6ed6d536ba1a05dbafb052238a87f4248775a0abfb749a3",
-  "manifestSha256": "f1d142df6f3f2878bdd40c713d16bd1d3c6e060c1cf73846c98251a8a20827e7"
+  "inventorySha256": "122797c89fe2040473c5962be4ff080f6ff5e58a3557b70241ac5674f39f9fec",
+  "manifestSha256": "6e320c6fe3c141e07333baf058a7c92dd024097e73fd94b06c3bcf8cacc06cee"
 }

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -399,8 +399,22 @@ function semverCompare(a, b) {
   return 0;
 }
 
-const SESSION_START_CONTEXT_BUDGET = 6000;
-const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
+const DEFAULT_SESSION_START_CONTEXT_BUDGET = 6000;
+
+// Aggregate character budget shared by everything SessionStart injects.
+// Override with OMC_SESSION_START_CONTEXT_BUDGET (positive integer). Any other
+// value falls back to the default so a bad setting can never blank the context.
+function resolveSessionStartContextBudget() {
+  const raw = (process.env.OMC_SESSION_START_CONTEXT_BUDGET || '').trim();
+  if (!raw) return DEFAULT_SESSION_START_CONTEXT_BUDGET;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_START_CONTEXT_BUDGET;
+}
+
+function sessionStartOmissionNotice(budget) {
+  return `[Additional SessionStart context omitted to preserve the ${budget}-character aggregate budget.]`;
+}
+
 const SESSION_STARTED_MARKER_FILE = 'session-started.json';
 const SAFE_SESSION_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$/;
 const LINUX_BOOT_ID_PATH = '/proc/sys/kernel/random/boot_id';
@@ -557,17 +571,18 @@ function buildSessionStartAdditionalContext(messages) {
   const ordered = [...prioritized.sort((a, b) => a.score - b.score || a.index - b.index), ...remaining]
     .map((entry) => entry.message);
 
+  const budget = resolveSessionStartContextBudget();
   let used = 0;
   const selected = [];
   for (const message of ordered) {
     const separator = selected.length > 0 ? 1 : 0;
-    if (used + separator + message.length > SESSION_START_CONTEXT_BUDGET) {
-      const remainingBudget = SESSION_START_CONTEXT_BUDGET - used - separator;
+    if (used + separator + message.length > budget) {
+      const remainingBudget = budget - used - separator;
       if (remainingBudget > 0) {
         selected.push(
           remainingBudget > 120
             ? compactBudgetedText(message, remainingBudget)
-            : compactBudgetedText(SESSION_START_OMISSION_NOTICE, remainingBudget),
+            : compactBudgetedText(sessionStartOmissionNotice(budget), remainingBudget),
         );
       }
       break;

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -639,6 +639,53 @@ ${'- preserve this startup guidance\n'.repeat(400)}
     expect((result.message || '').length).toBeLessThanOrEqual(6000);
   });
 
+  it('honors OMC_SESSION_START_CONTEXT_BUDGET so a large root AGENTS.md can arrive whole', async () => {
+    const sentinel = 'END-OF-AGENTS-MD-SENTINEL';
+    writeFileSync(
+      join(testDir, 'AGENTS.md'),
+      `# Project orientation\n\n${'- a plain orientation line that is not OMC guidance\n'.repeat(160)}\n${sentinel}\n`,
+    );
+    const previous = process.env.OMC_SESSION_START_CONTEXT_BUDGET;
+    try {
+      delete process.env.OMC_SESSION_START_CONTEXT_BUDGET;
+      const truncated = await processHook('session-start', { sessionId, directory: testDir });
+      expect(truncated.continue).toBe(true);
+      expect((truncated.message || '').length).toBeLessThanOrEqual(6000);
+      expect(truncated.message || '').toContain('[truncated to preserve SessionStart context budget]');
+      expect(truncated.message || '').not.toContain(sentinel);
+
+      process.env.OMC_SESSION_START_CONTEXT_BUDGET = '20000';
+      const full = await processHook('session-start', { sessionId, directory: testDir });
+      expect(full.continue).toBe(true);
+      expect(full.message || '').toContain('[ROOT AGENTS.md LOADED]');
+      expect(full.message || '').toContain(sentinel);
+      expect(full.message || '').not.toContain('[truncated to preserve SessionStart context budget]');
+    } finally {
+      if (previous === undefined) delete process.env.OMC_SESSION_START_CONTEXT_BUDGET;
+      else process.env.OMC_SESSION_START_CONTEXT_BUDGET = previous;
+    }
+  });
+
+  it('falls back to the default budget when OMC_SESSION_START_CONTEXT_BUDGET is not a positive integer', async () => {
+    writeFileSync(
+      join(testDir, 'AGENTS.md'),
+      `# Project orientation\n\n${'- a plain orientation line that is not OMC guidance\n'.repeat(160)}\n`,
+    );
+    const previous = process.env.OMC_SESSION_START_CONTEXT_BUDGET;
+    try {
+      for (const invalid of ['abc', '0', '-500', '12.5', '']) {
+        process.env.OMC_SESSION_START_CONTEXT_BUDGET = invalid;
+        const result = await processHook('session-start', { sessionId, directory: testDir });
+        expect(result.continue).toBe(true);
+        expect((result.message || '').length).toBeLessThanOrEqual(6000);
+        expect(result.message || '').toContain('[truncated to preserve SessionStart context budget]');
+      }
+    } finally {
+      if (previous === undefined) delete process.env.OMC_SESSION_START_CONTEXT_BUDGET;
+      else process.env.OMC_SESSION_START_CONTEXT_BUDGET = previous;
+    }
+  });
+
   it('keeps combined session-start restore context under aggregate budget', async () => {
     writeFileSync(
       join(testDir, '.omc', 'state', 'sessions', sessionId, 'team-state.json'),

--- a/src/__tests__/session-start-context-budget.test.ts
+++ b/src/__tests__/session-start-context-budget.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const NODE = process.execPath;
+const HOOK_SCRIPTS: Array<[string, string]> = [
+  ["plugin", join(__dirname, "..", "..", "scripts", "session-start.mjs")],
+  [
+    "template",
+    join(__dirname, "..", "..", "templates", "hooks", "session-start.mjs"),
+  ],
+];
+const TRUNCATION_NOTICE = "[truncated to preserve SessionStart context budget]";
+const SENTINEL = "END-OF-PRIORITY-CONTEXT-SENTINEL";
+
+function runHook(
+  script: string,
+  project: string,
+  home: string,
+  extraEnv: Record<string, string>,
+): string {
+  const stdout = execFileSync(NODE, [script], {
+    input: JSON.stringify({
+      hook_event_name: "SessionStart",
+      source: "startup",
+      session_id: "budget-env",
+      cwd: project,
+    }),
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      OMC_NOTIFY: "0",
+      ...extraEnv,
+    },
+    timeout: 15000,
+  });
+  const parsed = JSON.parse(stdout) as {
+    hookSpecificOutput?: { additionalContext?: string };
+  };
+  return parsed.hookSpecificOutput?.additionalContext || "";
+}
+
+describe.each(HOOK_SCRIPTS)(
+  "%s session-start.mjs honors OMC_SESSION_START_CONTEXT_BUDGET",
+  (_label, script) => {
+    let root: string;
+    let project: string;
+    let home: string;
+
+    beforeEach(() => {
+      root = mkdtempSync(join(tmpdir(), "omc-budget-env-"));
+      project = join(root, "project");
+      home = join(root, "home");
+      mkdirSync(join(project, ".omc"), { recursive: true });
+      mkdirSync(home, { recursive: true });
+      execFileSync("git", ["init", "--quiet"], {
+        cwd: project,
+        stdio: "ignore",
+      });
+      // 7,000 chars of Priority Context: over the default 6,000-char aggregate budget on its own.
+      writeFileSync(
+        join(project, ".omc", "notepad.md"),
+        `## Priority Context\n${"- keep this priority line\n".repeat(280)}${SENTINEL}\n`,
+        "utf-8",
+      );
+    });
+
+    afterEach(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it("truncates to the 6000-char default when the variable is unset", () => {
+      const context = runHook(script, project, home, {
+        OMC_SESSION_START_CONTEXT_BUDGET: "",
+      });
+      expect(context.length).toBeLessThanOrEqual(6000);
+      expect(context).toContain(TRUNCATION_NOTICE);
+      expect(context).not.toContain(SENTINEL);
+    });
+
+    it("delivers the whole context when the variable raises the budget", () => {
+      const context = runHook(script, project, home, {
+        OMC_SESSION_START_CONTEXT_BUDGET: "20000",
+      });
+      expect(context).toContain(SENTINEL);
+      expect(context).not.toContain(TRUNCATION_NOTICE);
+    });
+
+    it("ignores values that are not positive integers", () => {
+      for (const invalid of ["abc", "0", "-500", "12.5"]) {
+        const context = runHook(script, project, home, {
+          OMC_SESSION_START_CONTEXT_BUDGET: invalid,
+        });
+        expect(context.length).toBeLessThanOrEqual(6000);
+        expect(context).toContain(TRUNCATION_NOTICE);
+      }
+    });
+  },
+);

--- a/src/hooks/bridge.ts
+++ b/src/hooks/bridge.ts
@@ -187,8 +187,24 @@ const MODE_CONFIRMATION_SKILL_MAP: Record<string, string[]> = {
   ralplan: ["ralplan"],
 };
 
-const SESSION_START_CONTEXT_BUDGET = 6000;
-const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
+const DEFAULT_SESSION_START_CONTEXT_BUDGET = 6000;
+
+/**
+ * Aggregate character budget shared by everything SessionStart injects.
+ * Override with OMC_SESSION_START_CONTEXT_BUDGET (positive integer). Any other
+ * value falls back to the default so a bad setting can never blank the context.
+ */
+function resolveSessionStartContextBudget(): number {
+  const raw = process.env.OMC_SESSION_START_CONTEXT_BUDGET?.trim();
+  if (!raw) return DEFAULT_SESSION_START_CONTEXT_BUDGET;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_START_CONTEXT_BUDGET;
+}
+
+function sessionStartOmissionNotice(budget: number): string {
+  return `[Additional SessionStart context omitted to preserve the ${budget}-character aggregate budget.]`;
+}
+
 const SESSION_STARTED_MARKER_FILE = "session-started.json";
 const LINUX_BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id";
 
@@ -227,17 +243,18 @@ function buildSessionStartAdditionalContext(messages: string[]): string {
     .sort((a, b) => a.priority - b.priority || a.index - b.index)
     .map((entry) => entry.message);
 
+  const budget = resolveSessionStartContextBudget();
   let used = 0;
   const selected: string[] = [];
   for (const message of ordered) {
     const separatorLength = selected.length > 0 ? 1 : 0;
-    if (used + separatorLength + message.length > SESSION_START_CONTEXT_BUDGET) {
-      const remainingBudget = SESSION_START_CONTEXT_BUDGET - used - separatorLength;
+    if (used + separatorLength + message.length > budget) {
+      const remainingBudget = budget - used - separatorLength;
       if (remainingBudget > 0) {
         selected.push(
           remainingBudget > 120
             ? compactBudgetedText(message, remainingBudget)
-            : compactBudgetedText(SESSION_START_OMISSION_NOTICE, remainingBudget),
+            : compactBudgetedText(sessionStartOmissionNotice(budget), remainingBudget),
         );
       }
       break;

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -286,8 +286,21 @@ const OMC_STARTUP_COMPACTABLE_SECTIONS = [
   'team_compositions',
 ];
 const OMC_STARTUP_GUIDANCE_MAX_CHARS = 8000;
-const SESSION_START_CONTEXT_BUDGET = 6000;
-const SESSION_START_OMISSION_NOTICE = '[Additional SessionStart context omitted to preserve the 6000-character aggregate budget.]';
+const DEFAULT_SESSION_START_CONTEXT_BUDGET = 6000;
+
+// Aggregate character budget shared by everything SessionStart injects.
+// Override with OMC_SESSION_START_CONTEXT_BUDGET (positive integer). Any other
+// value falls back to the default so a bad setting can never blank the context.
+function resolveSessionStartContextBudget() {
+  const raw = (process.env.OMC_SESSION_START_CONTEXT_BUDGET || '').trim();
+  if (!raw) return DEFAULT_SESSION_START_CONTEXT_BUDGET;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_START_CONTEXT_BUDGET;
+}
+
+function sessionStartOmissionNotice(budget) {
+  return `[Additional SessionStart context omitted to preserve the ${budget}-character aggregate budget.]`;
+}
 
 const { MODEL_ROUTING_OVERRIDE_MESSAGE } = await import(pathToFileURL(join(__dirname, 'lib', 'model-routing-override-message.mjs')).href);
 
@@ -427,17 +440,18 @@ function buildSessionStartAdditionalContext(messages) {
   const ordered = [...prioritized.sort((a, b) => a.score - b.score || a.index - b.index), ...remaining]
     .map((entry) => entry.message);
 
+  const budget = resolveSessionStartContextBudget();
   let used = 0;
   const selected = [];
   for (const message of ordered) {
     const separator = selected.length > 0 ? 1 : 0;
-    if (used + separator + message.length > SESSION_START_CONTEXT_BUDGET) {
-      const remainingBudget = SESSION_START_CONTEXT_BUDGET - used - separator;
+    if (used + separator + message.length > budget) {
+      const remainingBudget = budget - used - separator;
       if (remainingBudget > 0) {
         selected.push(
           remainingBudget > 120
             ? compactBudgetedText(message, remainingBudget)
-            : compactBudgetedText(SESSION_START_OMISSION_NOTICE, remainingBudget),
+            : compactBudgetedText(sessionStartOmissionNotice(budget), remainingBudget),
         );
       }
       break;


### PR DESCRIPTION
## Why

Everything the SessionStart hook injects — mode restores, notepad Priority Context, root `AGENTS.md`, pending tasks — shares one hard-coded 6000-character budget, and whichever message overflows is cut mid-text with `...[truncated to preserve SessionStart context budget]`. Root `AGENTS.md` sorts last in `templates/hooks/session-start.mjs`, so on a real project it arrived 47% complete in a bare session (cut inside a table) and 33% with a 1.5 KB Priority Context ahead of it; the sections after the cut never reached any session. `src/hooks/bridge.ts` caps `AGENTS.md` at 20,000 chars, but the 6000 aggregate makes that cap unreachable. There is no knob: the constant lives in three files and only `OMC_SKIP_HOOKS` exists.

## How

- `OMC_SESSION_START_CONTEXT_BUDGET` (positive integer) overrides the aggregate budget. Unset, empty, or invalid values keep the 6000 default, so a bad setting can never blank the context.
- Applied identically to the three parallel implementations: `src/hooks/bridge.ts`, `scripts/session-start.mjs`, `templates/hooks/session-start.mjs`. The omission notice reports the effective budget instead of a hard-coded "6000-character".
- One row added to `docs/REFERENCE.md` → Environment Variables.
- No default behaviour changes.

## Repro

```bash
# any project whose AGENTS.md or notepad Priority Context exceeds ~6 KB
payload=$(printf '{"cwd":"%s","session_id":"repro","hook_event_name":"SessionStart"}' "$PWD")

echo "$payload" | node ~/.claude/hooks/session-start.mjs \
  | jq -r '.hookSpecificOutput.additionalContext' | tail -c 120
# → …[truncated to preserve SessionStart context budget]

echo "$payload" | OMC_SESSION_START_CONTEXT_BUDGET=20000 node ~/.claude/hooks/session-start.mjs \
  | jq -r '.hookSpecificOutput.additionalContext' | tail -c 120
# → the end of the file
```

## Tests

- `src/__tests__/hooks.test.ts`: the bridge honours the override (a large root `AGENTS.md` arrives whole, truncation notice gone) and falls back for `abc`, `0`, `-500`, `12.5`, and empty.
- `src/__tests__/session-start-context-budget.test.ts`: spawns both `scripts/` and `templates/hooks/` copies with a 7 KB Priority Context — default truncates, override delivers, invalid values fall back.
- `npm run lint` and `tsc --noEmit` clean; the touched suites pass (`hooks.test.ts`, `session-start-context-budget.test.ts`, `session-start-precompact-restore.test.ts`, `session-start-background-output.test.ts`).
- Full `npm run test:run` on this macOS host has pre-existing failures unrelated to this change (darwin-only directory-FD traversal, `/proc` reads, tmpdir realpath, a shallow-clone ancestry check): 548 failing tests on untouched `dev`, 529 with this branch; the failing files that mention session-start fail identically on both.
- `inventory/inventory-graph.json` regenerated with `npm run generate:inventory` (separate commit), as `generate:inventory:verify` requires after touching inventoried sources.
- `npm run format` not run: `bridge.ts` and `hooks.test.ts` were already not prettier-clean before this change, so reformatting them would bury the diff; the new test file is prettier-clean.

## Noticed, not changed

- `templates/hooks/session-start.mjs` has no `[ROOT AGENTS.md LOADED]` entry in its `priorityOrder`, unlike `src/hooks/bridge.ts`.
- The bridge's `MAX_AGENTS_CHARS = 20000` can never take effect under the 6000 aggregate.

Both left alone to keep this change minimal; happy to follow up if wanted.
