### PR TITLE
fix(worktree-paths): treat a bare repository as a work-tree-less repo, not a failed probe

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -6,14 +6,14 @@
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
     "head": "9a0a33ac852c111750af80cc8dd4783b9c61452c",
-    "sourceSha256": "c2e1fb797c2a3bb728de3d0705e3f5b1ece457365b998318df11a319bef309ca",
+    "sourceSha256": "f0f63327b4173e60ffa8121f30a19f22a86fa4e3bae370a4f23b62c155d6339e",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
   "head": "9a0a33ac852c111750af80cc8dd4783b9c61452c",
-  "sourceSha256": "c2e1fb797c2a3bb728de3d0705e3f5b1ece457365b998318df11a319bef309ca",
+  "sourceSha256": "f0f63327b4173e60ffa8121f30a19f22a86fa4e3bae370a4f23b62c155d6339e",
   "counts": {
     "public": {
       "skills": 38,
@@ -26,10 +26,10 @@
       "hookFiles": 295,
       "featureFiles": 71,
       "toolFiles": 61,
-      "libFiles": 41,
+      "libFiles": 42,
       "templateHooks": 21,
-      "srcFiles": 1334,
-      "total": 1355
+      "srcFiles": 1335,
+      "total": 1356
     },
     "generated": {
       "distFiles": 4986,
@@ -588,6 +588,7 @@
       "src/lib/__tests__/sync-publication-short-write.test.ts",
       "src/lib/__tests__/truncate-prompt.test.ts",
       "src/lib/__tests__/worktree-cleanup-safety.test.ts",
+      "src/lib/__tests__/worktree-paths-bare-container.test.ts",
       "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
       "src/lib/__tests__/worktree-paths-git-probe-failclosed.test.ts",
       "src/lib/__tests__/worktree-paths-git-probe-locale.test.ts",
@@ -38391,6 +38392,11 @@
         "path": "src/lib/__tests__/worktree-cleanup-safety.test.ts"
       },
       {
+        "id": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "kind": "lib",
+        "path": "src/lib/__tests__/worktree-paths-bare-container.test.ts"
+      },
+      {
         "id": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
         "kind": "lib",
         "path": "src/lib/__tests__/worktree-paths-foreign-root.test.ts"
@@ -65063,6 +65069,36 @@
         "kind": "imports"
       },
       {
+        "from": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/lib/__tests__/worktree-paths-bare-container.test.ts",
+        "to": "src/lib/worktree-paths.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/lib/__tests__/worktree-paths-foreign-root.test.ts",
         "to": "external:node:child_process",
         "kind": "imports"
@@ -77654,12 +77690,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6902,
-      "edgeCount": 7363,
-      "importEdgeCount": 6060,
+      "nodeCount": 6903,
+      "edgeCount": 7369,
+      "importEdgeCount": 6066,
       "registerEdgeCount": 59
     }
   },
-  "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "cea8643cbe8fc166d21ae48b4b875d34c713fb3e817add149aac80f7b7a6eb74"
+  "inventorySha256": "96b61cb5df14663620165d68dbccea8b03c6757c289db671e8a2be1356240e0e",
+  "manifestSha256": "b36c49788f4360d6d930547c914ee4e072bb44cf4a13b1891cae2ff96e553dc7"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "346e47ecab43645e1a36b9bbb97950a9b0dc8d32",
-    "sourceSha256": "48263e222a4c3531f93e9be29932ba921e7fdc1e993a39c11f8b3ea18b5671e8",
+    "head": "9a0a33ac852c111750af80cc8dd4783b9c61452c",
+    "sourceSha256": "c2e1fb797c2a3bb728de3d0705e3f5b1ece457365b998318df11a319bef309ca",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "346e47ecab43645e1a36b9bbb97950a9b0dc8d32",
-  "sourceSha256": "48263e222a4c3531f93e9be29932ba921e7fdc1e993a39c11f8b3ea18b5671e8",
+  "head": "9a0a33ac852c111750af80cc8dd4783b9c61452c",
+  "sourceSha256": "c2e1fb797c2a3bb728de3d0705e3f5b1ece457365b998318df11a319bef309ca",
   "counts": {
     "public": {
       "skills": 38,
@@ -77661,5 +77661,5 @@
     }
   },
   "inventorySha256": "4c67bc33ca843df1016f67d372b4b76fb320f462d959b442c8b2efffc091eea6",
