### PR TITLE
fix(setup): continue with canonical plugin root when launcher path is a compat symlink

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "84306c0a06311132ce05abac6fabbf8ec411ec20",
-    "sourceSha256": "b788593f0244a1aaa4d10a77f3021531c789239bd7eb3441f7ea25fb3f7aa37f",
+    "head": "8d7d867f1a2119bec8f200e6edb949161edd18b0",
+    "sourceSha256": "2cc9c41ffd2b1e12f640dbcfaf492c3592553ffce139cf0ae6bcb87b8c708e56",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "84306c0a06311132ce05abac6fabbf8ec411ec20",
-  "sourceSha256": "b788593f0244a1aaa4d10a77f3021531c789239bd7eb3441f7ea25fb3f7aa37f",
+  "head": "8d7d867f1a2119bec8f200e6edb949161edd18b0",
+  "sourceSha256": "2cc9c41ffd2b1e12f640dbcfaf492c3592553ffce139cf0ae6bcb87b8c708e56",
   "counts": {
     "public": {
       "skills": 37,
@@ -77595,5 +77595,5 @@
     }
   },
   "inventorySha256": "583f179d4fdbbaead6ed6d536ba1a05dbafb052238a87f4248775a0abfb749a3",
-  "manifestSha256": "2669576f363dee390dc9fc32d4e9d3cea2940ba238a9588f2347543f82be7f13"
+  "manifestSha256": "f1d142df6f3f2878bdd40c713d16bd1d3c6e060c1cf73846c98251a8a20827e7"
 }

--- a/scripts/setup-claude-md.sh
+++ b/scripts/setup-claude-md.sh
@@ -179,9 +179,11 @@ fi
 ACTIVE_PLUGIN_ROOT_NORMALIZED="$(normalize_plugin_root "$ACTIVE_PLUGIN_ROOT")"
 SCRIPT_PLUGIN_ROOT_NORMALIZED="$(normalize_plugin_root "$SCRIPT_PLUGIN_ROOT")"
 if [ "$ACTIVE_PLUGIN_ROOT_NORMALIZED" = "$SCRIPT_PLUGIN_ROOT_NORMALIZED" ]; then
-  # Same physical plugin root: keep executing this script. Re-exec'ing here is
-  # what turned a Windows-style installPath into an infinite process chain.
-  ACTIVE_PLUGIN_ROOT="$SCRIPT_PLUGIN_ROOT"
+  # Same physical plugin root: continue with the canonical path. The logical
+  # SCRIPT_PLUGIN_ROOT preserves a symlinked invocation path (e.g. a
+  # repair-plugin-cache.mjs compat symlink), which the coordinator rejects;
+  # the normalized form is the same directory without the link (issue #3980).
+  ACTIVE_PLUGIN_ROOT="$ACTIVE_PLUGIN_ROOT_NORMALIZED"
 else
   # Bounded re-exec (issue #3743): a defect that makes the guard compare
   # unequal roots forever must terminate loudly, not hang the user's shell.

--- a/src/__tests__/setup-claude-md-script.test.ts
+++ b/src/__tests__/setup-claude-md-script.test.ts
@@ -1436,6 +1436,73 @@ describe('setup-claude-md.sh stale CLAUDE_PLUGIN_ROOT resolution', () => {
     expect(installed).toContain('<!-- OMC:VERSION:4.9.0 -->');
     expect(installed).not.toContain('<!-- OMC:VERSION:4.8.2 -->');
   });
+  it('succeeds when the launcher path is a repair-plugin-cache compat symlink to the latest version (issue #3980)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'omc-3980-symlink-launcher-'));
+    tempRoots.push(root);
+
+    const cacheBase = join(root, '.claude', 'plugins', 'cache', 'omc', 'oh-my-claudecode');
+    const oldVersion = join(cacheBase, '4.8.2');
+    const newVersion = join(cacheBase, '4.9.0');
+    const projectRoot = join(root, 'project');
+    const homeRoot = join(root, 'home');
+
+    // Real latest version dir with the full setup surface.
+    mkdirSync(join(newVersion, 'docs'), { recursive: true });
+    writeFileSync(
+      join(newVersion, 'docs', 'CLAUDE.md'),
+      `<!-- OMC:START -->\n<!-- OMC:VERSION:4.9.0 -->\n\n# New\n<!-- OMC:END -->\n`,
+    );
+    installSetupSurface(newVersion);
+    buildCoordinatorFixture(newVersion, readFileSync(join(newVersion, 'docs', 'CLAUDE.md'), 'utf-8'), '4.9.0');
+
+    // Post-repair state: repair-plugin-cache.mjs replaces the stale version
+    // dir with a symlink fallback to the latest version.
+    symlinkSync('4.9.0', oldVersion, 'dir');
+
+    // Registry still records the compat path, as left by the repair.
+    mkdirSync(join(homeRoot, '.claude', 'plugins'), { recursive: true });
+    writeFileSync(
+      join(homeRoot, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        'oh-my-claudecode@omc': [
+          {
+            installPath: oldVersion,
+            version: '4.8.2',
+          },
+        ],
+      }),
+    );
+
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(join(homeRoot, '.claude'), { recursive: true });
+    writeFileSync(
+      join(homeRoot, '.claude', 'settings.json'),
+      JSON.stringify({ plugins: ['oh-my-claudecode'] }),
+    );
+
+    // Launch through the symlinked compat path, like a session whose plugin
+    // root is the stale version dir after cache repair.
+    const result = spawnSync(
+      'bash',
+      [join(oldVersion, 'scripts', 'setup-claude-md.sh'), 'local'],
+      {
+        cwd: projectRoot,
+        env: {
+          ...process.env,
+          HOME: homeRoot,
+          CLAUDE_CONFIG_DIR: join(homeRoot, '.claude'),
+        },
+        encoding: 'utf-8',
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('must not be a symbolic link');
+
+    const installed = readFileSync(join(projectRoot, '.claude', 'CLAUDE.md'), 'utf-8');
+    expect(installed).toContain('<!-- OMC:VERSION:4.9.0 -->');
+    expect(installed).not.toContain('<!-- OMC:VERSION:4.8.2 -->');
+  });
 describe('setup-claude-md.sh Volta shim + re-exec loop regression (issue #3743)', () => {
   // Reporter topology: the script runs from a non-cache checkout whose cache
   // base holds no valid semver sibling, installed_plugins.json records an


### PR DESCRIPTION
Fixes #3980.

## Root cause
repair-plugin-cache.mjs (Step 2.2 of omc-setup) replaces stale version dirs with symlinks to the latest version. setup-claude-md.sh compared canonicalized roots at L181 but then assigned the logical (symlinked) SCRIPT_PLUGIN_ROOT in the equality branch, handing the coordinator a symlinked root it deliberately rejects.

## Fix
One line at the source: in the equality branch, continue with the already-computed canonical root (ACTIVE_PLUGIN_ROOT_NORMALIZED) instead of the logical SCRIPT_PLUGIN_ROOT. No fallback added:
- The coordinator's symlink refusal is a trust boundary and is unchanged.
- The repair script's compat symlinks are intentional and unchanged.

## Verification
- Manual repro: symlinked old-version dir -> latest, launched setup through the symlink. Before: exit 1 'Plugin root must not be a symbolic link'. After: exit 0, CLAUDE.md installed.
- New regression test 'succeeds when the launcher path is a repair-plugin-cache compat symlink to the latest version (issue #3980)' fails before (exit 1) and passes after.
- Suites: setup-claude-md-script (37 passed), repair-plugin-cache-script + claude-md-transaction (46 passed). ESLint clean, tsc clean, bash -n clean.