### PR TITLE
fix(inventory): re-anchor inventory-graph provenance to the current dev head

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "c7855fe0883f0f9344cdd80846322944b5750ada",
+    "head": "7b4bab5374395d4d3c7f03071682fd0508fa53a0",
     "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "c7855fe0883f0f9344cdd80846322944b5750ada",
+  "head": "7b4bab5374395d4d3c7f03071682fd0508fa53a0",
   "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
   "counts": {
     "public": {
@@ -77661,5 +77661,5 @@
     }
   },
   "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "94760a9cdf0eac1653f68e9dd928dd6ed9768b9d39cb448f5c7e956668cdbaee"
+  "manifestSha256": "cc00b60f40fafc5cd1d1b52b16eaf7ef3858ee66c67502afb5208a9dad46e33f"
 }


### PR DESCRIPTION
## Problem

`dev` went red on the `Test` job immediately after #3985 was squash-merged:

```
[inventory-graph] committed provenance.head must be an ancestor of the current HEAD
 ❯ tests/lint/inventory-graph-drift.test.ts:353
```

The squash merge orphaned the PR branch commit `c7855fe0`, which `inventory/inventory-graph.json` recorded as `provenance.head`. The drift lint requires that anchor to be an ancestor of `HEAD`, so a baseline regenerated on a feature branch always breaks the base branch once the branch is squashed away. This is the same class of failure that stalled #3979 earlier today.

## Fix

Regenerated the baseline with `scripts/generate-inventory-graph.mjs --write` while `HEAD` was `dev` at `7b4bab5374395d4d3c7f03071682fd0508fa53a0`. That anchor is a real `dev` ancestor and remains one after this PR is squashed, so it does not re-break the base.

Diff is 3 lines: the two `provenance.head` / `head` fields plus the derived `manifestSha256`. The inventory payload is unchanged — `inventorySha256` stays `4c67bc33…`, counts stay `public=87 internal=1355 generated=4995`, graph stays `nodes=6902 edges=7363`.

## Verification

- `node scripts/generate-inventory-graph.mjs --verify` → `verify ok — baseline is current`
- `vitest run tests/lint/inventory-graph-drift.test.ts` → **11/11 passed**, including `verify mode passes when baseline is current (drift closed)` and the tamper-rejection cases.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*