-  "manifestSha256": "429413c957226fc7b44be7d0c6d90141000636f9383f7312cf39c0b23489cd8d"
+  "manifestSha256": "cea8643cbe8fc166d21ae48b4b875d34c713fb3e817add149aac80f7b7a6eb74"
 }

--- a/src/__tests__/npm-package-bin-surface.test.ts
+++ b/src/__tests__/npm-package-bin-surface.test.ts
@@ -372,9 +372,9 @@ describe("npm package bin surface regression", () => {
     expect(
       packedPackageFixture.files.has("dist/lib/worktree-paths.js"),
     ).toBe(true);
-    expect(source.match(/windowsHide/g)).toHaveLength(7);
+    expect(source.match(/windowsHide/g)).toHaveLength(8);
     expect(packedDist).not.toContain("execSync(");
-    expect(packedDist.match(/windowsHide: true/g)).toHaveLength(7);
+    expect(packedDist.match(/windowsHide: true/g)).toHaveLength(8);
     expect(packedDist).toContain("gitTopLevelCacheMap");
   });
 

--- a/src/lib/__tests__/worktree-paths-bare-container.test.ts
+++ b/src/lib/__tests__/worktree-paths-bare-container.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearWorktreeCache,
+  probeGitTopLevel,
+  setGitShowToplevelProbeForTests,
+  validateWorkingDirectory,
+  resolveWorkingDirectoryOrLinkedWorktree,
+  validateWorkingDirectoryOrLinkedWorktree,
+} from '../../lib/worktree-paths.js';
+
+// The `git worktree` container layout (#3990): a bare repository lives at
+// `<container>/.bare`, `<container>/.git` is a file pointing at it, and every
+// checkout is a sibling linked worktree. `git rev-parse --show-toplevel` in the
+// container exits 128 with "this operation must be run in a work tree" — a
+// benign absence of a work tree, not an unreadable repository. Before the fix
+// that answer was classified as `probe_failed`, so the fail-closed guards threw
+// and the HUD statusline printed "[OMC] HUD error" from a legitimate container.
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+    env: { ...process.env, LC_ALL: 'C', GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+  });
+}
+
+describe('bare-repository worktree container', () => {
+  let tempDir: string;
+  let container: string;
+  let linkedWorktree: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'bare-container-')));
+    container = join(tempDir, 'hub');
+    mkdirSync(container, { recursive: true });
+
+    git(container, ['init', '--bare', '--initial-branch=main', '.bare']);
+    writeFileSync(join(container, '.git'), 'gitdir: ./.bare\n');
+
+    // A bare repository has no commits yet, so create one through a temporary
+    // worktree so that `git worktree add` has a real branch to check out.
+    const seed = join(tempDir, 'seed');
+    git(tempDir, ['clone', join(container, '.bare'), 'seed']);
+    writeFileSync(join(seed, 'README.md'), '# hub\n');
+    git(seed, ['add', 'README.md']);
+    git(seed, ['-c', 'user.email=t@example.com', '-c', 'user.name=t', 'commit', '-m', 'seed']);
+    git(seed, ['push', 'origin', 'HEAD:refs/heads/main']);
+    rmSync(seed, { recursive: true, force: true });
+
+    linkedWorktree = join(container, 'feature');
+    git(container, ['worktree', 'add', 'feature', 'main']);
+
+    setGitShowToplevelProbeForTests(undefined);
+    clearWorktreeCache();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    setGitShowToplevelProbeForTests(undefined);
+    clearWorktreeCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('classifies the bare container as not_a_repository instead of probe_failed', () => {
+    expect(probeGitTopLevel(container).status).toBe('not_a_repository');
+  });
+
+  it('still resolves a real work tree inside the container', () => {
+    const probe = probeGitTopLevel(linkedWorktree);
+    expect(probe.status).toBe('ok');
+    if (probe.status !== 'ok') return;
+    expect(realpathSync(probe.root)).toBe(realpathSync(linkedWorktree));
+  });
+
+  it('validateWorkingDirectory returns the container instead of throwing', () => {
+    process.chdir(container);
+    clearWorktreeCache();
+
+    expect(realpathSync(validateWorkingDirectory())).toBe(container);
+    expect(realpathSync(validateWorkingDirectory(container))).toBe(container);
+  });
+
+  it('resolveWorkingDirectoryOrLinkedWorktree degrades instead of throwing from the container', () => {
+    process.chdir(container);
+    clearWorktreeCache();
+
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree();
+    expect(resolution.status).toBe('ok');
+    if (resolution.status !== 'ok') return;
+    expect(realpathSync(resolution.root)).toBe(container);
+
+    expect(realpathSync(validateWorkingDirectoryOrLinkedWorktree(container))).toBe(container);
+  });
+
+  it('reaches the linked worktree from the container as the session cwd', () => {
+    process.chdir(container);
+    clearWorktreeCache();
+
+    const resolution = resolveWorkingDirectoryOrLinkedWorktree(linkedWorktree);
+    expect(resolution.status).toBe('ok');
+    if (resolution.status !== 'ok') return;
+    expect(realpathSync(resolution.root)).toBe(realpathSync(linkedWorktree));
+  });
+
+  it('keeps rejecting a non-bare directory that only carries a bogus .git', () => {
+    const bogus = join(tempDir, 'bogus');
+    mkdirSync(bogus, { recursive: true });
+    writeFileSync(join(bogus, '.git'), 'gitdir: /nonexistent/elsewhere\n');
+    process.chdir(container);
+    clearWorktreeCache();
+
+    expect(() => resolveWorkingDirectoryOrLinkedWorktree(bogus)).toThrow(
+      /git probe failed and was not used/,
+    );
+  });
+});

