### PR TITLE
docs: replace retired mode guidance with the shipped 5.3.0 surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,16 +17,16 @@ oh-my-claudecode enables Claude Code to orchestrate specialized agents through a
        │                                │                              │
        ▼                                ▼                              ▼
 ┌─────────────┐              ┌──────────────────┐           ┌─────────────────┐
-│  "ultrawork │              │   CLAUDE.md      │           │ SKILL ACTIVATED │
+│  "execute   │              │   CLAUDE.md      │           │ SKILL ACTIVATED │
 │   refactor  │─────────────▶│   Auto-Routing   │──────────▶│                 │
-│   the API"  │              │                  │           │ ultrawork +     │
+│   the API"  │              │                  │           │ execute +       │
 └─────────────┘              │ Task Type:       │           │ default +       │
                              │  - Implementation│           │ git-master      │
                              │  - Multi-file    │           │                 │
                              │  - Parallel OK   │           │ ┌─────────────┐ │
                              │                  │           │ │ Parallel    │ │
                              │ Skills:          │           │ │ agents      │ │
-                             │  - ultrawork ✓   │           │ │ launched    │ │
+                             │  - execute ✓     │           │ │ launched    │ │
                              │  - default ✓     │           │ └─────────────┘ │
                              │  - git-master ✓  │           │                 │
                              └──────────────────┘           │ ┌─────────────┐ │
@@ -175,7 +175,7 @@ explore --> analyst --> planner --> critic --> executor --> verifier
 
 ### Overview
 
-Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 31 skills total (28 user-invocable + 3 internal/pipeline).
+Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 37 shipped skills.
 
 ### Skill Layers
 
@@ -190,13 +190,13 @@ Skills compose in three layers:
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  ENHANCEMENT LAYER (0-N skills)                              │
-│  ultrawork (parallel) | git-master (commits) | frontend-ui-ux│
+│  team (parallel) | git-master (commits) | frontend-ui-ux│
 └─────────────────────────────────────────────────────────────┘
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │  EXECUTION LAYER (primary skill)                             │
-│  default (build) | orchestrate (coordinate) | planner (plan) │
+│  execute (build) | team (coordinate) | omc-plan (plan)      │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -204,16 +204,18 @@ Skills compose in three layers:
 
 Example:
 ```
-Task: "ultrawork: refactor API with proper commits"
-Active skills: ultrawork + default + git-master
+Task: "execute: refactor API with proper commits"
+Active skills: execute + default + git-master
 ```
 
 ### How to Invoke Skills
 
 **Slash commands:**
 ```bash
-/oh-my-claudecode:autopilot build me a todo app
-/oh-my-claudecode:ralph refactor the auth module
+/oh-my-claudecode:omc-plan "plan a todo app"
+/oh-my-claudecode:execute build me a todo app
+/oh-my-claudecode:omc-review [path]
+/oh-my-claudecode:verify [target]
 /oh-my-claudecode:team 3:executor "implement fullstack app"
 ```
 
@@ -221,7 +223,7 @@ Active skills: ultrawork + default + git-master
 ```bash
 autopilot build me a todo app      # activates autopilot
 ralph: refactor the auth module    # activates ralph
-ultrawork implement OAuth          # activates ultrawork
+/oh-my-claudecode:execute implement OAuth  # explicit invocation, not a keyword trigger
 ```
 
 ### Core Workflow Skills
@@ -240,12 +242,12 @@ Repeating loop that does not stop until work is verified complete. The `verifier
 ralph: refactor the authentication module
 ```
 
-#### ultrawork
-Maximum parallelism — launches multiple agents simultaneously.
-- Trigger: `ultrawork`, `ulw`
+#### execute
+Carries an approved task through to working, verified code. Use an explicit invocation; the retired `ultrawork`/`ulw` names are not aliases.
 ```bash
-ultrawork implement user authentication with OAuth
+/oh-my-claudecode:execute implement user authentication with OAuth
 ```
+For coordinated parallel workers, use `/oh-my-claudecode:team` instead.
 
 #### team
 Coordinates N Claude agents with a 5-stage pipeline: `plan → prd → exec → verify → fix`
@@ -253,11 +255,12 @@ Coordinates N Claude agents with a 5-stage pipeline: `plan → prd → exec → 
 /oh-my-claudecode:team 3:executor "implement fullstack todo app"
 ```
 
-#### ccg (Claude-Codex-Gemini)
-Fans out to Codex and Antigravity simultaneously; Claude synthesizes the results. Gemini remains available as an enterprise/API-key fallback when using the legacy Gemini CLI.
-- Trigger: `ccg`, `claude-codex-gemini`
+#### Multi-provider advice with ask + team
+The retired `ccg` workflow is replaced by `/oh-my-claudecode:ask` plus `/oh-my-claudecode:team`: ask the selected providers for independent advice, then use a team to synthesize the results.
 ```bash
-ccg: review this authentication implementation
+/oh-my-claudecode:ask codex "review this authentication implementation"
+/oh-my-claudecode:ask antigravity "review this authentication implementation"
+/oh-my-claudecode:team 2:executor "synthesize the advisor findings"
 ```
 
 #### ralplan
@@ -275,25 +278,23 @@ ralplan this feature
 | `hud` | Status bar configuration | `/oh-my-claudecode:hud` |
 | `omc-setup` | Initial setup wizard | `/oh-my-claudecode:omc-setup` |
 | `omc-doctor` | Diagnose installation | `/oh-my-claudecode:omc-doctor` |
-| `skillify` | Extract reusable skills from session | `/oh-my-claudecode:skillify` (`learner` deprecated alias) |
+| `skillify` | Extract reusable skills from session | `/oh-my-claudecode:skillify` |
 | `skill` | Manage local skills (list/add/remove) | `/oh-my-claudecode:skill` |
 | `trace` | Evidence-driven causal tracing | `/oh-my-claudecode:trace` |
 | `release` | Automated release workflow | `/oh-my-claudecode:release` |
 | `deepinit` | Generate hierarchical AGENTS.md | `/oh-my-claudecode:deepinit` |
