### PR TITLE
fix(release): cover version-coupled surfaces in the release runbook

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "7b4bab5374395d4d3c7f03071682fd0508fa53a0",
-    "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
+    "head": "346e47ecab43645e1a36b9bbb97950a9b0dc8d32",
+    "sourceSha256": "48263e222a4c3531f93e9be29932ba921e7fdc1e993a39c11f8b3ea18b5671e8",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "7b4bab5374395d4d3c7f03071682fd0508fa53a0",
-  "sourceSha256": "e3c47eba7d445b054715341c55d6663dd454532ca61931fb47f07aece8b90630",
+  "head": "346e47ecab43645e1a36b9bbb97950a9b0dc8d32",
+  "sourceSha256": "48263e222a4c3531f93e9be29932ba921e7fdc1e993a39c11f8b3ea18b5671e8",
   "counts": {
     "public": {
       "skills": 38,
@@ -77661,5 +77661,5 @@
     }
   },
   "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "cc00b60f40fafc5cd1d1b52b16eaf7ef3858ee66c67502afb5208a9dad46e33f"
+  "manifestSha256": "429413c957226fc7b44be7d0c6d90141000636f9383f7312cf39c0b23489cd8d"
 }

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -300,13 +300,21 @@ function releaseNextSteps(version: string): string {
   return `
   git switch -c release/v${version}
   npm run build
+  # The build rewrites CLAUDE.md and .github/CLAUDE.md from docs/CLAUDE.md with the
+  # new version marker. The golden fixture carries the same marker, and the inventory
+  # baseline must be regenerated while HEAD is still the base-branch commit so that
+  # provenance.head stays an ancestor after the release squash merge.
+  cp CLAUDE.md tests/fixtures/prompt-projection/claude-managed-block.golden
+  node scripts/generate-inventory-graph.mjs --write
   npm run plugin:shipping:verify
   npm run plugin:shipping:stage
-  git add -- package.json package-lock.json .claude-plugin/plugin.json .claude-plugin/marketplace.json docs/CLAUDE.md CHANGELOG.md README.md docs/REFERENCE.md .github/CLAUDE.md docs/ARCHITECTURE.md .github/release-body.md
+  git add -- package.json package-lock.json .claude-plugin/plugin.json .claude-plugin/marketplace.json CLAUDE.md docs/CLAUDE.md CHANGELOG.md README.md docs/REFERENCE.md .github/CLAUDE.md docs/ARCHITECTURE.md .github/release-body.md tests/fixtures/prompt-projection/claude-managed-block.golden inventory/inventory-graph.json
   git commit -S -m "chore(release): bump version to v${version}"
   git push origin HEAD:release/v${version}
   # Open a release PR from release/v${version} to dev. The signed commit is required; do not push or merge a protected branch directly.
   # The maintainer shipping transaction stages only the verified generated closure.
+  # bridge/claude-md-coordinator.cjs embeds the engine version, so it ships inside the
+  # signed generated closure and needs a matching base-owned authorization entry.
 `;
 }
 


### PR DESCRIPTION
## Problem

The v5.4.0 release attempt (#3988) hit three CI failures that the printed release runbook could not prevent, because its `git add` list only covered docs and manifests:

| Failure | Cause |
|---|---|
| `src/projection/__tests__/parity.test.ts:49` | Root `CLAUDE.md` is rewritten by the build with the new version marker; parity requires `CLAUDE.md`, `.github/CLAUDE.md` and `docs/CLAUDE.md` to agree. Root `CLAUDE.md` was missing from the add list. |
| `src/projection/__tests__/fixtures.test.ts:26` | `tests/fixtures/prompt-projection/claude-managed-block.golden` embeds the same `<!-- OMC:VERSION -->` marker and is never refreshed. |
| `tests/lint/inventory-graph-drift.test.ts:353` | `inventory/inventory-graph.json` was not regenerated, and regenerating it on the release branch head produces a `provenance.head` that the release squash merge orphans — the exact failure mode that required #3987 earlier today. |

## Change

`releaseNextSteps` in `scripts/release.ts` now, right after `npm run build`:

- copies the composed `CLAUDE.md` over the golden fixture
- runs `node scripts/generate-inventory-graph.mjs --write` while `HEAD` is still the base-branch commit, so the provenance anchor stays an ancestor across the squash merge
- stages `CLAUDE.md`, the golden fixture and `inventory/inventory-graph.json` alongside the existing paths

It also records that `bridge/claude-md-coordinator.cjs` embeds the engine version and therefore ships inside the signed generated closure, which is why a release needs a matching base-owned authorization entry.

The `verify` → `stage` → `git add --` shape asserted by `src/__tests__/release-guidance.test.ts` is preserved, and no `dist/` or `bridge/` path is added to the runbook's `git add` list.

## Verification

`vitest run src/__tests__/release-guidance.test.ts` → **3/3 passed** (this suite pins the runbook shape, the signed-commit requirement, and the prohibition on broad or protected-branch staging).

`scripts/release.ts patch --dry-run` still renders the full changelog preview and next-steps block without writing files.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*