### PR TITLE
chore(ci): authorize generated artifacts for release PR #3988

### DIFF
--- a/.github/generated-artifact-authorizations.json
+++ b/.github/generated-artifact-authorizations.json
@@ -17416,6 +17416,26 @@
           "previousFilename": null
         }
       ]
+    },
+    {
+      "pullNumber": 3988,
+      "targetRef": "main",
+      "mergeBaseSha": "4820f5641828cb980b7eb488a3c187f3d01459c3",
+      "headSha": "d38ed1dbdd5330553c1aa3a93230a8107cd72346",
+      "owner": "Yeachan-Heo",
+      "expiresAt": "2026-10-31T00:00:00.000Z",
+      "generatedDelta": {
+        "count": 1,
+        "sha256": "b54e0c18656ed71b93a2092403a330fa5c98f665402a34711732d5c6ad5439d6"
+      },
+      "generatedFiles": [
+        {
+          "status": "modified",
+          "filename": "bridge/claude-md-coordinator.cjs",
+          "sha": "6b4ba0bc504ce8a97768ef8d9e7d49be1113635d",
+          "previousFilename": null
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the base-owned generated-artifact authorization entry for release PR #3988 (`chore(release): v5.4.0`).

- `pullNumber`: 3988, `targetRef`: `main`
- `mergeBaseSha`: `4820f5641828cb980b7eb488a3c187f3d01459c3`
- `headSha`: `d38ed1dbdd5330553c1aa3a93230a8107cd72346` (GitHub-verified, author `Yeachan-Heo`)
- `generatedDelta`: `count: 1`, `sha256: b54e0c18656ed71b93a2092403a330fa5c98f665402a34711732d5c6ad5439d6`
- authorized closure: `bridge/claude-md-coordinator.cjs` (`6b4ba0bc504ce8a97768ef8d9e7d49be1113635d`) — the only generated path in the release bump (`COMPILED_ENGINE_VERSION` 5.3.0 → 5.4.0)

## Why

`Authorize generated artifacts from base trust root` on #3988 failed with `generated changes have no base-owned authorization entry`. The verifier reads this manifest from the base trust root, so the entry must land on `main` before the release PR can pass.

Validated locally against `validateAuthorizationManifest` from `scripts/verify-generated-artifact-authorization.mjs@main`: 26 entries, no schema/digest/closure errors.

## Merge order

1. Merge this PR into `main`.
2. Reopen (or re-sync) #3988 so `pull_request_target` re-evaluates authorization against the updated trust root.
3. Merge #3988. `headSha` is pinned, so #3988 must not receive another push before then.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