-| `deep-interview` | Socratic deep interview | `/deep-interview` |
-| `sciomc` | Parallel scientist agent orchestration | `/oh-my-claudecode:sciomc` |
+| `deep-interview` | Socratic deep interview | `/oh-my-claudecode:deep-interview` |
+| `research` | Parallel or focused research | `/oh-my-claudecode:research` |
 | `external-context` | Parallel document-specialist research | `/oh-my-claudecode:external-context` |
 | `ai-slop-cleaner` | Clean AI expression patterns | `/oh-my-claudecode:ai-slop-cleaner` |
-| `writer-memory` | Memory system for writing projects | `/oh-my-claudecode:writer-memory` |
+| `remember` | Save durable session memory | `/oh-my-claudecode:remember` |
 
 ### Magic Keyword Reference
 
 | Keyword | Effect |
 |---------|--------|
-| `ultrawork`, `ulw`, `uw` | Parallel agent orchestration |
 | `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `e2e this` | Autonomous execution pipeline |
 | `ralph`, `don't stop`, `must complete`, `until done` | Loop until verified complete |
-| `ccg`, `claude-codex-gemini` | 3-model orchestration (use `antigravity` workers when using the Antigravity CLI) |
 | `ralplan` | Consensus-based planning |
 | `deep interview`, `ouroboros` | Socratic deep interview |
 | `code review`, `review code` | Comprehensive code review mode |
@@ -305,16 +306,18 @@ ralplan this feature
 | `deslop`, `anti-slop` | AI expression cleanup |
 | `cancelomc`, `stopomc` | Cancel active execution mode |
 
+Canonical execution, planning, review, verification, and team workflows use explicit `/oh-my-claudecode:<registered-name>` invocations. The `team` detector never auto-matches, and `plan this`/`plan the` do not activate a workflow.
+
 ### Keyword Detection Sources
 
 Keywords are processed in two places:
 
 | Source | Role | Customizable |
 |--------|------|--------------|
-| `config.jsonc` `magicKeywords` | 4 categories (ultrawork, search, analyze, ultrathink) | Yes |
-| `keyword-detector` hook | 11+ triggers (autopilot, ralph, ccg, etc.) | No |
+| `config.jsonc` `magicKeywords` | 3 categories (`search`, `analyze`, `ultrathink`) | Yes |
+| `keyword-detector` hook | Built-in workflow and mode triggers | No |
 
-The `autopilot`, `ralph`, and `ccg` triggers are hardcoded in the hook and cannot be changed through config.
+Workflow keywords such as `autopilot`, `ralph`, `ralplan`, and `deep interview` are handled by the keyword-detector hook and cannot be changed through config. Team orchestration and the `omc-plan`/`omc-review` workflows require explicit slash invocations.
 
 ---
 
@@ -359,13 +362,14 @@ Injected pattern meanings:
 | `hook success: Success` | Hook ran normally, continue as planned |
 | `hook additional context: ...` | Additional context information, take note |
 | `[MAGIC KEYWORD: ...]` | Magic keyword detected, execute indicated skill |
-| `The boulder never stops` | ralph/ultrawork mode is active |
+| `The boulder never stops` | ralph/autopilot mode is active |
+
 
 ### Key Hooks
 
 **keyword-detector** — fires on `UserPromptSubmit`. Detects magic keywords in user input and activates the corresponding skill.
 
