### PR TITLE
docs: replace retired mode references with the shipped 5.3.0 surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,17 +17,17 @@ oh-my-claudecode enables Claude Code to orchestrate specialized agents through a
        │                                │                              │
        ▼                                ▼                              ▼
 ┌─────────────┐              ┌──────────────────┐           ┌─────────────────┐
-│  "ultrawork │              │   CLAUDE.md      │           │ SKILL ACTIVATED │
+│  "team      │              │   CLAUDE.md      │           │ SKILL ACTIVATED │
 │   refactor  │─────────────▶│   Auto-Routing   │──────────▶│                 │
-│   the API"  │              │                  │           │ ultrawork +     │
-└─────────────┘              │ Task Type:       │           │ default +       │
+│   the API"  │              │                  │           │ team + execute  │
+└─────────────┘              │ Task Type:       │           │                 │
                              │  - Implementation│           │ git-master      │
                              │  - Multi-file    │           │                 │
                              │  - Parallel OK   │           │ ┌─────────────┐ │
                              │                  │           │ │ Parallel    │ │
                              │ Skills:          │           │ │ agents      │ │
-                             │  - ultrawork ✓   │           │ │ launched    │ │
-                             │  - default ✓     │           │ └─────────────┘ │
+                             │  - team ✓       │           │ │ launched    │ │
+                             │  - execute ✓    │           │ └─────────────┘ │
                              │  - git-master ✓  │           │                 │
                              └──────────────────┘           │ ┌─────────────┐ │
                                                             │ │ Atomic      │ │
@@ -175,7 +175,7 @@ explore --> analyst --> planner --> critic --> executor --> verifier
 
 ### Overview
 
-Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 31 skills total (28 user-invocable + 3 internal/pipeline).
+Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 37 shipped skills.
 
 ### Skill Layers
 
@@ -190,13 +190,13 @@ Skills compose in three layers:
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  ENHANCEMENT LAYER (0-N skills)                              │
-│  ultrawork (parallel) | git-master (commits) | frontend-ui-ux│
+│  team (parallel) | git-master (commits) | execute          │
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  EXECUTION LAYER (primary skill)                             │
-│  default (build) | orchestrate (coordinate) | planner (plan) │
+│  execute (approved work) | autopilot (end to end) | planner (plan) │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -204,8 +204,8 @@ Skills compose in three layers:
 
 Example:
 ```
-Task: "ultrawork: refactor API with proper commits"
-Active skills: ultrawork + default + git-master
+Task: "team: refactor API with proper commits"
+Active skills: team + execute + git-master
 ```
 
 ### How to Invoke Skills
@@ -217,11 +217,11 @@ Active skills: ultrawork + default + git-master
 /oh-my-claudecode:team 3:executor "implement fullstack app"
 ```
 
-**Magic keywords** — include a keyword in natural language and the skill activates automatically:
+**Magic keywords** — include a keyword in natural language and the skill activates automatically; parallel team work and approved execution use explicit slash commands:
 ```bash
 autopilot build me a todo app      # activates autopilot
 ralph: refactor the auth module    # activates ralph
-ultrawork implement OAuth          # activates ultrawork
+/oh-my-claudecode:team 3:executor "implement OAuth"  # explicit parallel team skill
 ```
 
 ### Core Workflow Skills
@@ -240,24 +240,18 @@ Repeating loop that does not stop until work is verified complete. The `verifier
 ralph: refactor the authentication module
 ```
 
-#### ultrawork
-Maximum parallelism — launches multiple agents simultaneously.
-- Trigger: `ultrawork`, `ulw`
+#### execute
+Carries an approved task through to working, verified code.
+- Manual command: `/oh-my-claudecode:execute`
 ```bash
-ultrawork implement user authentication with OAuth
+/oh-my-claudecode:execute implement user authentication with OAuth
 ```
 
 #### team
-Coordinates N Claude agents with a 5-stage pipeline: `plan → prd → exec → verify → fix`
+Coordinates N Claude agents with a 5-stage pipeline: `plan → prd → exec → verify → fix`.
+Use the implicit Claude Code agent team with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`; each teammate is spawned through the Agent/Task tool with a distinct `name` value.
 ```bash
 /oh-my-claudecode:team 3:executor "implement fullstack todo app"
-```
-
-#### ccg (Claude-Codex-Gemini)
-Fans out to Codex and Antigravity simultaneously; Claude synthesizes the results. Gemini remains available as an enterprise/API-key fallback when using the legacy Gemini CLI.
-- Trigger: `ccg`, `claude-codex-gemini`
-```bash
-ccg: review this authentication implementation
 ```
 
 #### ralplan