--- a/src/lib/worktree-paths.ts
+++ b/src/lib/worktree-paths.ts
@@ -483,7 +483,39 @@ function isNotAGitRepositoryError(error: unknown): boolean {
     return false;
   }
   const stderr = gitErrorStderr(error);
-  return err.status === 128 && /not a git repository/i.test(stderr);
+  // A bare repository (the `git worktree` container layout: a bare `.git` at the
+  // container root with sibling linked worktrees) answers `rev-parse
+  // --show-toplevel` with exit 128 and "this operation must be run in a work
+  // tree" rather than "not a git repository". That is a benign absence of a work
+  // tree, not an unreadable git, so it must classify as not_a_repository instead
+  // of probe_failed — otherwise every fail-closed caller (HUD statusline, state
+  // resolution) throws from a legitimate container root (#3990).
+  return err.status === 128 && /(?:not a git repository|must be run in a work tree)/i.test(stderr);
+}
+
+/**
+ * True when `cwd` is inside a bare repository.
+ *
+ * A bare container legitimately carries a `.git` file (`gitdir: ./.bare`), so
+ * the `.git`-present guards below cannot treat its presence as evidence of a
+ * broken or foreign repository. Any failure to answer is reported as not bare,
+ * which keeps those guards fail-closed by default.
+ */
+function isBareRepository(cwd: string): boolean {
+  try {
+    return (
+      execFileSync('git', ['rev-parse', '--is-bare-repository'], {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        timeout: 5000,
+        env: { ...process.env, LC_ALL: 'C' },
+      }).trim() === 'true'
+    );
+  } catch {
+    return false;
+  }
 }
 
 function formatGitProbeDetail(error: unknown): string {
@@ -2239,7 +2271,7 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
     } catch {
       cwdReal = process.cwd();
     }