-**persistent-mode** — fires on `Stop`. When a persistent mode (ralph, ultrawork) is active, prevents Claude from stopping until work is verified complete.
+**persistent-mode** — fires on `Stop`. When a persistent mode (ralph, autopilot, team, or ultragoal) is active, prevents Claude from stopping until work is verified complete.
 
 **pre-compact** — fires on `PreCompact`. Saves critical information (active modes, TODOs, background jobs, and durable plan anchors: PRD/boulder references) to a checkpoint before the context window is compressed. The `SessionStart` hook restores the newest matching checkpoint when `source === "compact"`, so plan detail survives auto-compaction (issue #3730).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,7 +175,7 @@ explore --> analyst --> planner --> critic --> executor --> verifier
 
 ### Overview
 
-Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 37 shipped skills.
+Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 38 shipped skills.
 
 ### Skill Layers
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -27,7 +27,7 @@ OMC ships two surfaces and they are designed to coexist:
 
 | Surface | What you get | Recommended install |
 |---|---|---|
-| **Claude Code plugin** (`oh-my-claudecode@omc`) | In-session skills, agents, hooks, statusline, MCP servers — the `/autopilot`, `/ralph`, `/execute`, `/team` slash commands | Marketplace plugin install (Step 1–2 below) |
+| **Claude Code plugin** (`oh-my-claudecode@omc`) | In-session skills, agents, hooks, statusline, MCP servers — the `/oh-my-claudecode:autopilot`, `/oh-my-claudecode:ralph`, `/oh-my-claudecode:execute`, and `/oh-my-claudecode:team` slash commands | Marketplace plugin install (Step 1–2 below) |
 | **Terminal CLI** (`omc` binary, package `oh-my-claude-sisyphus`) | Shell commands: `omc setup`, `omc update`, `omc team`, `omc ask`, and a hard-deprecated `omc autoresearch` shim | `npm i -g oh-my-claude-sisyphus@latest` |
 
 Most users want **both**: the plugin for the in-session experience, and the npm CLI for shell-side automation and updates. Running them in parallel is fully supported — `omc update` and `omc setup` are idempotent and detect the plugin install to avoid duplicating in-session skills (#2252).
@@ -69,13 +69,9 @@ Both can be installed at the same time. The CLI auto-detects the plugin install 
 
 ### Step 3: Run initial setup
 
-After installation, enter one of the following in Claude Code:
+After installation, run this in Claude Code:
 
 ```bash
-# Option 1: natural language
-setup omc
-
-# Option 2: skill command
 /oh-my-claudecode:omc-setup
 ```
 
@@ -230,10 +226,11 @@ analyze why this test is failing
 deepsearch for files that handle authentication
 
 # Simple implementation
-ultrawork add a health check endpoint
+/oh-my-claudecode:execute add a health check endpoint
+
 ```
 
-These keywords invoke a single appropriate agent directly, without running the full pipeline.
+The analysis and search examples use keyword shortcuts; use the explicit execute invocation for implementation.
 
 ### Next steps
 
@@ -283,7 +280,6 @@ Defaults → User config (~/.config/claude-omc/config.jsonc)
 
   // Magic keyword customization
   "magicKeywords": {
-    "ultrawork": ["ultrawork", "ulw", "uw"],
     "search": ["search", "find", "locate"],
     "analyze": ["analyze", "investigate", "examine"],
     "ultrathink": ["ultrathink", "think", "reason"]
@@ -361,14 +357,11 @@ You can change the AI model used by each agent:
 
 ### Customizing magic keywords
 
-You can change keywords in four categories via the `magicKeywords` section of `config.jsonc`:
+You can change keywords in three categories via the `magicKeywords` section of `config.jsonc`:
 
 ```jsonc
 {
   "magicKeywords": {
-    // Triggers parallel execution mode
-    "ultrawork": ["ultrawork", "ulw", "parallel"],
-
     // Triggers codebase search mode
     "search": ["search", "find", "locate", "grep"],
 
@@ -381,7 +374,7 @@ You can change keywords in four categories via the `magicKeywords` section of `c
 }
 ```
 
-> ℹ️ **Note:** The `magicKeywords` section in `config.jsonc` only allows customizing four categories: `ultrawork`, `search`, `analyze`, and `ultrathink`. Keywords such as `autopilot`, `ralph`, and `ccg` are hardcoded in the keyword-detector hook and cannot be changed via config files.
+> ℹ️ **Note:** The `magicKeywords` section in `config.jsonc` only allows customizing three categories: `search`, `analyze`, and `ultrathink`. Workflow keywords such as `autopilot`, `ralph`, `ralplan`, and `deep interview` are handled by the keyword-detector hook and cannot be changed through this config section.
 
 ### Model routing configuration
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -47,7 +47,7 @@ Handle orchestration, keyword detection, and mode persistence.
 | Hook | Description |
 |------|-------------|
 | keyword-detector | Detects magic keywords and activates corresponding skills |
-| persistent-mode | Enforces continuation when an execution mode (ralph, autopilot, ultrawork, etc.) is active — injects reinforcement messages on Stop to prevent premature halting |
+| persistent-mode | Enforces continuation when an active execution mode (ralph, autopilot, ultragoal, or team) is active — injects reinforcement messages on Stop to prevent premature halting |
 
 ### Context Management Hooks
 
@@ -101,7 +101,7 @@ Fires when the user submits a prompt.
 | `keyword-detector.mjs` | Detects magic keywords and invokes the corresponding skill | 30s outer host fuse; 8s trusted Worker limit |
 | `skill-injector.mjs` | Injects skill prompts | 30s outer host fuse; 12s trusted Worker limit |
 
-Runs on all user input (`matcher: "*"`). When the keyword detector finds keywords like "ultrawork", "ralph", or "autopilot", it injects the corresponding skill invocation instruction via `additionalContext`.
+Runs on all user input (`matcher: "*"`). When the keyword detector finds supported keywords such as "ralph", "autopilot", "ralplan", or "deep interview", it injects the corresponding skill invocation instruction via `additionalContext`.
 
 The 30s timeout is a per-command outer host fuse that includes launcher startup before `run.cjs`. Once the runner reaches its exact trusted Worker branch, `keyword-detector.mjs` is limited to 8s and `skill-injector.mjs` to 12s; lower manifest limits are never extended. A command that never reaches `run.cjs` can consume its full 30s outer fuse. The host schedules the two commands externally, so this does not claim an aggregate prompt latency.
 
@@ -201,7 +201,7 @@ Fires when Claude finishes a response.
 |--------|------|---------|
 | `context-guard-stop.mjs` | Monitors context usage | 5s |
 | `workflow-drift-guard.mjs` | Blocks narrow structured-question and fake-completion drift | 3s |
-| `persistent-mode.mjs` | Maintains active mode state (ralph, ultrawork, etc.) | 10s |
+| `persistent-mode.mjs` | Maintains active mode state (ralph, autopilot, ultragoal, team, etc.) | 10s |
 | `code-simplifier.mjs` | Auto-simplifies modified files (opt-in) | 5s |
 
 `persistent-mode` injects a reinforcement message like "The boulder never stops" when an active execution mode is running, prompting continued work. A fresh unconfirmed ultragoal is exempt while Claude `/goal` confirmation is pending; confirmed runs remain fail-closed.
@@ -228,11 +228,11 @@ Detects magic keywords in user prompts and invokes the corresponding skill.
 
 - **Event**: UserPromptSubmit
 - **Behavior**: Sanitizes the prompt (removes code blocks, URLs, file paths) then matches keyword patterns
-- **Conflict resolution**: cancel has highest priority, then ralph > autopilot > ultrawork
+- **Conflict resolution**: cancel has highest priority, then ralph > autopilot > ralplan
+
 - **Safety**: Disabled inside team workers to prevent infinite spawning
 
 See the [Magic Keywords](#magic-keywords) section for the full keyword list.
-
 
 #### workflow-drift-guard
 
@@ -263,16 +263,17 @@ Ambiguous-regex and malformed-ternary uncertainty is bounded to the current phys
 
 #### persistent-mode
 
-Enforces continuation when an execution mode is active. This is the hook that keeps skills like autopilot, ralph, and ultrawork running.
+Enforces continuation when an execution mode is active. This is the hook that keeps skills like autopilot and ralph running.
 
 - **Event**: Stop
-- **Behavior**: Checks `.omc/state/` for active mode state files. If any mode (ralph, ultragoal, autopilot, ultrawork, team, pipeline) is active, injects a reinforcement message to prevent Claude from stopping.
+- **Behavior**: Checks `.omc/state/` for active mode state files. If any mode (ralph, ultragoal, autopilot, or team) is active, injects a reinforcement message to prevent Claude from stopping.
+
 - **Reinforcement message**: "The boulder never stops" — prompts Claude to continue working
 - **Staleness check**: States older than 2 hours are treated as inactive to prevent stale state from blocking new sessions
 - **Notification**: Sends Discord/Telegram/Slack notification on first stop (if configured)
 - **Cancel**: Use `/oh-my-claudecode:cancel` to deactivate modes
 
-> **Note**: autopilot, ralph, and ultrawork are **skills** (invoked via keyword-detector), not hooks. The persistent-mode hook is what enforces their continuation by blocking the Stop event.
+> **Note**: autopilot and ralph are **skills** (invoked via keyword-detector), while team and ultragoal are explicit workflow invocations. The persistent-mode hook is what enforces their continuation by blocking the Stop event.
 
 ### Mode State Management
 
@@ -282,7 +283,7 @@ Execution mode hooks manage state files in the `.omc/state/` directory.
 {
   "active": true,
   "started_at": "2025-01-15T10:30:00Z",
-  "prompt": "ultrawork implement auth",
+  "prompt": "ralph implement auth",
   "session_id": "abc123",
   "project_path": "/path/to/project",
   "iteration": 0,
@@ -292,8 +293,9 @@ Execution mode hooks manage state files in the `.omc/state/` directory.
 }
 ```
 
-When a session ID is present, state is stored in session scope under `.omc/state/sessions/{sessionId}/`.
+The `linked_ultrawork` field is a legacy state field retained for compatibility with retired state files; it is not an invocable mode.
 
+When a session ID is present, state is stored in session scope under `.omc/state/sessions/{sessionId}/`.
 
 #### ultragoal-state.json lifecycle
 
@@ -318,7 +320,8 @@ or
 /oh-my-claudecode:cancel
 ```
 
-`cancel` removes state files for all active modes: ralph, autopilot, ultrawork, and any others.
+`cancel` removes state files for all active modes, including ralph, autopilot, ultragoal, and team, and clears legacy retired-mode artifacts when present.
+
 
 ---
 
@@ -416,8 +419,6 @@ These keywords invoke a skill and create a state file.
 | `cancelomc`, `stopomc` | cancel | Cancels all active modes |
 | `ralph`, `don't stop`, `must complete`, `until done` | ralph | Persistent execution until verification completes |
 | `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `auto-pilot`, `full auto`, `fullsend`, `e2e this` | autopilot | Fully autonomous execution |
-| `ultrawork`, `ulw`, `uw` | ultrawork | Maximum parallel execution |
-| `ccg`, `claude-codex-gemini` | ccg | Claude-Codex-Gemini tri-model orchestration (use `antigravity` workers when using the Antigravity CLI) |
 | `ralplan` | ralplan | Consensus-based iterative planning |
 | `deep interview`, `ouroboros` | deep-interview | Socratic deep interview |
 
@@ -471,17 +472,15 @@ When multiple keywords are detected simultaneously, they resolve by the followin
 cancel  (highest priority, exclusive)
   → ralph
     → autopilot
-      → ultrawork
-        → ccg
-          → ralplan
-            → deep-interview
-              → ai-slop-cleaner
-                → tdd
-                  → code-review
-                    → security-review
-                      → ultrathink
-                        → deepsearch
-                          → analyze
+      → ralplan
+        → deep-interview
+          → ai-slop-cleaner
+            → tdd
+              → code-review
+                → security-review
+                  → ultrathink
+                    → deepsearch
+                      → analyze
 ```
 
 `cancel` is exclusive — it ignores all other matches and only runs the cancel action. All other keywords can be matched together and are processed in priority order.
@@ -495,7 +494,7 @@ cancel  (highest priority, exclusive)
 autopilot: implement user authentication with OAuth
 
 # Parallel execution
-ultrawork write all tests for this module
+/oh-my-claudecode:team 3:executor "write all tests for this module"
 
 # Persistent execution
 ralph refactor this authentication module
@@ -512,7 +511,7 @@ stopomc
 
 ### Note on the `team` Keyword
 
-`team` is not auto-detected. It must be invoked explicitly via the `/team` slash command to prevent infinite spawning.
+`team` is not auto-detected. It must be invoked explicitly via the `/oh-my-claudecode:team` slash command to prevent infinite spawning.
 
 ```
 /oh-my-claudecode:team 3:executor "build a fullstack todo app"

--- a/docs/PERFORMANCE-MONITORING.md
+++ b/docs/PERFORMANCE-MONITORING.md
@@ -140,7 +140,7 @@ Replay data is stored at: `.omc/state/agent-replay-{sessionId}.jsonl`
 
 Each line is a JSON event:
 ```json
-{"t":0.0,"agent":"a1b2c3d","agent_type":"executor","event":"agent_start","task":"Implement feature","parent_mode":"ultrawork"}
+{"t":0.0,"agent":"a1b2c3d","agent_type":"executor","event":"agent_start","task":"Implement feature","parent_mode":"team"}
 {"t":5.2,"agent":"a1b2c3d","event":"tool_start","tool":"Read"}
 {"t":5.4,"agent":"a1b2c3d","event":"tool_end","tool":"Read","duration_ms":200,"success":true}
 ```

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -2,6 +2,8 @@
 
 Complete reference for oh-my-claudecode. For quick start, see the main [README.md](../README.md).
 
+For v5.3.0, the plugin ships 19 agents, 37 skills, 21 command files, and one configured MCP server exposing exactly 55 tools.
+
 ---
 
 ## Table of Contents
@@ -12,9 +14,9 @@ Complete reference for oh-my-claudecode. For quick start, see the main [README.m
 - [Plugin directory flags](#plugin-directory-flags)
 - [CLI Commands: ask/team/session](#cli-commands-askteamsession)
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated-opt-in-only)
-- [Agents (29 Total)](#agents-29-total)
+- [Agents (19 Total)](#agents-19-total)
 - [Goal Workflow UX: `/goal`, Ralph, Team, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultragoal)
-- [Skills (38 Total)](#skills-38-total)
+- [Skills (37 Total)](#skills-37-total)
 - [Slash Commands](#slash-commands)
 - [Shipyard Methodology](./shipyard.md) — governed delivery & shared harness map
 - [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
@@ -50,7 +52,7 @@ npm i -g oh-my-claude-sisyphus@latest
 omc setup
 ```
 
-The npm package exposes both `oh-my-claudecode` and `omc`; examples prefer `omc` unless troubleshooting needs the long alias. The CLI does not make in-session slash skills available by itself; install the plugin for `/autopilot`, `/ralph`, `/execute`, `/team`, and other interactive skills.
+The npm package exposes both `oh-my-claudecode` and `omc`; examples prefer `omc` unless troubleshooting needs the long alias. The CLI does not make in-session slash skills available by itself; install the plugin for `/oh-my-claudecode:autopilot`, `/oh-my-claudecode:ralph`, `/oh-my-claudecode:execute`, `/oh-my-claudecode:team`, and other interactive skills.
 
 ### Requirements
 
@@ -123,7 +125,6 @@ If both configurations exist, **project-scoped takes precedence** over global:
 | `OMC_DISABLE_MULTIREPO`    | _(unset)_            | Set to `1` to disable workspace-marker resolution and fall back to git-root + cwd resolution order. `OMC_STATE_DIR` is still honoured. See [Rollback / disable multi-repo](#rollback--disable-multi-repo-omc_disable_multirepo) below.                                       |
 | `DISABLE_OMC`              | _(unset)_            | Set to `1` or `true` to disable all OMC hooks |
 | `OMC_SKIP_HOOKS`           | _(unset)_            | Comma-separated list of hook names to skip                                                                                                                                                                                                                                  |
-| `OMC_SESSION_START_CONTEXT_BUDGET` | `6000`       | Character budget shared by everything the SessionStart hook injects (mode restores, notepad Priority Context, root `AGENTS.md`, pending tasks). Raise it when a large `AGENTS.md` arrives truncated; lower it to spend less context. Positive integer; other values fall back to the default |
 
 #### Centralized State with `OMC_STATE_DIR`
 
@@ -211,7 +212,7 @@ Resolution order inside `getOmcRoot()`:
 3. `git rev-parse --show-toplevel` (monorepo / single repo).
 4. `process.cwd()` (last resort).
 
-Once a workspace is anchored, multiple Claude Code sessions in different sub-repos can run `/ultragoal`, `/ralph`, `/execute`, `/autopilot` in parallel without bleeding state. For `/ultragoal` specifically, pass `--plan-id <id>` or `--auto-plan-id` on `create-goals` so each session writes to `.omc/ultragoal/plans/{planId}/` instead of the shared `goals.json` — see "ultragoal multi-plan" below. The PARALLEL SESSION WARNING in `session-start.mjs` performs a PID-aware liveness check and no longer suppresses restore when the owner session is dead.
+Once a workspace is anchored, multiple Claude Code sessions in different sub-repos can run `/oh-my-claudecode:ultragoal`, `/oh-my-claudecode:ralph`, `/oh-my-claudecode:execute`, and `/oh-my-claudecode:autopilot` in parallel without bleeding state. For `/oh-my-claudecode:ultragoal` specifically, pass `--plan-id <id>` or `--auto-plan-id` on `create-goals` so each session writes to `.omc/ultragoal/plans/{planId}/` instead of the shared `goals.json` — see "ultragoal multi-plan" below. The PARALLEL SESSION WARNING in `session-start.mjs` performs a PID-aware liveness check and no longer suppresses restore when the owner session is dead.
 
 #### `.omc/handoffs/` shared contract
 
@@ -649,7 +650,7 @@ Use OMC's terminal and library surfaces in non-interactive environments:
 - Run CLI commands that have deterministic exit codes, for example `omc setup`, `omc ask ...`, `omc session search ... --json`, or repo-owned verification scripts such as `npm run sync-metadata:verify`.
 - Provide authentication through runner environment variables (`ANTHROPIC_API_KEY`) or pre-authenticated provider CLIs for `codex`, `gemini`, `antigravity`, `grok`, or `cursor` when using `omc ask` / `omc team`.
 - Keep state explicit for ephemeral runners by setting `OMC_STATE_DIR` when state must survive worktree deletion or checkout replacement.
-- Avoid interactive slash skills (`/autopilot`, `/ralph`, `/execute`, `/deep-interview`, `/team`) in CI jobs; they require an active Claude Code session and user-visible conversation loop.
+- Avoid interactive slash skills (`/oh-my-claudecode:autopilot`, `/oh-my-claudecode:ralph`, `/oh-my-claudecode:execute`, `/oh-my-claudecode:deep-interview`, `/oh-my-claudecode:team`) in CI jobs; they require an active Claude Code session and user-visible conversation loop.
 - OMC does not currently provide a VS Code extension or VS Code-specific automation contract. The documented IDE path is to use Claude Code's own integrations, then install OMC through the Claude Code plugin surface.
 - Programmatic Agent SDK usage is supported through the exported TypeScript helpers and the in-process MCP server helpers in this package; it is a Node.js library surface, not an interactive plugin installer.
 
@@ -724,7 +725,9 @@ Bounded handoff policy:
 2. For larger payloads, pass a short summary plus the descriptor.
 3. Keep durable content in artifact paths such as `.omc/plans/`, `.omc/prompts/`, and related artifact stores rather than embedding full bodies into queue or status records.
 
-## Agents (29 Total)
+## Agents (19 Total)
+
+Model-tier aliases are shown in the table below; the shipped agent catalog contains 19 base agents.
 
 Always use `oh-my-claudecode:` prefix when calling via Task tool.
 
@@ -846,7 +849,7 @@ Fail-closed invariants: a malformed ledger entry, an amended original that is st
 
 ## Named autopilot stage profiles (v1)
 
-A named profile is selected only by `/autopilot --workflow <name> <task>`; it is not a dynamic slash command, prompt alias, mode, plugin, filename, or independent state identity. Existing `/autopilot <task>` behavior remains the legacy no-profile path.
+A named profile is selected only by `/oh-my-claudecode:autopilot --workflow <name> <task>`; it is not a dynamic slash command, prompt alias, mode, plugin, filename, or independent state identity. Existing `/oh-my-claudecode:autopilot <task>` behavior remains the legacy no-profile path.
 
 Named profiles require Linux with the `flock` utility in v1. Their authenticated transcript boundary depends on Linux no-follow file-descriptor traversal and their recoverable mutation lock depends on kernel advisory locking; unsupported environments reject explicit `--workflow` activation before state mutation while legacy autopilot remains supported.
 
@@ -882,7 +885,7 @@ Autopilot continues to own cancel, resume, cleanup, state inspection, HUD, and S
 
 V1 deliberately defers `stageModels` and all model/provider/role routing, inline/no-spawn execution, dynamic commands/modes/state files, arbitrary stages/prompts/plugins and control-flow extensions, and the separate custom-skill inline-array frontmatter parser mismatch. See [ADR 03487](./adr/03487-named-autopilot-stage-profiles.md) for the decision record.
 
-## Skills (38 Total)
+## Skills (37 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
@@ -901,12 +904,11 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `cancel-ralph`            | Deprecated compatibility alias for `cancel`                                   | `/oh-my-claudecode:cancel-ralph`            |
 | `configure-notifications` | Configure Telegram, Discord, and Slack notification integrations               | `/oh-my-claudecode:configure-notifications` |
 | `debug`                   | Diagnose the current OMC session or repository state                           | `/oh-my-claudecode:debug`                   |
-| `deep-interview`          | Socratic deep interview with ambiguity gating                                  | `/deep-interview`                           |
+| `deep-interview`          | Socratic deep interview with ambiguity gating                                  | `/oh-my-claudecode:deep-interview`                |
 | `deepinit`                | Generate hierarchical AGENTS.md documentation                                  | `/oh-my-claudecode:deepinit`                |
 | `drydock`                 | Shipyard harness scaffold: 4-pillar shared environment, --check drift audit    | `/oh-my-claudecode:drydock`                 |
 | `execute`                 | Carry an approved task through to working, verified code                       | `/oh-my-claudecode:execute`                |
 | `external-context`        | Parallel document-specialist research                                          | `/oh-my-claudecode:external-context`       |
-| `harbor`                  | Shipyard intake gate: verify external issues and PRs, hand a signature docket  | `/oh-my-claudecode:harbor`                  |
 | `hud`                     | Configure HUD/statusline                                                        | `/oh-my-claudecode:hud`                     |
 | `launch`                  | Shipyard governed delivery pipeline: spec, tickets, frontier execution          | `/oh-my-claudecode:launch`                  |
 | `loft`                    | Shipyard shape-before-steel discipline: throwaway artifacts answer design questions | `/oh-my-claudecode:loft`              |
@@ -937,7 +939,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 
 ## Slash Commands
 
-Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Interview is intentionally documented with the short `/deep-interview` path because that path receives OMC's rendered runtime threshold guidance before the interview starts. The skills table above is the full runtime-backed list, including frontmatter aliases; the commands below list shipped command files and direct skill entrypoints. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction helper is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC. The helper preserves the user's note and instructs them to run bare `/compact`; OMC does not invoke native compaction itself because Claude Code's built-in `/compact` is not a prompt skill.
+Most installed skills are exposed as `/oh-my-claudecode:<registered-name>`. The plugin ships 21 command files alongside the 37 skill entrypoints listed above; the commands below list both surfaces. Compatibility keyword modes like `deep-analyze` and `tdd` are prompt-triggered behaviors, not standalone slash commands. OMC's manual compaction helper is plugin-scoped as `/oh-my-claudecode:compact`; bare `/compact` remains Claude Code's native command and is not shadowed by OMC. The helper preserves the user's note and instructs them to run bare `/compact`; OMC does not invoke native compaction itself because Claude Code's built-in `/compact` is not a prompt skill.
 
 | Command                                                  | Description                                                                                   |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
@@ -951,11 +953,10 @@ Most installed skills are exposed as `/oh-my-claudecode:<skill-name>`. Deep Inte
 | `/oh-my-claudecode:configure-notifications`              | Configure notification integrations                                                           |
 | `/oh-my-claudecode:compact [note]`                       | Prepare an OMC-safe manual handoff telling the user to run bare `/compact [note]`              |
 | `/oh-my-claudecode:debug`                                | Diagnose the current OMC session or repository state                                          |
-| `/deep-interview <idea>`                                 | Socratic interview with ambiguity scoring before execution                                    |
+| `/oh-my-claudecode:deep-interview <idea>`                                 | Socratic interview with ambiguity scoring before execution                                    |
 | `/oh-my-claudecode:deepinit [path]`                      | Index codebase with hierarchical AGENTS.md files                                              |
 | `/oh-my-claudecode:execute <task>`                      | Carry an approved task through to working, verified code                                      |
 | `/oh-my-claudecode:external-context <topic>`             | Run parallel document-specialist research                                                     |
-| `/oh-my-claudecode:harbor [sweep\|look at #N\|what's ready?]` | Sweep external issues and PRs, verify claims, hand a signature docket                    |
 | `/oh-my-claudecode:hud [setup\|minimal\|focused\|full\|status]` | Configure HUD/statusline                                                               |
 | `/oh-my-claudecode:drydock [--check]`                   | Lay the shipyard harness keel in a repo (5 surfaces); --check audits drift                     |
 | `/oh-my-claudecode:launch <brief\|spec-path> [--serial]` | Run the shipyard governed delivery pipeline (spec -> tickets -> frontier)                      |
@@ -995,6 +996,8 @@ handoff: .omc/specs/deep-interview-{slug}.md
 ```
 
 When present, OMC appends a standardized **Skill Pipeline** section to the rendered skill prompt so the current stage, handoff artifact, and explicit next `Skill("oh-my-claudecode:...")` invocation are carried forward consistently.
+
+Pipeline metadata may use on-disk directory keys such as `plan`; invoke the registered workflow as `/oh-my-claudecode:omc-plan` (and use `/oh-my-claudecode:omc-review` for the review workflow).
 
 ### Skills 2.0 Compatibility (MVP)
 
@@ -1384,11 +1387,12 @@ Use Claude Code's plugin management:
 /plugin uninstall oh-my-claudecode@oh-my-claudecode
 ```
 
-Or manually remove the installed files:
+Or remove only files left by an older standalone OMC install:
 
 ```bash
+# Leave Claude Code native commands untouched; OMC uses `omc-plan`/`omc-review`.
 rm ~/.claude/agents/{architect,document-specialist,explore,designer,writer,vision,critic,analyst,executor,qa-tester}.md
-rm ~/.claude/commands/{analyze,autopilot,deepsearch,plan,review,ultrawork}.md
+rm ~/.claude/commands/{analyze,autopilot,deepsearch}.md
 ```
 
 ---

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -16,7 +16,7 @@ For v5.3.0, the plugin ships 19 agents, 37 skills, 21 command files, and one con
 - [Legacy MCP Team Runtime Tools (Deprecated)](#legacy-mcp-team-runtime-tools-deprecated-opt-in-only)
 - [Agents (19 Total)](#agents-19-total)
 - [Goal Workflow UX: `/goal`, Ralph, Team, Ultragoal](#goal-workflow-ux-goal-ralph-team-ultragoal)
-- [Skills (37 Total)](#skills-37-total)
+- [Skills (38 Total)](#skills-38-total)
 - [Slash Commands](#slash-commands)
 - [Shipyard Methodology](./shipyard.md) — governed delivery & shared harness map
 - [Claude Code `/goal` Adapter Design](#claude-code-goal-adapter-design)
@@ -885,7 +885,7 @@ Autopilot continues to own cancel, resume, cleanup, state inspection, HUD, and S
 
 V1 deliberately defers `stageModels` and all model/provider/role routing, inline/no-spawn execution, dynamic commands/modes/state files, arbitrary stages/prompts/plugins and control-flow extensions, and the separate custom-skill inline-array frontmatter parser mismatch. See [ADR 03487](./adr/03487-named-autopilot-stage-profiles.md) for the decision record.
 
-## Skills (37 Total)
+## Skills (38 Total)
 
 Includes bundled workflow, utility, domain, and compatibility skills. Runtime truth comes from the builtin skill loader scanning `skills/*/SKILL.md` and expanding aliases declared in frontmatter.
 
@@ -909,6 +909,7 @@ Marketplace/plugin installs compact the native plugin `skills/*/SKILL.md` files 
 | `drydock`                 | Shipyard harness scaffold: 4-pillar shared environment, --check drift audit    | `/oh-my-claudecode:drydock`                 |
 | `execute`                 | Carry an approved task through to working, verified code                       | `/oh-my-claudecode:execute`                |
 | `external-context`        | Parallel document-specialist research                                          | `/oh-my-claudecode:external-context`       |
+| `harbor`                  | Shipyard intake gate: verify external issues and PRs, hand a signature docket  | `/oh-my-claudecode:harbor`                  |
 | `hud`                     | Configure HUD/statusline                                                        | `/oh-my-claudecode:hud`                     |
 | `launch`                  | Shipyard governed delivery pipeline: spec, tickets, frontier execution          | `/oh-my-claudecode:launch`                  |
 | `loft`                    | Shipyard shape-before-steel discipline: throwaway artifacts answer design questions | `/oh-my-claudecode:loft`              |
@@ -957,6 +958,7 @@ Most installed skills are exposed as `/oh-my-claudecode:<registered-name>`. The 
 | `/oh-my-claudecode:deepinit [path]`                      | Index codebase with hierarchical AGENTS.md files                                              |
 | `/oh-my-claudecode:execute <task>`                      | Carry an approved task through to working, verified code                                      |
 | `/oh-my-claudecode:external-context <topic>`             | Run parallel document-specialist research                                                     |
+| `/oh-my-claudecode:harbor [sweep\|look at #N\|what's ready?]` | Sweep external issues and PRs, verify claims, hand a signature docket                    |
 | `/oh-my-claudecode:hud [setup\|minimal\|focused\|full\|status]` | Configure HUD/statusline                                                               |
 | `/oh-my-claudecode:drydock [--check]`                   | Lay the shipyard harness keel in a repo (5 surfaces); --check audits drift                     |
 | `/oh-my-claudecode:launch <brief\|spec-path> [--serial]` | Run the shipyard governed delivery pipeline (spec -> tickets -> frontier)                      |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -2,6 +2,8 @@
 
 > OMC provides MCP tools for state management, code intelligence, and data analysis.
 
+At v5.3.0, the configured MCP server exposes exactly 55 tools.
+
 Unlike skills that users invoke directly, tools are used internally by agents during task execution.
 
 ## Tool Categories
@@ -22,7 +24,7 @@ Unlike skills that users invoke directly, tools are used internally by agents du
 
 ## State
 
-State tools manage the state of OMC execution modes (autopilot, ralph, ultrawork, etc.). Each mode records its current progress, active status, and configuration in state files.
+State tools manage the current OMC execution modes (autopilot, ralph, team, ultragoal, and related workflows). Retired mode names may remain only as legacy state-file artifacts for cleanup or migration; they are not invocable modes.
 
 ### Storage Path
 
@@ -31,10 +33,14 @@ State tools manage the state of OMC execution modes (autopilot, ralph, ultrawork
 ├── sessions/{sessionId}/     # Session-scoped state
 │   ├── autopilot-state.json
 │   ├── ralph-state.json
-│   └── ultrawork-state.json
+│   ├── team-state.json
+│   ├── ultragoal-state.json
+│   └── ultrawork-state.json  # Legacy retired-mode state
 ├── autopilot-state.json      # Legacy fallback
 ├── ralph-state.json
-└── ultrawork-state.json
+├── team-state.json
+├── ultragoal-state.json
+└── ultrawork-state.json      # Legacy retired-mode state
 ```
 
 When a session ID is provided, the session-scoped path is used; otherwise the legacy path is used as a fallback.

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "f8e5c9070c11074d4a9a4c1573e1140d7625f8cf",
+    "head": "c7855fe0883f0f9344cdd80846322944b5750ada",
     "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "f8e5c9070c11074d4a9a4c1573e1140d7625f8cf",
+  "head": "c7855fe0883f0f9344cdd80846322944b5750ada",
   "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
   "counts": {
     "public": {
@@ -77661,5 +77661,5 @@
     }
   },
   "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "aab1d214ade7f17260bf95288ae9944c760b0910973127e9451c437fe2d83a94"
+  "manifestSha256": "94760a9cdf0eac1653f68e9dd928dd6ed9768b9d39cb448f5c7e956668cdbaee"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "6576a16d8dfdee3f18a1aed009e1c91e27e69615",
-    "sourceSha256": "d982824c5daabdc66d00264deca0e74ddceb44993f0f2a010e942254ba668f4a",
+    "head": "b810585c12050d0db806663800c4478668a9f157",
+    "sourceSha256": "74fd552e0f6bf6683df9fe6c3a943ee5814bb62605e9c67901bc3081b1cbab11",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "6576a16d8dfdee3f18a1aed009e1c91e27e69615",
-  "sourceSha256": "d982824c5daabdc66d00264deca0e74ddceb44993f0f2a010e942254ba668f4a",
+  "head": "b810585c12050d0db806663800c4478668a9f157",
+  "sourceSha256": "74fd552e0f6bf6683df9fe6c3a943ee5814bb62605e9c67901bc3081b1cbab11",
   "counts": {
     "public": {
       "skills": 38,
@@ -77661,5 +77661,5 @@
     }
   },
   "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "edf61e4e5d711c7a379c491f935437f269baf7880d076eefc9ff72ac685c1fe1"
+  "manifestSha256": "abde128966f8c4132a4bcec373d8863456534bcae092789ab3fdda47c659ef34"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b810585c12050d0db806663800c4478668a9f157",
-    "sourceSha256": "74fd552e0f6bf6683df9fe6c3a943ee5814bb62605e9c67901bc3081b1cbab11",
+    "head": "f8e5c9070c11074d4a9a4c1573e1140d7625f8cf",
+    "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b810585c12050d0db806663800c4478668a9f157",
-  "sourceSha256": "74fd552e0f6bf6683df9fe6c3a943ee5814bb62605e9c67901bc3081b1cbab11",
+  "head": "f8e5c9070c11074d4a9a4c1573e1140d7625f8cf",
+  "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
   "counts": {
     "public": {
       "skills": 38,
@@ -77661,5 +77661,5 @@
     }
   },
   "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "abde128966f8c4132a4bcec373d8863456534bcae092789ab3fdda47c659ef34"
+  "manifestSha256": "aab1d214ade7f17260bf95288ae9944c760b0910973127e9451c437fe2d83a94"
 }


### PR DESCRIPTION
Seven user-facing docs still teach capabilities v5 removed. Found while closing website/docs parity for 5.3.0.

> Replaces #3984, which was cut from a stale local `main` (the unpushed 4.15.1 merge `6c59219c`). All six files it touched differ on `origin/main`, so merging it would have applied 4.15.1-era edits onto 5.3.0. This branch is based on `origin/main` (`4820f564`).

## Highest impact: `docs/CLAUDE.md`

This is the agent-facing contract, so stale entries **misroute the runtime**, not just readers. It listed `ultrawork` among Tier-0 workflows, advertised keyword triggers `"ulw"→ultrawork` and `"ccg"→ccg`, showed `/team` as the team entry point, and pointed at the removed `omc-reference` skill.

Now: canonical Tier-0 chain with qualified registered names, an explicit retired-in-v5.0.0 list mapping each old name to its successor, the real keyword-trigger set from `src/hooks/keyword-detector/index.ts`, and `/oh-my-claudecode:wiki` as the registry pointer.

## The rest

| Problem | Source truth |
|---|---|
| `ultrawork`/`ulw` shown as a runnable parallel mode across all six docs | `skills/cancel/SKILL.md` treats it as legacy state only; successors are `execute` and `team` (`docs/MIGRATION.md:62-67`) |
| `ccg`, `sciomc`, `writer-memory`, `learner`, `mcp-setup` presented as available | not in the v5.3 manifest |
| bare/unqualified invocations | `/oh-my-claudecode:<registered-name>` per `docs/CLAUDE.md:29-33` and every command wrapper |
| bare `plan`/`review` | registered as `omc-plan`/`omc-review` via `toSafeSkillName` (`src/features/builtin-skills/skills.ts:60-83`); bare forms hit Claude Code natives |
| team shown as keyword-activated | its detector pattern deliberately never matches |
| `plan the …` activation | removed (`README.md:412-413`) |
| REFERENCE said 29 agents; ARCHITECTURE said 31 skills | 19 agents / 37 skills / 21 commands / 55 MCP tools |

## Preserved deliberately

- `linked_ultrawork` in `HOOKS.md` — a real state field asserted by source tests, kept and labelled as legacy state.
- The `ralph` skill — still shipped here, unlike oh-my-codex. Not retired.
- `docs/design/**`, `docs/issues/**`, `docs/prs/**`, `docs/qa/**`, changelog and release notes — historical records, untouched.