@@ -275,25 +269,23 @@ ralplan this feature
 | `hud` | Status bar configuration | `/oh-my-claudecode:hud` |
 | `omc-setup` | Initial setup wizard | `/oh-my-claudecode:omc-setup` |
 | `omc-doctor` | Diagnose installation | `/oh-my-claudecode:omc-doctor` |
-| `skillify` | Extract reusable skills from session | `/oh-my-claudecode:skillify` (`learner` deprecated alias) |
+| `skillify` | Extract reusable skills from session | `/oh-my-claudecode:skillify` |
 | `skill` | Manage local skills (list/add/remove) | `/oh-my-claudecode:skill` |
 | `trace` | Evidence-driven causal tracing | `/oh-my-claudecode:trace` |
 | `release` | Automated release workflow | `/oh-my-claudecode:release` |
 | `deepinit` | Generate hierarchical AGENTS.md | `/oh-my-claudecode:deepinit` |
 | `deep-interview` | Socratic deep interview | `/deep-interview` |
-| `sciomc` | Parallel scientist agent orchestration | `/oh-my-claudecode:sciomc` |
+| `research` | Investigate an open question and return grounded findings | `/oh-my-claudecode:research` |
 | `external-context` | Parallel document-specialist research | `/oh-my-claudecode:external-context` |
 | `ai-slop-cleaner` | Clean AI expression patterns | `/oh-my-claudecode:ai-slop-cleaner` |
-| `writer-memory` | Memory system for writing projects | `/oh-my-claudecode:writer-memory` |
+| `configure-notifications` | Configure Telegram, Discord, and Slack notification integrations | `/oh-my-claudecode:configure-notifications` |
 
 ### Magic Keyword Reference
 
 | Keyword | Effect |
 |---------|--------|
-| `ultrawork`, `ulw`, `uw` | Parallel agent orchestration |
 | `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `e2e this` | Autonomous execution pipeline |
 | `ralph`, `don't stop`, `must complete`, `until done` | Loop until verified complete |
-| `ccg`, `claude-codex-gemini` | 3-model orchestration (use `antigravity` workers when using the Antigravity CLI) |
 | `ralplan` | Consensus-based planning |
 | `deep interview`, `ouroboros` | Socratic deep interview |
 | `code review`, `review code` | Comprehensive code review mode |
@@ -305,16 +297,18 @@ ralplan this feature
 | `deslop`, `anti-slop` | AI expression cleanup |
 | `cancelomc`, `stopomc` | Cancel active execution mode |
 
+Parallel work is not a magic keyword; invoke `/oh-my-claudecode:team` explicitly. Use `/oh-my-claudecode:execute` to carry an approved task through verified code.
+
 ### Keyword Detection Sources
 
 Keywords are processed in two places:
 
 | Source | Role | Customizable |
 |--------|------|--------------|
-| `config.jsonc` `magicKeywords` | 4 categories (ultrawork, search, analyze, ultrathink) | Yes |
-| `keyword-detector` hook | 11+ triggers (autopilot, ralph, ccg, etc.) | No |
+| `config.jsonc` `magicKeywords` | Supported search, analyze, and ultrathink categories | Yes |
+| `keyword-detector` hook | Hardcoded triggers such as autopilot and ralph | No |
 
-The `autopilot`, `ralph`, and `ccg` triggers are hardcoded in the hook and cannot be changed through config.
+The `autopilot` and `ralph` triggers are hardcoded in the hook and cannot be changed through config.
 
 ---
 
@@ -359,13 +353,13 @@ Injected pattern meanings:
 | `hook success: Success` | Hook ran normally, continue as planned |
 | `hook additional context: ...` | Additional context information, take note |
 | `[MAGIC KEYWORD: ...]` | Magic keyword detected, execute indicated skill |
-| `The boulder never stops` | ralph/ultrawork mode is active |
+| `The boulder never stops` | An active persistent execution workflow is running |
 
 ### Key Hooks
 
 **keyword-detector** — fires on `UserPromptSubmit`. Detects magic keywords in user input and activates the corresponding skill.
 