-    if (existsSync(join(cwdReal, '.git'))) {
+    if (existsSync(join(cwdReal, '.git')) && !isBareRepository(cwdReal)) {
       throw new Error(formatGitProbeFailedMessage(callerLabel));
     }
     trustedRoot = process.cwd();
@@ -2294,7 +2326,11 @@ export function resolveWorkingDirectoryOrLinkedWorktree(workingDirectory?: strin
     throw new Error(`workingDirectory '${workingDirectory}' does not exist or is not accessible.`);
   }
 
-  if (providedProbe.status === 'not_a_repository' && existsSync(join(resolvedReal, '.git'))) {
+  if (
+    providedProbe.status === 'not_a_repository' &&
+    existsSync(join(resolvedReal, '.git')) &&
+    !isBareRepository(resolvedReal)
+  ) {
     throw new Error(formatGitProbeFailedMessage(workingDirectory));
   }
 


### PR DESCRIPTION
Closes #3990.

## Problem

Running Claude Code with `cwd` at a **bare-repository worktree container** (a bare `.git` at the container root, checkouts as sibling linked worktrees) prints `[OMC] HUD error - check stderr` since v5.3.0. It worked in v5.1.0.

`git rev-parse --show-toplevel` in a bare repo exits **128** with `fatal: this operation must be run in a work tree` — not `not a git repository`. `isNotAGitRepositoryError` only matched the latter, so the probe classified a perfectly readable repository as `probe_failed`. The fail-closed guards from the #3858 series then threw where v5.1.0 degraded:

1. `validateWorkingDirectory` throws on `probe_failed`, which the HUD reaches through `readHudState` / `ensureSessionStateDir`.
2. `resolveWorkingDirectoryOrLinkedWorktree` throws on the `not_a_repository` + `existsSync('.git')` branch — and a bare container legitimately has a `.git` **file** (`gitdir: ./.bare`), so this fires too, breaking `resolveStateWorkingDirectory` for the MCP state tools.

`getOmcRoot` already tolerated the layout, which is the inconsistency the reporter identified: state resolution should degrade the same way.

## Fix

- `isNotAGitRepositoryError` also accepts the work-tree stderr, so a bare repo classifies as `not_a_repository`.
- A new `isBareRepository` helper gates both `.git`-present guards (the `cwdReal` branch and the `resolvedReal` branch). Any failure to answer reports *not bare*, so the guards stay fail-closed by default.

Foreign-repo and bogus-`.git` rejection is unchanged: those directories are not bare, so the guards still fire.

Thanks @diblaze — the report already contained the exact root cause, the exit code, and the two guard sites; this PR is that diagnosis plus regression coverage.

## Verification

New `src/lib/__tests__/worktree-paths-bare-container.test.ts` builds a **real** bare container with a linked worktree (no probe stubs) and asserts:

- the container classifies as `not_a_repository`
- the linked worktree still probes `ok` to its own root
- `validateWorkingDirectory()` / `validateWorkingDirectory(container)` return the container
- `resolveWorkingDirectoryOrLinkedWorktree()` degrades to `ok` from the container
- the linked worktree is reachable with the container as session cwd
- a non-bare directory carrying only a bogus `.git` **still** fails closed

`vitest run src/lib/__tests__/worktree-paths-bare-container.test.ts` → **6/6 passed** with the fix, and **4 of 6 fail without it** with the exact `git probe failed and was not used` error from the report — so the coverage is not tautological.

`inventory/inventory-graph.json` regenerated (anchored to the `dev` head `9a0a33ac`, which stays an ancestor across the squash merge) and `tests/lint/inventory-graph-drift.test.ts` → **11/11 passed**.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*