-**persistent-mode** — fires on `Stop`. When a persistent mode (ralph, ultrawork) is active, prevents Claude from stopping until work is verified complete.
+**persistent-mode** — fires on `Stop`. When a persistent mode (ralph, team) is active, prevents Claude from stopping until work is verified complete.
 
 **pre-compact** — fires on `PreCompact`. Saves critical information (active modes, TODOs, background jobs, and durable plan anchors: PRD/boulder references) to a checkpoint before the context window is compressed. The `SessionStart` hook restores the newest matching checkpoint when `source === "compact"`, so plan detail survives auto-compaction (issue #3730).
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -65,7 +65,7 @@ npm i -g oh-my-claude-sisyphus@latest
 > yet. The warning is tracked in [#2913](https://github.com/Yeachan-Heo/oh-my-claudecode/issues/2913)
 > and does not by itself mean the OMC CLI install failed.
 
-Both can be installed at the same time. The CLI auto-detects the plugin install and will not double-register skills under `~/.claude/skills/` (if you previously hit the duplicate-skill bug, run `omc update` once on 4.11.2+ — it self-heals leftover standalone skills that the plugin now provides via `prunePluginDuplicateSkills`).
+Both can be installed at the same time. The CLI auto-detects the plugin install and will not double-register skills under `~/.claude/skills/` (if you previously hit the duplicate-skill bug, run `omc update` once on 5.3.0+ — it self-heals leftover standalone skills that the plugin now provides via `prunePluginDuplicateSkills`).
 
 ### Step 3: Run initial setup
 
@@ -220,7 +220,7 @@ To configure the HUD display, run:
 
 ### Starting smaller
 
-If autopilot feels too large, start with a single-task command:
+If autopilot feels too large, start with a focused skill:
 
 ```bash
 # Code analysis
@@ -229,11 +229,11 @@ analyze why this test is failing
 # File search
 deepsearch for files that handle authentication
 
-# Simple implementation
-ultrawork add a health check endpoint
+# Approved implementation task
+/oh-my-claudecode:execute add a health check endpoint
 ```
 
-These keywords invoke a single appropriate agent directly, without running the full pipeline.
+These surfaces invoke focused work without running the full autopilot pipeline. Use `/oh-my-claudecode:team` when the task needs parallel agents.
 
 ### Next steps
 
@@ -281,9 +281,8 @@ Defaults → User config (~/.config/claude-omc/config.jsonc)
     "astTools": true
   },
 
-  // Magic keyword customization
+  // Magic keyword customization for supported categories
   "magicKeywords": {
-    "ultrawork": ["ultrawork", "ulw", "uw"],
     "search": ["search", "find", "locate"],
     "analyze": ["analyze", "investigate", "examine"],
     "ultrathink": ["ultrathink", "think", "reason"]
@@ -361,14 +360,11 @@ You can change the AI model used by each agent:
 
 ### Customizing magic keywords
 
-You can change keywords in four categories via the `magicKeywords` section of `config.jsonc`:
+You can customize the supported search, analysis, and deep-reasoning categories via the `magicKeywords` section of `config.jsonc`:
 
 ```jsonc
 {
   "magicKeywords": {
-    // Triggers parallel execution mode
-    "ultrawork": ["ultrawork", "ulw", "parallel"],
-
     // Triggers codebase search mode
     "search": ["search", "find", "locate", "grep"],
 
@@ -381,7 +377,7 @@ You can change keywords in four categories via the `magicKeywords` section of `c
 }
 ```
 
-> ℹ️ **Note:** The `magicKeywords` section in `config.jsonc` only allows customizing four categories: `ultrawork`, `search`, `analyze`, and `ultrathink`. Keywords such as `autopilot`, `ralph`, and `ccg` are hardcoded in the keyword-detector hook and cannot be changed via config files.
+> ℹ️ **Note:** Parallel work is not configured as a magic keyword. Use `/oh-my-claudecode:team` for coordinated agents, or `/oh-my-claudecode:execute` to carry an approved task through verified implementation. Keywords such as `autopilot` and `ralph` are hardcoded in the keyword-detector hook and cannot be changed via config files.
 
 ### Model routing configuration
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -47,7 +47,7 @@ Handle orchestration, keyword detection, and mode persistence.
 | Hook | Description |
 |------|-------------|
 | keyword-detector | Detects magic keywords and activates corresponding skills |
-| persistent-mode | Enforces continuation when an execution mode (ralph, autopilot, ultrawork, etc.) is active — injects reinforcement messages on Stop to prevent premature halting |
+| persistent-mode | Enforces continuation when an execution mode (ralph, autopilot, team, etc.) is active — injects reinforcement messages on Stop to prevent premature halting |
 
 ### Context Management Hooks
 
@@ -101,7 +101,7 @@ Fires when the user submits a prompt.
 | `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 30s outer host fuse; 8s trusted Worker limit |
 | `skill-injector.mjs` | Injects skill prompts | 30s outer host fuse; 12s trusted Worker limit |
 
-Runs on all user input (`matcher: "*"`). When the keyword detector finds keywords like "ultrawork", "ralph", or "autopilot", it injects the corresponding skill invocation instruction via `additionalContext`.
+Runs on all user input (`matcher: "*"`). When the keyword detector finds keywords like "ralph" or "autopilot", it injects the corresponding skill invocation instruction via `additionalContext`. Parallel work is invoked explicitly with `/oh-my-claudecode:team` and is not auto-detected.
 
 The 30s timeout is a per-command outer host fuse that includes launcher startup before `run.cjs`. Once the runner reaches its exact trusted Worker branch, `keyword-detector.mjs` is limited to 8s and `skill-injector.mjs` to 12s; lower manifest limits are never extended. A command that never reaches `run.cjs` can consume its full 30s outer fuse. The host schedules the two commands externally, so this does not claim an aggregate prompt latency.
 
@@ -201,7 +201,7 @@ Fires when Claude finishes a response.
 |--------|------|---------|
 | `context-guard-stop.mjs` | Monitors context usage | 5s |
 | `workflow-drift-guard.mjs` | Blocks narrow structured-question and fake-completion drift | 3s |
-| `persistent-mode.mjs` | Maintains active mode state (ralph, ultrawork, etc.) | 10s |
+| `persistent-mode.mjs` | Maintains active mode state (ralph, team, etc.) | 10s |
 | `code-simplifier.mjs` | Auto-simplifies modified files (opt-in) | 5s |
 
 `persistent-mode` injects a reinforcement message like "The boulder never stops" when an active execution mode is running, prompting continued work. A fresh unconfirmed ultragoal is exempt while Claude `/goal` confirmation is pending; confirmed runs remain fail-closed.
@@ -228,7 +228,7 @@ Detects magic keywords in user prompts and invokes the corresponding skill.
 
 - **Event**: UserPromptSubmit
 - **Behavior**: Sanitizes the prompt (removes code blocks, URLs, file paths) then matches keyword patterns
-- **Conflict resolution**: cancel has highest priority, then ralph > autopilot > ultrawork
+- **Conflict resolution**: cancel has highest priority, then ralph > autopilot
 - **Safety**: Disabled inside team workers to prevent infinite spawning
 
 See the [Magic Keywords](#magic-keywords) section for the full keyword list.
@@ -263,26 +263,26 @@ Ambiguous-regex and malformed-ternary uncertainty is bounded to the current phys
 
 #### persistent-mode
 
-Enforces continuation when an execution mode is active. This is the hook that keeps skills like autopilot, ralph, and ultrawork running.
+Enforces continuation when an execution mode is active. This is the hook that keeps skills like autopilot, ralph, and team running.
 
 - **Event**: Stop
-- **Behavior**: Checks `.omc/state/` for active mode state files. If any mode (ralph, ultragoal, autopilot, ultrawork, team, pipeline) is active, injects a reinforcement message to prevent Claude from stopping.
+- **Behavior**: Checks `.omc/state/` for active mode state files. If any current mode (ralph, ultragoal, autopilot, team) or legacy/retired state (ultrawork, pipeline) is active, injects a reinforcement message to prevent Claude from stopping.
 - **Reinforcement message**: "The boulder never stops" — prompts Claude to continue working
 - **Staleness check**: States older than 2 hours are treated as inactive to prevent stale state from blocking new sessions
 - **Notification**: Sends Discord/Telegram/Slack notification on first stop (if configured)
 - **Cancel**: Use `/oh-my-claudecode:cancel` to deactivate modes
 
-> **Note**: autopilot, ralph, and ultrawork are **skills** (invoked via keyword-detector), not hooks. The persistent-mode hook is what enforces their continuation by blocking the Stop event.
+> **Note**: autopilot, ralph, and team are **skills** (invoked through their current skill surfaces), not hooks. Legacy/retired `ultrawork` and `pipeline` state is cleanup-only and must never be invoked or reactivated. The persistent-mode hook enforces continuation by blocking the Stop event.
 
 ### Mode State Management
 
-Execution mode hooks manage state files in the `.omc/state/` directory.
+Execution mode hooks manage state files in the `.omc/state/` directory. Current records use modes such as autopilot, ralph, team, and ultragoal; legacy fields such as `linked_ultrawork` may appear only for cleanup diagnostics and are not invocable modes.
 
 ```json
 {
   "active": true,
   "started_at": "2025-01-15T10:30:00Z",
-  "prompt": "ultrawork implement auth",
+  "prompt": "team 2:executor implement auth",
   "session_id": "abc123",
   "project_path": "/path/to/project",
   "iteration": 0,
@@ -318,7 +318,7 @@ or
 /oh-my-claudecode:cancel
 ```
 
-`cancel` removes state files for all active modes: ralph, autopilot, ultrawork, and any others.
+`cancel` removes state files for all active modes: ralph, autopilot, team, and any others; it also clears legacy/retired `ultrawork` state.
 
 ---
 
@@ -416,8 +416,6 @@ These keywords invoke a skill and create a state file.
 | `cancelomc`, `stopomc` | cancel | Cancels all active modes |
 | `ralph`, `don't stop`, `must complete`, `until done` | ralph | Persistent execution until verification completes |
 | `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `auto-pilot`, `full auto`, `fullsend`, `e2e this` | autopilot | Fully autonomous execution |
-| `ultrawork`, `ulw`, `uw` | ultrawork | Maximum parallel execution |
-| `ccg`, `claude-codex-gemini` | ccg | Claude-Codex-Gemini tri-model orchestration (use `antigravity` workers when using the Antigravity CLI) |
 | `ralplan` | ralplan | Consensus-based iterative planning |
 | `deep interview`, `ouroboros` | deep-interview | Socratic deep interview |
 
@@ -471,8 +469,6 @@ When multiple keywords are detected simultaneously, they resolve by the followin
 cancel  (highest priority, exclusive)
   → ralph
     → autopilot
-      → ultrawork
-        → ccg
           → ralplan
             → deep-interview
               → ai-slop-cleaner
@@ -484,7 +480,7 @@ cancel  (highest priority, exclusive)
                           → analyze
 ```
 
-`cancel` is exclusive — it ignores all other matches and only runs the cancel action. All other keywords can be matched together and are processed in priority order.
+`cancel` is exclusive — it ignores all other matches and only runs the cancel action. All other keywords can be matched together and are processed in priority order. Team is not part of keyword priority; invoke `/oh-my-claudecode:team` explicitly for coordinated parallel work.
 
 ### Usage Examples
 
@@ -495,7 +491,7 @@ cancel  (highest priority, exclusive)
 autopilot: implement user authentication with OAuth
 
 # Parallel execution
-ultrawork write all tests for this module
+/oh-my-claudecode:team 3:executor "write all tests for this module"
 
 # Persistent execution
 ralph refactor this authentication module
@@ -512,7 +508,7 @@ stopomc
 
 ### Note on the `team` Keyword
 
-`team` is not auto-detected. It must be invoked explicitly via the `/team` slash command to prevent infinite spawning.
+`team` is not auto-detected. It must be invoked explicitly via `/oh-my-claudecode:team` to prevent infinite spawning.
 
 ```
 /oh-my-claudecode:team 3:executor "build a fullstack todo app"

--- a/docs/PERFORMANCE-MONITORING.md
+++ b/docs/PERFORMANCE-MONITORING.md
@@ -140,7 +140,7 @@ Replay data is stored at: `.omc/state/agent-replay-{sessionId}.jsonl`
 
 Each line is a JSON event:
 ```json
-{"t":0.0,"agent":"a1b2c3d","agent_type":"executor","event":"agent_start","task":"Implement feature","parent_mode":"ultrawork"}
+{"t":0.0,"agent":"a1b2c3d","agent_type":"executor","event":"agent_start","task":"Implement feature","parent_mode":"team"}
 {"t":5.2,"agent":"a1b2c3d","event":"tool_start","tool":"Read"}
 {"t":5.4,"agent":"a1b2c3d","event":"tool_end","tool":"Read","duration_ms":200,"success":true}
 ```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,6 +1,6 @@
 # Reference Documentation
 
-Complete reference for oh-my-claudecode. For quick start, see the main [README.md](../README.md).
+Complete reference for oh-my-claudecode. The 5.3.0 package ships 19 agents, 37 skills, and 21 commands, and its single configured MCP server exposes 55 tools. For quick start, see the main [README.md](../README.md).
 
 ---
 
@@ -12,7 +12,7 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [Plugin directory flags](#plugin-directory-flags)
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated-opt-in-only)
-- [Agents (29 Total)](#agents-29-total)
+- [Agents (19 Total)](#agents-19-total)
 - [Goal Workflow UX: `/goal`, Ralph, Team, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultragoal)
 - [Skills (37 Total)](#skills-37-total)
 - [Slash Commands](#slash-commands)
@@ -218,7 +218,7 @@ Once a workspace is anchored, multiple Claude Code sessions in different sub-rep
 
 **Only the `team` skill writes to `.omc/handoffs/`.** All other code that reads the directory does so read-only. This is enforced by the lint test `tests/lint/handoffs-writers.test.ts`, which scans `src/**` and `templates/**` and fails if any file outside `src/team/` or `src/hooks/team-pipeline/` references `handoffs/` as a write target.
 
-- Handoff files survive team cancellation and OMC state cleanup intentionally — they are post-mortem artifacts. Claude Code 2.1.178+ has no `TeamDelete`.
+- Handoff files survive team cancellation and OMC state cleanup intentionally — they are post-mortem artifacts. Claude Code 2.1.178+ removed native `TeamCreate`/`TeamDelete`; teams use the implicit agent team with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, spawning teammates through the Agent/Task tool with distinct `name` values.
 - Do **not** session-scope `.omc/handoffs/` unless the `team` skill explicitly evolves to per-session inboxes (tracked as a follow-up in the ADR).
 
 #### Branded path types (`ReadPath` / `WritePath`)
@@ -723,69 +723,57 @@ Bounded handoff policy:
 2. For larger payloads, pass a short summary plus the descriptor.
 3. Keep durable content in artifact paths such as `.omc/plans/`, `.omc/prompts/`, and related artifact stores rather than embedding full bodies into queue or status records.
 
-## Agents (29 Total)
+## Agents (19 Total)
 
 Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
 ### By Domain and Tier
 
-| Domain             | LOW (Haiku)             | MEDIUM (Sonnet)       | HIGH (Opus)         |
-| ------------------ | ----------------------- | --------------------- | ------------------- |
-| **Analysis**       | `architect-low`         | `architect-medium`    | `architect`         |
-| **Execution**      | `executor-low`          | `executor`            | `executor-high`     |
-| **Search**         | `explore`               | -                     | `explore-high`      |
-| **Research**       | -                       | `document-specialist` | -                   |
-| **Frontend**       | `designer-low`          | `designer`            | `designer-high`     |
-| **Docs**           | `writer`                | -                     | -                   |
-| **Visual**         | -                       | `vision`              | -                   |
-| **Planning**       | -                       | -                     | `planner`           |
-| **Critique**       | -                       | -                     | `critic`            |
-| **Pre-Planning**   | -                       | -                     | `analyst`           |
-| **Testing**        | -                       | `qa-tester`           | -                   |
-| **Tracing**        | -                       | `tracer`              | -                   |
-| **Security**       | `security-reviewer-low` | -                     | `security-reviewer` |
-| **Build**          | -                       | `debugger`            | -                   |
-| **TDD**            | -                       | `test-engineer`       | -                   |
-| **Code Review**    | -                       | -                     | `code-reviewer`     |
-| **Data Analysis** | -                       | `scientist`           | `scientist-high`    |
-| **Git**            | -                       | `git-master`          | -                   |
-| **Simplification** | -                       | -                     | `code-simplifier`   |
+| Domain | Agent(s) | Default model |
+| ------ | --------- | ------------- |
+| **Analysis** | `architect` | opus |
+| **Pre-planning** | `analyst` | opus |
+| **Planning** | `planner` | opus |
+| **Critique** | `critic` | opus |
+| **Execution** | `executor` | sonnet |
+| **Debugging** | `debugger` | sonnet |
+| **Verification** | `verifier` | sonnet |
+| **Tracing** | `tracer` | sonnet |
+| **Search** | `explore` | haiku |
+| **Research** | `document-specialist` | sonnet |
+| **Frontend** | `designer` | sonnet |
+| **Docs** | `writer` | haiku |
+| **Interactive QA** | `qa-tester` | sonnet |
+| **Testing** | `test-engineer` | sonnet |
+| **Security** | `security-reviewer` | sonnet |
+| **Code Review** | `code-reviewer` | opus |
+| **Data Analysis** | `scientist` | sonnet |
+| **Git** | `git-master` | sonnet |
+| **Simplification** | `code-simplifier` | opus |
 
 ### Agent Selection Guide
 
-| Task Type                      | Best Agent                                                             | Model  |
-| ------------------------------ | ---------------------------------------------------------------------- | ------ |
-| Quick code lookup              | `explore`                                                              | haiku  |
-| Find files/patterns            | `explore`                                                              | haiku  |
-| Complex architectural search   | `explore-high`                                                         | opus   |
-| Simple code change             | `executor-low`                                                         | haiku  |
-| Feature implementation         | `executor`                                                             | sonnet |
-| Complex refactoring            | `executor-high`                                                        | opus   |
-| Debug simple issue             | `architect-low`                                                        | haiku  |
-| Debug complex issue            | `architect`                                                            | opus   |
-| UI component                   | `designer`                                                             | sonnet |
-| Complex UI system              | `designer-high`                                                        | opus   |
-| Write docs/comments            | `writer`                                                               | haiku  |
-| Research docs/APIs             | `document-specialist` (repo docs first; optional Context Hub / `chub`) | sonnet |
-| Analyze images/diagrams        | `vision`                                                               | sonnet |
-| Strategic planning             | `planner`                                                              | opus   |
-| Review/critique plan           | `critic`                                                               | opus   |
-| Pre-planning analysis          | `analyst`                                                              | opus   |
-| Test CLI interactively         | `qa-tester`                                                            | sonnet |
-| Evidence-driven causal tracing | `tracer`                                                               | sonnet |
-| Security review                | `security-reviewer`                                                    | sonnet |
-| Quick security scan            | `security-reviewer-low`                                                | haiku  |
-| Fix build errors               | `debugger`                                                             | sonnet |
-| Simple build fix               | `debugger` (model=haiku)                                               | haiku  |
-| TDD workflow                   | `test-engineer`                                                        | sonnet |
-| Quick test suggestions         | `test-engineer` (model=haiku)                                          | haiku  |
-| Code review                    | `code-reviewer`                                                        | opus   |
-| Quick code check               | `code-reviewer` (model=haiku)                                          | haiku  |
-| Data analysis/stats            | `scientist`                                                            | sonnet |
-| Quick data inspection          | `scientist` (model=haiku)                                              | haiku  |
-| Deep data analysis            | `scientist-high`                                                       | opus   |
-| Git operations                 | `git-master`                                                           | sonnet |
-| Code simplification            | `code-simplifier`                                                      | opus   |
+| Task Type | Best Agent | Model |
+| ---------- | ---------- | ----- |
+| Codebase discovery and file mapping | `explore` | haiku |
+| Requirements analysis | `analyst` | opus |
+| System architecture and interfaces | `architect` | opus |
+| Strategic planning | `planner` | opus |
+| Plan or design critique | `critic` | opus |
+| Feature implementation | `executor` | sonnet |
+| Debugging and build errors | `debugger` | sonnet |
+| Completion verification | `verifier` | sonnet |
+| Evidence-driven tracing | `tracer` | sonnet |
+| UI component design | `designer` | sonnet |
+| Documentation | `writer` | haiku |
+| External docs/API research | `document-specialist` | sonnet |
+| Interactive CLI/service validation | `qa-tester` | sonnet |
+| Test strategy and coverage | `test-engineer` | sonnet |
+| Security review | `security-reviewer` | sonnet |
+| Code review | `code-reviewer` | opus |
+| Data analysis and statistics | `scientist` | sonnet |
+| Git operations | `git-master` | sonnet |
+| Code simplification | `code-simplifier` | opus |
 
 ---
 
@@ -935,7 +923,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 
 ## Slash Commands
 
-Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list, including frontmatter aliases; the commands below list shipped command files and direct skill entrypoints. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction helper is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC. The helper preserves the user's note and instructs them to run bare `/compact`; OMC does not invoke native compaction itself because Claude Code's built-in `/compact` is not a prompt skill.
+The 5.3.0 package ships 21 command files. Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list, including frontmatter aliases; the commands below list shipped command files and direct skill entrypoints. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction helper is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC. The helper preserves the user's note and instructs them to run bare `/compact`; OMC does not invoke native compaction itself because Claude Code's built-in `/compact` is not a prompt skill.
 
 | Command                                                  | Description                                                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -1384,8 +1372,8 @@ Use Claude Code's plugin management:
 Or manually remove the installed files:
 
 ```bash
-rm ~/.claude/agents/{architect,document-specialist,explore,designer,writer,vision,critic,analyst,executor,qa-tester}.md
-rm ~/.claude/commands/{analyze,autopilot,deepsearch,plan,review,ultrawork}.md
+rm ~/.claude/agents/{explore,analyst,planner,architect,debugger,executor,verifier,tracer,security-reviewer,code-reviewer,test-engineer,designer,writer,qa-tester,scientist,git-master,document-specialist,code-simplifier,critic}.md
+rm ~/.claude/commands/{analyze,autopilot,deepsearch,plan,review,execute,team}.md
 ```
 
 ---

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # MCP Tools
 
-> OMC provides MCP tools for state management, code intelligence, and data analysis.
+> OMC provides MCP tools for state management, code intelligence, and data analysis. Version 5.3.0 exposes 55 tools through the single configured MCP server.
 
 Unlike skills that users invoke directly, tools are used internally by agents during task execution.
 
@@ -22,7 +22,7 @@ Unlike skills that users invoke directly, tools are used internally by agents du
 
 ## State
 
-State tools manage the state of OMC execution modes (autopilot, ralph, ultrawork, etc.). Each mode records its current progress, active status, and configuration in state files.
+State tools manage the state of OMC execution modes (autopilot, ralph, team, etc.). Legacy/retired mode state such as `ultrawork` may remain only for cleanup and diagnostics; it is not invocable. Each mode records its current progress, active status, and configuration in state files.
 
 ### Storage Path
 
@@ -31,10 +31,10 @@ State tools manage the state of OMC execution modes (autopilot, ralph, ultrawork
 ├── sessions/{sessionId}/     # Session-scoped state
 │   ├── autopilot-state.json
 │   ├── ralph-state.json
-│   └── ultrawork-state.json
+│   └── ultrawork-state.json   # legacy/retired cleanup state; never invoke
 ├── autopilot-state.json      # Legacy fallback
 ├── ralph-state.json
-└── ultrawork-state.json
+└── ultrawork-state.json       # legacy/retired fallback state; never invoke
 ```
 
 When a session ID is provided, the session-scoped path is used; otherwise the legacy path is used as a fallback.


### PR DESCRIPTION
Six user-facing docs still taught capabilities the runtime no longer routes. Found while closing website/docs parity for 5.3.0.

## Findings

| Name | Status in source | Docs said |
|---|---|---|
| `ultrawork` / `ulw` | `skills/cancel/SKILL.md` treats it as legacy state only and says never to reactivate or route it | runnable parallel-work mode in GETTING-STARTED, REFERENCE, TOOLS, HOOKS, ARCHITECTURE, PERFORMANCE-MONITORING |
| `ultrapilot` | `skills/execute/SKILL.md` routes it into `execute` | available mode |
| `sciomc`, `writer-memory`, `mcp-setup` | not shipped in 5.3.0 | available |
| counts | 19 agents / 37 skills / 21 commands | stale |

## Change

Guidance now points at `execute` for carrying an approved task to verified code and `team` for parallel lanes, using this repo's own `/oh-my-claudecode:<skill>` invocation form. `REFERENCE.md` states the real inventory.

Legacy names that describe **on-disk state** rather than an invocable mode are kept and labelled as legacy — notably the `linked_ultrawork` state field in `HOOKS.md`, whose presence source tests assert (`src/__tests__/ralph-prd-mandatory.test.ts`).

`ralph` is deliberately untouched: unlike oh-my-codex it is still a shipped skill here.

## Non-goals

`docs/design/**`, `docs/issues/**`, `docs/prs/**`, `docs/qa/**` and the changelog are historical engineering records and keep naming their era's capabilities.