### PR TITLE
fix(team): validate effective providers and harden launch gate ownership

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b26c25055cdc56165a12920549211afc0cb6542c",
-    "sourceSha256": "2358964b8316010d2d013345c71b4253f368301119f2cb8e9761599cfb749dc8",
+    "head": "d9a780e225a5488e95068818a56b8c19a3d8581d",
+    "sourceSha256": "a2910cadc994d0d3d94a9e0e53efcd291f3000d34e919eb260d0f2de9ac864be",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b26c25055cdc56165a12920549211afc0cb6542c",
-  "sourceSha256": "2358964b8316010d2d013345c71b4253f368301119f2cb8e9761599cfb749dc8",
+  "head": "d9a780e225a5488e95068818a56b8c19a3d8581d",
+  "sourceSha256": "a2910cadc994d0d3d94a9e0e53efcd291f3000d34e919eb260d0f2de9ac864be",
   "counts": {
     "public": {
       "skills": 38,
@@ -77697,5 +77697,5 @@
     }
   },
   "inventorySha256": "96b61cb5df14663620165d68dbccea8b03c6757c289db671e8a2be1356240e0e",
-  "manifestSha256": "d482f08eb37c9bee0e351071e5984c5c798f7cda50346ee93760d57da3eb1ed9"
+  "manifestSha256": "d450ef926124ad3f0dffe04de526b5748d44327bf13281b737558ea7324e5b7b"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "d9a780e225a5488e95068818a56b8c19a3d8581d",
-    "sourceSha256": "a2910cadc994d0d3d94a9e0e53efcd291f3000d34e919eb260d0f2de9ac864be",
+    "head": "654c8abcc3e4d121c56e9df69d75ab9813b77136",
+    "sourceSha256": "9fae15e15f13eb38f4ae768f08239bd69fc8561f0c57552abf611808a7888c24",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "d9a780e225a5488e95068818a56b8c19a3d8581d",
-  "sourceSha256": "a2910cadc994d0d3d94a9e0e53efcd291f3000d34e919eb260d0f2de9ac864be",
+  "head": "654c8abcc3e4d121c56e9df69d75ab9813b77136",
+  "sourceSha256": "9fae15e15f13eb38f4ae768f08239bd69fc8561f0c57552abf611808a7888c24",
   "counts": {
     "public": {
       "skills": 38,
@@ -77697,5 +77697,5 @@
     }
   },
   "inventorySha256": "96b61cb5df14663620165d68dbccea8b03c6757c289db671e8a2be1356240e0e",
-  "manifestSha256": "d450ef926124ad3f0dffe04de526b5748d44327bf13281b737558ea7324e5b7b"
+  "manifestSha256": "0001d6524990d7d1f13c894417fb92fb919fa52e1146562fa0b9d066f3883c2c"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "9a0a33ac852c111750af80cc8dd4783b9c61452c",
-    "sourceSha256": "f0f63327b4173e60ffa8121f30a19f22a86fa4e3bae370a4f23b62c155d6339e",
+    "head": "b26c25055cdc56165a12920549211afc0cb6542c",
+    "sourceSha256": "2358964b8316010d2d013345c71b4253f368301119f2cb8e9761599cfb749dc8",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "9a0a33ac852c111750af80cc8dd4783b9c61452c",
-  "sourceSha256": "f0f63327b4173e60ffa8121f30a19f22a86fa4e3bae370a4f23b62c155d6339e",
+  "head": "b26c25055cdc56165a12920549211afc0cb6542c",
+  "sourceSha256": "2358964b8316010d2d013345c71b4253f368301119f2cb8e9761599cfb749dc8",
   "counts": {
     "public": {
       "skills": 38,
@@ -70025,11 +70025,6 @@
       },
       {
         "from": "src/team/__tests__/runtime-v2.cursor-routing.test.ts",
-        "to": "src/team/model-contract.ts",
-        "kind": "type-imports"
-      },
-      {
-        "from": "src/team/__tests__/runtime-v2.cursor-routing.test.ts",
         "to": "src/team/runtime-v2.ts",
         "kind": "imports"
       },
@@ -70100,11 +70095,6 @@
       },
       {
         "from": "src/team/__tests__/runtime-v2.explicit-provider-routing.test.ts",
-        "to": "src/team/model-contract.ts",
-        "kind": "type-imports"
-      },
-      {
-        "from": "src/team/__tests__/runtime-v2.explicit-provider-routing.test.ts",
         "to": "src/team/runtime-v2.ts",
         "kind": "imports"
       },
@@ -70151,6 +70141,11 @@
       {
         "from": "src/team/__tests__/runtime-v2.gemini-preflight.test.ts",
         "to": "src/team/runtime-v2.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/runtime-v2.gemini-preflight.test.ts",
+        "to": "src/team/types.ts",
         "kind": "imports"
       },
       {
@@ -73472,6 +73467,11 @@
         "from": "src/team/runtime-v2.ts",
         "to": "src/team/tmux-session.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/team/runtime-v2.ts",
+        "to": "src/team/types.ts",
+        "kind": "imports"
       },
       {
         "from": "src/team/runtime-v2.ts",
@@ -77692,10 +77692,10 @@
     "stats": {
       "nodeCount": 6903,
       "edgeCount": 7369,
-      "importEdgeCount": 6066,
+      "importEdgeCount": 6068,
       "registerEdgeCount": 59
     }
   },
   "inventorySha256": "96b61cb5df14663620165d68dbccea8b03c6757c289db671e8a2be1356240e0e",
-  "manifestSha256": "b36c49788f4360d6d930547c914ee4e072bb44cf4a13b1891cae2ff96e553dc7"
+  "manifestSha256": "d482f08eb37c9bee0e351071e5984c5c798f7cda50346ee93760d57da3eb1ed9"
 }

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -962,11 +962,11 @@ Precedence: `OMC_TEAM_ROLE_OVERRIDES` > `.claude/omc.jsonc` (project) > `~/.conf
 
 ### Missing CLI preflight
 
-Team startup strictly preflights only providers that are effective for its initial workers, including idle-worker assignments and explicit role routes. A missing, relative, or untrusted binary for a selected provider fails before team state or multiplexer side effects are created. Providers that are merely present in the routing snapshot or declared agent list but are not selected are not probed. Routing is authoritative: the runtime never silently changes a selected role to Claude when its provider is unavailable. Scale-up and worker recovery independently preflight the provider they are about to launch and fail closed if it is unavailable. Probe provider availability with `omc doctor --team-routing`.
+Team startup strictly preflights only providers that are effective for its initial workers, including idle-worker assignments and explicit role routes. Role routing selects each worker's initial startup provider; later tasks delivered to an existing pane keep that worker's provider and are not re-routed by task role. A missing, relative, or untrusted binary for a selected provider fails before team state or multiplexer side effects are created. Providers that are merely present in the routing snapshot or declared agent list, including providers for roles never selected for a launch, are not probed. Routing is authoritative: the runtime never silently changes a selected role to Claude when its provider is unavailable. Scale-up and worker recovery independently preflight the provider they are about to launch and fail closed if it is unavailable. Probe provider availability with `omc doctor --team-routing`.
 
 ### Stickiness — resolved once, reused everywhere
 
-Resolved routing is immutable per team. Editing config mid-team-lifetime does not affect running teams; a new `/team` invocation picks up the new mapping. This guarantees that spawn, scale-up, and worker-restart all see identical routing, including across worktree detaches (the snapshot travels with `TeamConfig`).
+Resolved routing is immutable per team. It selects each worker's initial startup assignment; later tasks in an existing pane stay on that worker's provider instead of triggering task-role provider re-routing. Editing config mid-team-lifetime does not affect running teams; a new `/team` invocation picks up the new mapping. Spawn, scale-up, and worker-restart use the same snapshot for the workers they launch, including across worktree detaches (the snapshot travels with `TeamConfig`).
 
 ### Zero-config behavior
 

--- a/skills/team/SKILL.md
+++ b/skills/team/SKILL.md
@@ -613,6 +613,12 @@ Tmux CLI workers run in dedicated tmux panes with filesystem access. They are **
 - They run as one-shot autonomous jobs, not persistent teammates
 - The lead manages their lifecycle (spawn, monitor, collect results)
 
+### Cursor/Codex startup evidence timeout
+
+The v2 runtime waits up to 30 seconds for current-attempt task/status evidence. If that is absent, a read-only pane activity probe can grant a busy Cursor/Codex worker one additional 30-second evidence window. An idle, dead, or unverified pane gets only the normal 1-second final recheck. The trigger is never resent, and pane activity alone never counts as successful startup.
+
+The default busy-worker evidence budget is therefore 60 seconds, plus probe and evidence-read overhead (roughly a minute, not a hard 61-second wall-clock limit). Pane creation, readiness, and cleanup add separate time. Startup is serial, so these waits can accumulate per worker. `OMC_TEAM_ENGAGED_PANE_RECHECK_MS` overrides the additional window in milliseconds; positive values are capped at 120000, while invalid or non-positive values retain the default.
+
 ### When to Route Where
 
 | Task Type                        | Best Route                     | Why                                                 |
@@ -954,9 +960,9 @@ OMC_TEAM_ROLE_OVERRIDES='{"critic":{"provider":"codex"},"code-reviewer":{"provid
 
 Precedence: `OMC_TEAM_ROLE_OVERRIDES` > `.claude/omc.jsonc` (project) > `~/.config/claude-omc/config.jsonc` (user) > built-in defaults. Invalid JSON logs a warning and is ignored — env overrides are best-effort and never abort the run.
 
-### Fallback when a CLI is missing
+### Missing CLI preflight
 
-If the CLI for a configured provider is absent from `PATH` at spawn time, `buildLaunchArgs()` throws, the team lead emits a visible team/conversation warning, and the runtime falls back to a deterministic Claude assignment pre-computed by `buildResolvedRoutingSnapshot` (same tier + same agent, `provider: "claude"`) only when the Claude CLI is resolvable. If the Claude CLI is unavailable, no runnable fallback exists: orchestration/startup is unavailable and the warning stays loud rather than claiming a fallback. Probe provider availability with `omc doctor --team-routing`.
+Team startup strictly preflights only providers that are effective for its initial workers, including idle-worker assignments and explicit role routes. A missing, relative, or untrusted binary for a selected provider fails before team state or multiplexer side effects are created. Providers that are merely present in the routing snapshot or declared agent list but are not selected are not probed. Routing is authoritative: the runtime never silently changes a selected role to Claude when its provider is unavailable. Scale-up and worker recovery independently preflight the provider they are about to launch and fail closed if it is unavailable. Probe provider availability with `omc doctor --team-routing`.
 
 ### Stickiness — resolved once, reused everywhere
 

--- a/src/__tests__/skills.test.ts
+++ b/src/__tests__/skills.test.ts
@@ -632,13 +632,22 @@ describe('Builtin Skills', () => {
       expect(skill?.template).toContain('Only when no tmux-compatible binary is available');
     });
 
-    it('conditions team Claude fallback guidance on Claude CLI availability', () => {
+    it('documents fail-closed provider preflight instead of implicit Claude fallback', () => {
       const skill = getBuiltinSkill('team');
       expect(skill).toBeDefined();
-      expect(skill?.template).toContain('only when the Claude CLI is resolvable');
-      expect(skill?.template).toContain('no runnable fallback exists');
-      expect(skill?.template).toContain('orchestration/startup is unavailable');
+      expect(skill?.template).toContain('Missing CLI preflight');
+      expect(skill?.template).toContain(
+        'strictly preflights only providers that are effective for its initial workers',
+      );
+      expect(skill?.template).toContain(
+        'fails before team state or multiplexer side effects are created',
+      );
+      expect(skill?.template).toContain(
+        'never silently changes a selected role to Claude when its provider is unavailable',
+      );
+      expect(skill?.template).toContain('fail closed if it is unavailable');
       expect(skill?.template).toContain('omc doctor --team-routing');
+      expect(skill?.template).not.toContain('only when the Claude CLI is resolvable');
     });
 
 

--- a/src/team/__tests__/runtime-v2-role-routing.test.ts
+++ b/src/team/__tests__/runtime-v2-role-routing.test.ts
@@ -212,6 +212,27 @@ describe('runtime-v2 role routing — processCliWorkerVerdicts (AC-7)', () => {
     return { teamRoot, outputFile, taskPath };
   }
 
+  it('keeps a configured role provider authoritative instead of changing to its fallback', async () => {
+    const { resolveTaskAssignment } = await import('../runtime-v2.js');
+    const assignment = resolveTaskAssignment(
+      { subject: 'Review PR', description: 'Inspect the implementation', role: 'executor' },
+      {
+        executor: {
+          primary: { provider: 'gemini', model: 'gemini-2.5-pro', agent: 'executor' },
+          fallback: { provider: 'claude', model: 'sonnet', agent: 'executor' },
+        },
+      } as any,
+      { executor: { provider: 'gemini' } } as any,
+      'claude',
+    );
+
+    expect(assignment).toMatchObject({
+      agentType: 'gemini',
+      model: 'gemini-2.5-pro',
+      role: 'executor',
+    });
+  });
+
   it('approve verdict transitions task to completed and renames verdict file', async () => {
     cwd = await mkdtempFixture('omc-runtime-routing-approve-');
     const { outputFile, taskPath } = await bootstrap({ verdict: 'approve' });

--- a/src/team/__tests__/runtime-v2.cursor-routing.test.ts
+++ b/src/team/__tests__/runtime-v2.cursor-routing.test.ts
@@ -2,13 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { resolveTaskAssignment } from '../runtime-v2.js';
 import { buildResolvedRoutingSnapshot } from '../stage-router.js';
-import type { CliAgentType } from '../model-contract.js';
 
 const resolvedRouting = buildResolvedRoutingSnapshot({});
-const binaries: Partial<Record<CliAgentType, string>> = {
-  claude: '/usr/bin/claude',
-  cursor: '/usr/bin/cursor-agent',
-};
 
 /**
  * Cursor used to be pinned to the executor role: reviewer-style roles threw,
@@ -23,7 +18,6 @@ describe('runtime-v2 cursor task assignment', () => {
       { subject: 'Implement plan', description: 'apply the implementation plan' },
       resolvedRouting,
       undefined,
-      binaries,
       'cursor',
     );
 
@@ -44,7 +38,6 @@ describe('runtime-v2 cursor task assignment', () => {
         { subject: description, description },
         resolvedRouting,
         undefined,
-        binaries,
         'cursor',
       );
 
@@ -57,7 +50,6 @@ describe('runtime-v2 cursor task assignment', () => {
       { subject: 'Executor task', description: 'apply the implementation plan', role: 'executor' },
       resolvedRouting,
       undefined,
-      binaries,
       'cursor',
     );
 
@@ -70,7 +62,6 @@ describe('runtime-v2 cursor task assignment', () => {
         { subject: 'Review the change', description: 'inspect without editing', role },
         resolvedRouting,
         undefined,
-        binaries,
         'cursor',
       );
 
@@ -88,7 +79,7 @@ describe('runtime-v2 cursor task assignment', () => {
 
     for (const task of cases) {
       expect(() =>
-        resolveTaskAssignment(task, resolvedRouting, undefined, binaries, 'cursor'),
+        resolveTaskAssignment(task, resolvedRouting, undefined, 'cursor'),
       ).not.toThrow();
     }
   });
@@ -101,7 +92,6 @@ describe('runtime-v2 cursor task assignment', () => {
       { subject: 'Review auth', description: 'review the auth module for maintainability' },
       resolvedRouting,
       undefined,
-      binaries,
       'cursor',
     );
 

--- a/src/team/__tests__/runtime-v2.explicit-provider-routing.test.ts
+++ b/src/team/__tests__/runtime-v2.explicit-provider-routing.test.ts
@@ -2,15 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { resolveTaskAssignment } from '../runtime-v2.js';
 import { buildResolvedRoutingSnapshot } from '../stage-router.js';
-import type { CliAgentType } from '../model-contract.js';
 
 const resolvedRouting = buildResolvedRoutingSnapshot({});
-const binaries: Partial<Record<CliAgentType, string>> = {
-  claude: '/usr/bin/claude',
-  gemini: '/usr/bin/gemini',
-  codex: '/usr/bin/codex',
-  antigravity: '/usr/bin/agy',
-};
 
 describe('runtime-v2 explicit provider + role preservation', () => {
   // Regression: `1:antigravity:executor` must launch antigravity, not silently fall
@@ -20,7 +13,6 @@ describe('runtime-v2 explicit provider + role preservation', () => {
       { subject: 'Executor task', description: 'apply the implementation', role: 'executor' },
       resolvedRouting,
       undefined,
-      binaries,
       'antigravity',
     );
     expect(assignment).toEqual({ agentType: 'antigravity', model: '', role: 'executor' });
@@ -31,7 +23,6 @@ describe('runtime-v2 explicit provider + role preservation', () => {
       { subject: 'Review', description: 'review the change', role: 'reviewer' },
       resolvedRouting,
       undefined,
-      binaries,
       'gemini',
     );
     expect(assignment.agentType).toBe('gemini');
@@ -44,7 +35,6 @@ describe('runtime-v2 explicit provider + role preservation', () => {
       { subject: 'Executor task', description: 'apply the implementation', role: 'executor' },
       resolvedRouting,
       undefined,
-      binaries,
       'claude',
     );
     expect(assignment.agentType).toBe('claude');

--- a/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
+++ b/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { ABSOLUTE_MAX_WORKERS } from '../types.js';
@@ -180,6 +180,25 @@ describe('runtime-v2 Gemini preflight routing', () => {
       .rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('rejects an empty provider list before provider preflight or state creation', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'invalid-agent-types-'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    await expect(startTeamV2({
+      teamName: 'invalid-agent-types-team',
+      workerCount: 1,
+      agentTypes: [],
+      tasks: [],
+      cwd,
+      pluginConfig: {},
+    })).rejects.toThrow('Invalid agent types. Expected at least one provider.');
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalled();
+    expect(mocks.createTeamSession).not.toHaveBeenCalled();
+    await expect(import('node:fs/promises').then(fs => fs.access(join(cwd, '.omc', 'state', 'team', 'invalid-agent-types-team'))))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it.each([false, true])('starts a gemini-only team without unused claude (has task: %s)', async (hasTask) => {
     cwd = await mkdtemp(join(tmpdir(), 'unused-default-claude-'));
     modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
@@ -292,6 +311,84 @@ describe('runtime-v2 Gemini preflight routing', () => {
     })).resolves.toBeDefined();
     expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledExactlyOnceWith('codex');
     expect(mocks.spawnOwnedWorkerInPane.mock.calls[0]?.[2]).toMatchObject({ provider: 'codex' });
+  });
+
+  it('uses the prepared Cursor reviewer launch for the real worker overlay', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'cursor-reviewer-overlay-'));
+    modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
+      if (agentType === 'claude') throw new Error('CLI binary not found: claude');
+      return `/usr/bin/${agentType ?? 'claude'}`;
+    });
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'cursor-reviewer-overlay-team',
+      workerCount: 1,
+      agentTypes: ['claude'],
+      tasks: [{ subject: 'Review code', description: 'Review code without editing files', role: 'code-reviewer' }],
+      cwd,
+      pluginConfig: {
+        team: { roleRouting: { 'code-reviewer': { provider: 'cursor' } } },
+      } as any,
+    });
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledExactlyOnceWith('cursor');
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalledWith('claude');
+    expect(mocks.spawnOwnedWorkerInPane.mock.calls[0]?.[2]).toMatchObject({ provider: 'cursor' });
+    expect(runtime.config).toMatchObject({
+      max_workers: ABSOLUTE_MAX_WORKERS,
+      workers: [{ worker_cli: 'cursor', role: 'code-reviewer', launch_descriptor: { provider: 'cursor' } }],
+    });
+
+    const overlay = await readFile(join(
+      runtime.config.team_state_root!,
+      'workers',
+      'worker-1',
+      'AGENTS.md',
+    ), 'utf8');
+    expect(overlay).toContain('### Agent-Type Guidance (cursor)');
+    expect(overlay).toMatch(/do NOT run .*transition-task-status.*reviewer assignment/);
+    expect(overlay).toContain('## BEFORE YOU YIELD THE REVIEW TURN');
+    expect(overlay).not.toMatch(/## BEFORE YOU EXIT[\s\S]*transition-task-status/);
+  });
+
+  it('uses the prepared Claude launch when routing replaces a declared Cursor provider', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'claude-reviewer-overlay-'));
+    modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
+      if (agentType === 'cursor') throw new Error('CLI binary not found: cursor');
+      return `/usr/bin/${agentType ?? 'claude'}`;
+    });
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'claude-reviewer-overlay-team',
+      workerCount: 1,
+      agentTypes: ['cursor'],
+      tasks: [{ subject: 'Review code', description: 'Review code without editing files', role: 'code-reviewer' }],
+      cwd,
+      pluginConfig: {
+        team: { roleRouting: { 'code-reviewer': { provider: 'claude' } } },
+      } as any,
+    });
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledExactlyOnceWith('claude');
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalledWith('cursor');
+    expect(mocks.spawnOwnedWorkerInPane.mock.calls[0]?.[2]).toMatchObject({ provider: 'claude' });
+    expect(runtime.config.workers[0]).toMatchObject({
+      worker_cli: 'claude',
+      role: 'code-reviewer',
+      launch_descriptor: { provider: 'claude' },
+    });
+
+    const overlay = await readFile(join(
+      runtime.config.team_state_root!,
+      'workers',
+      'worker-1',
+      'AGENTS.md',
+    ), 'utf8');
+    expect(overlay).toContain('### Agent-Type Guidance (claude)');
+    expect(overlay).not.toContain('### Agent-Type Guidance (cursor)');
+    expect(overlay).toMatch(/## BEFORE YOU EXIT[\s\S]*transition-task-status/);
   });
 
   it.each([

--- a/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
+++ b/src/team/__tests__/runtime-v2.gemini-preflight.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { ABSOLUTE_MAX_WORKERS } from '../types.js';
 
 const mocks = vi.hoisted(() => ({
   createTeamSession: vi.fn(),
   spawnWorkerInPane: vi.fn(),
   spawnOwnedWorkerInPane: vi.fn(),
+  deliverStartupInbox: vi.fn(),
   sendToWorker: vi.fn(),
   waitForPaneReady: vi.fn(),
   applyMainVerticalLayout: vi.fn(),
@@ -55,6 +57,7 @@ vi.mock('../tmux-session.js', async importOriginal => ({
   createTeamSession: mocks.createTeamSession,
   spawnWorkerInPane: mocks.spawnWorkerInPane,
   spawnOwnedWorkerInPane: mocks.spawnOwnedWorkerInPane,
+  deliverStartupInbox: mocks.deliverStartupInbox,
   sendToWorker: mocks.sendToWorker,
   waitForPaneReady: mocks.waitForPaneReady,
   paneHasActiveTask: vi.fn(() => false),
@@ -88,9 +91,26 @@ vi.mock('../mcp-comm.js', () => ({
 
 describe('runtime-v2 Gemini preflight routing', () => {
   let cwd = '';
+  let home = '';
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'provider-preflight-home-'));
+    vi.stubEnv('HOME', home);
+    vi.stubEnv('USERPROFILE', home);
+    vi.stubEnv('OMC_STATE_DIR', undefined);
     vi.resetModules();
+    mocks.createTeamSession.mockClear();
+    mocks.spawnWorkerInPane.mockClear();
+    mocks.spawnOwnedWorkerInPane.mockClear();
+    mocks.waitForPaneReady.mockClear();
+    mocks.applyMainVerticalLayout.mockClear();
+    mocks.tmuxExecAsync.mockClear();
+    mocks.queueInboxInstruction.mockClear();
+    modelContractMocks.buildWorkerArgv.mockClear();
+    modelContractMocks.resolveValidatedBinaryPath.mockClear().mockImplementation((agentType?: string) => {
+      if (agentType === 'gemini') throw new Error('Resolved CLI binary \'gemini\' to untrusted location: /tmp/gemini');
+      return `/usr/bin/${agentType ?? 'claude'}`;
+    });
     mocks.createTeamSession.mockResolvedValue({
       sessionName: 'issue2675-session',
       leaderPaneId: '%1',
@@ -112,6 +132,19 @@ describe('runtime-v2 Gemini preflight routing', () => {
       };
     });
     mocks.waitForPaneReady.mockResolvedValue(true);
+    mocks.deliverStartupInbox.mockImplementation(async (context: {
+      attempt: { attempt_id: string; team_name: string; worker_name: string };
+    }) => {
+      const workerDir = join(cwd, '.omc', 'state', 'team', context.attempt.team_name, 'workers', context.attempt.worker_name);
+      await mkdir(workerDir, { recursive: true });
+      await writeFile(join(workerDir, 'status.json'), JSON.stringify({
+        state: 'working',
+        current_task_id: '1',
+        updated_at: new Date().toISOString(),
+        launch_attempt_id: context.attempt.attempt_id,
+      }));
+      return { ok: true, kind: 'attempted_unconfirmed' };
+    });
     mocks.applyMainVerticalLayout.mockResolvedValue(undefined);
     mocks.tmuxExecAsync.mockImplementation(async (args: string[]) => {
       if (args[0] === 'split-window') {
@@ -123,11 +156,146 @@ describe('runtime-v2 Gemini preflight routing', () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     if (cwd) await rm(cwd, { recursive: true, force: true });
+    if (home) await rm(home, { recursive: true, force: true });
+  });
+
+  it('rejects an invalid worker count before provider preflight or state creation', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'invalid-worker-count-'));
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    await expect(startTeamV2({
+      teamName: 'invalid-worker-count-team',
+      workerCount: 0,
+      agentTypes: ['gemini'],
+      tasks: [],
+      cwd,
+      pluginConfig: {},
+    })).rejects.toThrow(`Invalid worker count "0". Expected 1-${ABSOLUTE_MAX_WORKERS}.`);
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalled();
+    expect(mocks.createTeamSession).not.toHaveBeenCalled();
+    await expect(import('node:fs/promises').then(fs => fs.access(join(cwd, '.omc', 'state', 'team', 'invalid-worker-count-team'))))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it.each([false, true])('starts a gemini-only team without unused claude (has task: %s)', async (hasTask) => {
+    cwd = await mkdtemp(join(tmpdir(), 'unused-default-claude-'));
+    modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
+      if (agentType === 'claude') throw new Error('CLI binary not found: claude');
+      return `/usr/bin/${agentType ?? 'claude'}`;
+    });
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    await expect(startTeamV2({
+      teamName: 'gemini-only-team',
+      workerCount: 1,
+      agentTypes: ['gemini'],
+      tasks: hasTask ? [{ subject: 'Implement feature', description: 'Implement feature', role: 'executor' }] : [],
+      cwd,
+      pluginConfig: {},
+    })).resolves.toBeDefined();
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledWith('gemini');
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalledWith('claude');
+    expect(mocks.createTeamSession).toHaveBeenCalled();
+    if (hasTask) {
+      expect(mocks.spawnOwnedWorkerInPane.mock.calls[0]?.[2]).toMatchObject({ provider: 'gemini' });
+    }
+  });
+
+  it('does not preflight an unused configured external provider', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'unused-configured-provider-'));
+    modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
+      if (agentType === 'gemini') throw new Error('CLI binary not found: gemini');
+      return `/usr/bin/${agentType ?? 'claude'}`;
+    });
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    await expect(startTeamV2({
+      teamName: 'codex-only-team',
+      workerCount: 1,
+      agentTypes: ['codex'],
+      tasks: [{ subject: 'Implement feature', description: 'Implement feature', role: 'executor' }],
+      cwd,
+      pluginConfig: {
+        team: { roleRouting: { writer: { provider: 'gemini' } } },
+      } as any,
+    })).resolves.toBeDefined();
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledWith('codex');
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalledWith('gemini');
+    expect(mocks.createTeamSession).toHaveBeenCalled();
+  });
+
+  it('uses the first explicit-owner task for startup before later unowned work', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'owner-before-unowned-preflight-'));
+    modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
+      if (agentType === 'gemini') throw new Error('CLI binary not found: gemini');
+      if (agentType === 'codex') return '/usr/bin/codex';
+      throw new Error(`CLI binary not found: ${agentType}`);
+    });
+    const { startTeamV2 } = await import('../runtime-v2.js');
+
+    const runtime = await startTeamV2({
+      teamName: 'owner-before-unowned-team',
+      workerCount: 1,
+      agentTypes: ['claude'],
+      tasks: [
+        {
+          subject: 'Implement feature',
+          description: 'Implement the requested feature',
+          owner: 'worker-1',
+          role: 'executor',
+        },
+        {
+          subject: 'Review feature',
+          description: 'Review the implementation',
+          role: 'code-reviewer',
+        },
+      ],
+      cwd,
+      pluginConfig: {
+        team: {
+          roleRouting: {
+            executor: { provider: 'codex' },
+            'code-reviewer': { provider: 'gemini' },
+          },
+        },
+      } as any,
+    });
+
+    expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledExactlyOnceWith('codex');
+    expect(modelContractMocks.resolveValidatedBinaryPath).not.toHaveBeenCalledWith('gemini');
+    expect(mocks.spawnOwnedWorkerInPane.mock.calls[0]?.[2]).toMatchObject({ provider: 'codex' });
+    expect(runtime.config.workers[0]).toMatchObject({
+      worker_cli: 'codex',
+      assigned_tasks: ['1'],
+    });
+  });
+
+  it('does not require a declared provider replaced by an explicit role route', async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'overridden-provider-'));
+    modelContractMocks.resolveValidatedBinaryPath.mockImplementation((agentType?: string) => {
+      if (agentType !== 'codex') throw new Error(`CLI binary not found: ${agentType}`);
+      return '/usr/bin/codex';
+    });
+    const { startTeamV2 } = await import('../runtime-v2.js');
+    await expect(startTeamV2({
+      teamName: 'role-override-team',
+      workerCount: 1,
+      agentTypes: ['claude'],
+      tasks: [{ subject: 'Implement feature', description: 'Implement feature', role: 'executor' }],
+      cwd,
+      pluginConfig: { team: { roleRouting: { executor: { provider: 'codex' } } } },
+    })).resolves.toBeDefined();
+    expect(modelContractMocks.resolveValidatedBinaryPath).toHaveBeenCalledExactlyOnceWith('codex');
+    expect(mocks.spawnOwnedWorkerInPane.mock.calls[0]?.[2]).toMatchObject({ provider: 'codex' });
   });
 
   it.each([
-    ["untrusted absolute", "Resolved CLI binary 'gemini' to untrusted location: /tmp/shadow/gemini"],
+    ["untrusted absolute", "Resolved CLI binary 'gemini' to untrusted location: /tmp/gemini"],
     ["relative", "Resolved CLI binary 'gemini' to relative path: ./gemini"],
     ["missing", "CLI binary not found: gemini"],
   ])('fails before launch for a %s provider path', async (_case, reason) => {
@@ -149,6 +317,8 @@ describe('runtime-v2 Gemini preflight routing', () => {
     expect(mocks.createTeamSession).not.toHaveBeenCalled();
     expect(mocks.spawnOwnedWorkerInPane).not.toHaveBeenCalled();
     expect(modelContractMocks.buildWorkerArgv).not.toHaveBeenCalled();
+    await expect(import('node:fs/promises').then(fs => fs.access(join(cwd, '.omc', 'state', 'team', 'issue2675-team'))))
+      .rejects.toMatchObject({ code: 'ENOENT' });
   });
   it('fails a routed-only provider before state or session side effects', async () => {
     cwd = await mkdtemp(join(tmpdir(), 'routed-provider-preflight-'));

--- a/src/team/__tests__/tmux-session.startup.test.ts
+++ b/src/team/__tests__/tmux-session.startup.test.ts
@@ -543,6 +543,19 @@ describe('worker pane startup safety', () => {
   });
 
   it.each(['codex', 'cursor'] as const)(
+    'does not grant busy grace to a %s trust prompt with interrupt text',
+    async provider => {
+      const context = await acceptedContext(provider);
+      tmuxState.captures = [
+        'Do you trust the contents of this directory?\n› 1. Yes, continue\n  2. No, quit\nesc to interrupt\nctrl+c to stop\n',
+      ];
+
+      await expect(probeStartupPaneActivity(context)).resolves.toBe('idle');
+      expect(tmuxState.args.some(args => args[0] === 'send-keys')).toBe(false);
+    },
+  );
+
+  it.each(['codex', 'cursor'] as const)(
     'classifies an unreadable %s pane as unknown without sending a key',
     async provider => {
       const context = await acceptedContext(provider);

--- a/src/team/__tests__/worker-launch-ack.test.ts
+++ b/src/team/__tests__/worker-launch-ack.test.ts
@@ -639,11 +639,15 @@ describe('worker launch acknowledgement', () => {
           outcome: string;
           cleanup_verified: boolean;
           pid: number;
+          exit_code: number | null;
+          signal: string | null;
         };
         expect(terminal).toMatchObject({
           kind: 'worker_launch_provider_terminal',
           outcome: 'exit',
           cleanup_verified: true,
+          exit_code: null,
+          signal: null,
         });
         expect(Number.isSafeInteger(terminal.pid)).toBe(true);
         expect(() => process.kill(-terminal.pid, 0)).toThrow(expect.objectContaining({ code: 'ESRCH' }));
@@ -719,6 +723,254 @@ describe('worker launch acknowledgement', () => {
         .toThrow(expect.objectContaining({ code: 'ESRCH' }));
     } finally {
       await bootstrap?.catch(() => undefined);
+      vi.doUnmock('node:child_process');
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('ignores a late EPIPE emitted after release before start publication', async () => {
+    vi.resetModules();
+    const actualChildProcess = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    type GateSocket = {
+      end: (chunk?: unknown, callback?: (error?: Error | null) => void) => unknown;
+      emit: (event: string, error: unknown) => boolean;
+    };
+    const lateError = Object.assign(new Error('provider gate peer closed'), { code: 'EPIPE' });
+    const spawnMock = vi.fn((
+      command: string,
+      args: string[],
+      options: Parameters<typeof spawn>[2],
+    ) => {
+      const child = actualChildProcess.spawn(command, args, options);
+      child.once('spawn', () => {
+        const gate = child.stdio[3] as unknown as GateSocket | null;
+        if (!gate) return;
+        const nativeEnd = gate.end.bind(gate);
+        gate.end = ((chunk?: unknown, callback?: (error?: Error | null) => void) => {
+          if (chunk !== 'release\n') return nativeEnd(chunk, callback);
+          return nativeEnd(chunk, (error?: Error | null) => {
+            callback?.(error);
+            // The release callback has succeeded, but this peer-close event
+            // arrives before the bootstrap publishes provider-started.
+            gate.emit('error', lateError);
+          });
+        }) as GateSocket['end'];
+      });
+      return child;
+    });
+    vi.doMock('node:child_process', () => ({ ...actualChildProcess, spawn: spawnMock }));
+    let bootstrap: ReturnType<typeof runWorkerLaunchBootstrap> | undefined;
+    const launchAttempt = await attempt();
+    const providerMarker = join(cwd, 'late-release-before-start-provider-ran');
+    const providerStop = join(cwd, 'late-release-before-start-provider-stop');
+    try {
+      const workerLaunch = await import('../worker-launch-ack.js');
+      bootstrap = workerLaunch.runWorkerLaunchBootstrap(buildWorkerLaunchBootstrapSpec(
+        launchAttempt,
+        [process.execPath, '-e', [
+          "const fs=require('node:fs')",
+          `fs.writeFileSync(${JSON.stringify(providerMarker)},'ran')`,
+          `const timer=setInterval(()=>{if(fs.existsSync(${JSON.stringify(providerStop)})){clearInterval(timer);process.exit(0)}},5)`,
+        ].join(';')],
+        cwd,
+      ));
+      await expect(awaitWorkerLaunchAcknowledgement(launchAttempt, {
+        timeoutMs: 2_000,
+        pollIntervalMs: 5,
+      })).resolves.toEqual({ ok: true });
+      await expect(awaitWorkerLaunchProviderStarted(launchAttempt, {
+        timeoutMs: 2_000,
+        pollIntervalMs: 5,
+      })).resolves.toBe(true);
+      await expect(readFile(providerMarker, 'utf8')).resolves.toBe('ran');
+      await writeFile(providerStop, 'stop', 'utf8');
+      await expect(bootstrap).resolves.toEqual({ outcome: 'ran', exitCode: 0, signal: null });
+    } finally {
+      await writeFile(providerStop, 'stop', 'utf8').catch(() => undefined);
+      await terminateWorkerLaunchProvider(launchAttempt, 2_000).catch(() => false);
+      await bootstrap?.catch(() => undefined);
+      vi.doUnmock('node:child_process');
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32').each(['EPIPE', 'ECONNRESET', 'ERR_PROVIDER_GATE_LATE'] as const)(
+    'ignores a post-release %s after provider-start publication',
+    async errorCode => {
+      vi.resetModules();
+      const actualChildProcess = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      type GateSocket = {
+        end: (chunk?: unknown, callback?: (error?: Error | null) => void) => unknown;
+        emit: (event: string, error: unknown) => boolean;
+      };
+      const lateError = Object.assign(new Error(`provider gate ${errorCode}`), { code: errorCode });
+      let emitLateGateError: (() => void) | undefined;
+      const spawnMock = vi.fn((
+        command: string,
+        args: string[],
+        options: Parameters<typeof spawn>[2],
+      ) => {
+        const child = actualChildProcess.spawn(command, args, options);
+        child.once('spawn', () => {
+          const gate = child.stdio[3] as unknown as GateSocket | null;
+          if (!gate) return;
+          const nativeEnd = gate.end.bind(gate);
+          gate.end = ((chunk?: unknown, callback?: (error?: Error | null) => void) => {
+            if (chunk !== 'release\n') return nativeEnd(chunk, callback);
+            return nativeEnd(chunk, (error?: Error | null) => {
+              callback?.(error);
+              emitLateGateError = () => { gate.emit('error', lateError); };
+            });
+          }) as GateSocket['end'];
+        });
+        return child;
+      });
+      vi.doMock('node:child_process', () => ({ ...actualChildProcess, spawn: spawnMock }));
+      let bootstrap: ReturnType<typeof runWorkerLaunchBootstrap> | undefined;
+      const launchAttempt = await attempt();
+      const providerStop = join(cwd, `late-release-${errorCode}-provider-stop`);
+      try {
+        const workerLaunch = await import('../worker-launch-ack.js');
+        bootstrap = workerLaunch.runWorkerLaunchBootstrap(buildWorkerLaunchBootstrapSpec(
+          launchAttempt,
+          [process.execPath, '-e', [
+            "const fs=require('node:fs')",
+            `const timer=setInterval(()=>{if(fs.existsSync(${JSON.stringify(providerStop)})){clearInterval(timer);process.exit(0)}},5)`,
+          ].join(';')],
+          cwd,
+          { releaseAfterSpawn: true },
+        ));
+        await expect(awaitWorkerLaunchAcknowledgement(launchAttempt, {
+          timeoutMs: 2_000,
+          pollIntervalMs: 5,
+        })).resolves.toEqual({ ok: true });
+        await expect(awaitWorkerLaunchProviderStarted(launchAttempt, {
+          timeoutMs: 2_000,
+          pollIntervalMs: 5,
+        })).resolves.toBe(true);
+        expect(emitLateGateError).toBeDefined();
+        emitLateGateError!();
+        await new Promise<void>(resolve => setImmediate(resolve));
+        const started = JSON.parse(await readFile(launchAttempt.startedPath, 'utf8')) as { pid: number };
+        expect(isProcessAlive(started.pid)).toBe(true);
+        await writeFile(providerStop, 'stop', 'utf8');
+        await expect(bootstrap).resolves.toEqual({ outcome: 'ran', exitCode: 0, signal: null });
+      } finally {
+        await writeFile(providerStop, 'stop', 'utf8').catch(() => undefined);
+        await terminateWorkerLaunchProvider(launchAttempt, 2_000).catch(() => false);
+        await bootstrap?.catch(() => undefined);
+        vi.doUnmock('node:child_process');
+        vi.resetModules();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')('does not signal a still-present group after supervisor exit', async () => {
+    vi.resetModules();
+    const actualChildProcess = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    type GateSocket = {
+      end: (chunk?: unknown, callback?: (error?: Error | null) => void) => unknown;
+      emit: (event: string, error: unknown) => boolean;
+    };
+    const lateError = Object.assign(new Error('provider gate peer closed'), { code: 'EPIPE' });
+    let killSupervisor: (() => void) | undefined;
+    let supervisorExited = false;
+    let exitMetadataObserved = false;
+    let postReapTerminateCalls = 0;
+    const nativeTerminate = dynamicProcessUtils.terminateOwnedProcessGroup;
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup').mockImplementation(async options => {
+      if (supervisorExited) {
+        postReapTerminateCalls++;
+        return 'already-dead';
+      }
+      return nativeTerminate(options);
+    });
+    const spawnMock = vi.fn((
+      command: string,
+      args: string[],
+      options: Parameters<typeof spawn>[2],
+    ) => {
+      const child = actualChildProcess.spawn(command, args, options);
+      let gate: GateSocket | null = null;
+      // Attach before returning so this observer runs before the bootstrap's
+      // exit listener. Node has populated signalCode by this point.
+      child.once('exit', () => {
+        supervisorExited = true;
+        exitMetadataObserved = child.exitCode === null && child.signalCode === 'SIGKILL';
+        gate?.emit('error', lateError);
+      });
+      child.once('spawn', () => {
+        gate = child.stdio[3] as unknown as GateSocket | null;
+        if (!gate) return;
+        const nativeEnd = gate.end.bind(gate);
+        gate.end = ((chunk?: unknown, callback?: (error?: Error | null) => void) => {
+          if (chunk !== 'release\n') return nativeEnd(chunk, callback);
+          // Let the provider execute, but withhold the release callback. This
+          // is a real failed release with a live descendant when the supervisor
+          // is killed below.
+          const result = nativeEnd(chunk);
+          killSupervisor = () => { child.kill('SIGKILL'); };
+          return result;
+        }) as GateSocket['end'];
+      });
+      return child;
+    });
+    vi.doMock('node:child_process', () => ({ ...actualChildProcess, spawn: spawnMock }));
+    let bootstrap: ReturnType<typeof runWorkerLaunchBootstrap> | undefined;
+    const launchAttempt = await attempt();
+    let providerPid: number | undefined;
+    let providerGroupId: number | undefined;
+    try {
+      const workerLaunch = await import('../worker-launch-ack.js');
+      bootstrap = workerLaunch.runWorkerLaunchBootstrap(buildWorkerLaunchBootstrapSpec(
+        launchAttempt,
+        [process.execPath, '-e', [
+          "const fs=require('node:fs')",
+          `fs.writeFileSync(${JSON.stringify(join(cwd, 'failed-release-provider.json'))},JSON.stringify({pid:process.pid}))`,
+          'setInterval(()=>{},1000)',
+        ].join(';')],
+        cwd,
+        { releaseAfterSpawn: true },
+      ));
+      await expect(awaitWorkerLaunchAcknowledgement(launchAttempt, {
+        timeoutMs: 2_000,
+        pollIntervalMs: 5,
+      })).resolves.toEqual({ ok: true });
+      const providerMarker = join(cwd, 'failed-release-provider.json');
+      await vi.waitFor(async () => {
+        const record = JSON.parse(await readFile(providerMarker, 'utf8')) as { pid: number };
+        expect(record.pid).toBeGreaterThan(0);
+        providerPid = record.pid;
+      }, { timeout: 2_000, interval: 5 });
+      const ownedGroup = dynamicProcessUtils.captureOwnedProcessGroup(providerPid!);
+      expect(ownedGroup).not.toBeNull();
+      providerGroupId = ownedGroup!.processGroupId;
+      expect(killSupervisor).toBeDefined();
+      killSupervisor!();
+      await expect(bootstrap).resolves.toEqual({ outcome: 'provider_cleanup_unverified' });
+      expect(exitMetadataObserved).toBe(true);
+      expect(postReapTerminateCalls).toBe(0);
+      expect(() => process.kill(-providerGroupId!, 0)).not.toThrow();
+      await vi.waitFor(async () => {
+        const terminal = JSON.parse(await readFile(`${launchAttempt.startedPath}.terminal`, 'utf8'));
+        expect(terminal).toMatchObject({
+          outcome: 'cleanup_unverified',
+          cleanup_verified: false,
+          signal: 'SIGKILL',
+        });
+      }, { timeout: 2_000, interval: 5 });
+      expect(postReapTerminateCalls).toBe(0);
+    } finally {
+      killSupervisor?.();
+      if (!providerGroupId && providerPid) {
+        providerGroupId = dynamicProcessUtils.captureOwnedProcessGroup(providerPid)?.processGroupId;
+      }
+      if (providerGroupId) {
+        try { process.kill(-providerGroupId, 'SIGKILL'); } catch { /* group already absent */ }
+      }
+      await bootstrap?.catch(() => undefined);
+      terminateSpy.mockRestore();
       vi.doUnmock('node:child_process');
       vi.resetModules();
     }

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -61,6 +61,7 @@ import type {
   WorkerStatus,
   WorkerHeartbeat,
 } from './types.js';
+import { ABSOLUTE_MAX_WORKERS } from './types.js';
 import type { TeamPhase } from './phase-controller.js';
 import { validateTeamName } from './team-name.js';
 import { TASK_ID_SAFE_PATTERN, WORKER_NAME_SAFE_PATTERN } from './contracts.js';
@@ -559,14 +560,14 @@ const MONITOR_SIGNAL_STALE_MS = 30_000;
  *   3. Fallback to the `fallbackAgent` round-robin pick if snapshot lookup
  *      fails (role outside canonical vocabulary or snapshot missing).
  *
- * Returns the primary assignment by default; callers swap to the Claude
- * fallback if the primary provider's CLI binary is missing at spawn time.
+ * Returns the authoritative primary assignment for the selected route.
+ * A missing provider binary is a startup error; routing never changes
+ * providers implicitly.
  */
 export function resolveTaskAssignment(
   task: { subject: string; description: string; role?: string },
   resolvedRouting: Record<CanonicalTeamRole, { primary: RoleAssignment; fallback: RoleAssignment }>,
   roleRoutingConfig: Partial<Record<CanonicalTeamRole, TeamRoleAssignmentSpec>> | undefined,
-  resolvedBinaryPaths: Partial<Record<CliAgentType, string>>,
   fallbackAgent: CliAgentType,
 ): { agentType: CliAgentType; model: string; role: CanonicalTeamRole | null } {
   const canonicalRoles = new Set<string>(CANONICAL_TEAM_ROLES as readonly string[]);
@@ -3213,6 +3214,9 @@ async function rollbackStartedNativeWorktreeStartup(args: {
  * NO watchdog polling — the leader drives monitoring via monitorTeamV2().
  */
 export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntimeV2> {
+  if (!Number.isInteger(config.workerCount) || config.workerCount < 1 || config.workerCount > ABSOLUTE_MAX_WORKERS) {
+    throw new Error(`Invalid worker count "${config.workerCount}". Expected 1-${ABSOLUTE_MAX_WORKERS}.`);
+  }
   const sanitized = sanitizeTeamName(config.teamName);
   const leaderCwd = resolve(config.cwd);
   validateTeamName(sanitized);
@@ -3247,35 +3251,88 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
 
   const workspaceMode = worktreeMode === 'disabled' ? 'single' as const : 'worktree' as const;
 
-  // Validate CLIs and pin absolute binary paths for user-declared agentTypes.
-  // Unsupported, relative, missing, or untrusted providers fail before any team
-  // state or multiplexer side effect is created.
   const agentTypes = config.agentTypes as CliAgentType[];
+  const workerNames = Array.from({ length: config.workerCount }, (_, index) => `worker-${index + 1}`);
+  const workerNameSet = new Set(workerNames);
+  const externalModelsDefaults = resolveExternalModelsDefaults(pluginCfg.externalModels?.defaults, process.env);
+  const resolveDefaultModel = (agentType: CliAgentType): string | undefined => {
+    return resolveDefaultWorkerModel(agentType, process.env, externalModelsDefaults);
+  };
+
+  // Resolve the exact startup allocation before any side effects so preflight
+  // covers only providers that can actually be launched. Explicit owners win;
+  // the remaining tasks use the same role-aware allocator as startup below.
+  const startupAllocations: Array<{ workerName: string; taskIndex: number }> = [];
+  const unownedTaskIndices: number[] = [];
+  for (let i = 0; i < config.tasks.length; i++) {
+    const owner = config.tasks[i]?.owner;
+    if (typeof owner === 'string' && workerNameSet.has(owner)) {
+      startupAllocations.push({ workerName: owner, taskIndex: i });
+    } else {
+      unownedTaskIndices.push(i);
+    }
+  }
+  if (unownedTaskIndices.length > 0) {
+    const allocationTasks: TaskAllocationInput[] = unownedTaskIndices.map(idx => ({
+      id: String(idx),
+      subject: config.tasks[idx].subject,
+      description: config.tasks[idx].description,
+      ...(config.tasks[idx].role ? { role: config.tasks[idx].role } : {}),
+    }));
+    const allocationWorkers: WorkerAllocationInput[] = workerNames.map((name, i) => ({
+      name,
+      role: config.workerRoles?.[i]
+        ?? (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as string,
+      currentLoad: 0,
+    }));
+    for (const r of allocateTasksToWorkers(allocationTasks, allocationWorkers)) {
+      startupAllocations.push({ workerName: r.workerName, taskIndex: Number(r.taskId) });
+    }
+  }
+  // Keep the first allocation for each worker as the initial startup task.
+  // Explicit owners are appended before allocator results, so this preserves
+  // owner priority when a worker also receives later unowned work.
+  const startupByWorker = new Map<string, number>();
+  for (const allocation of startupAllocations) {
+    if (!startupByWorker.has(allocation.workerName)) {
+      startupByWorker.set(allocation.workerName, allocation.taskIndex);
+    }
+  }
+
+  // Validate CLIs and pin absolute binary paths for effective startup
+  // assignments only. Unsupported, relative, missing, or untrusted selected
+  // providers fail before any team state or multiplexer side effect is created.
   const resolvedBinaryPaths: Partial<Record<CliAgentType, string>> = {};
   const missingBinaryReasons: Array<{ agentType: CliAgentType; reason: string }> = [];
-  for (const agentType of [...new Set(agentTypes)]) {
+  const startupAssignments = new Map<string, {
+    agentType: CliAgentType;
+    model?: string;
+    role?: CanonicalTeamRole;
+  }>();
+  const effectiveAgentTypes = new Set<CliAgentType>();
+  for (let i = 0; i < workerNames.length; i++) {
+    const workerName = workerNames[i]!;
+    const taskIndex = startupByWorker.get(workerName);
+    const fallbackAgent = (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as CliAgentType;
+    const resolvedAssignment = taskIndex === undefined
+      ? { agentType: fallbackAgent, model: '', role: undefined }
+      : resolveTaskAssignment(config.tasks[taskIndex]!, resolvedRouting,
+        pluginCfg.team?.roleRouting as Partial<Record<CanonicalTeamRole, TeamRoleAssignmentSpec>> | undefined,
+        fallbackAgent);
+    const assignment = {
+      agentType: resolvedAssignment.agentType,
+      model: resolvedAssignment.model || resolveDefaultModel(resolvedAssignment.agentType),
+      ...(resolvedAssignment.role ? { role: resolvedAssignment.role } : {}),
+    };
+    startupAssignments.set(workerName, assignment);
+    effectiveAgentTypes.add(assignment.agentType);
+  }
+  for (const agentType of effectiveAgentTypes) {
     try {
       resolvedBinaryPaths[agentType] = resolvePreflightBinaryPath(agentType).path;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       missingBinaryReasons.push({ agentType, reason });
-    }
-  }
-  if (missingBinaryReasons.length > 0) {
-    const missing = missingBinaryReasons.map(({ agentType, reason }) => `${agentType}:${reason}`).join(';');
-    throw new Error(`cli_binary_preflight_failed:${missing}`);
-  }
-  // Resolve extra providers referenced by routing snapshots. A selected route
-  // without an exact validated path fails before worker launch.
-  for (const { primary } of Object.values(resolvedRouting)) {
-    const provider = primary.provider as CliAgentType;
-    if (resolvedBinaryPaths[provider]) continue;
-    if (missingBinaryReasons.some((m) => m.agentType === provider)) continue;
-    try {
-      resolvedBinaryPaths[provider] = resolvePreflightBinaryPath(provider).path;
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      missingBinaryReasons.push({ agentType: provider, reason });
     }
   }
   if (missingBinaryReasons.length > 0) {
@@ -3307,8 +3364,6 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     }, null, 2), 'utf-8');
   }
 
-  // Build allocation inputs for the new role-aware allocator
-  const workerNames = Array.from({ length: config.workerCount }, (_, index) => `worker-${index + 1}`);
   const workerWorktrees = new Map<string, NonNullable<ReturnType<typeof ensureWorkerWorktree>>>();
   try {
     if (worktreeMode !== 'disabled') {
@@ -3324,54 +3379,12 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     if (!await rollbackUnpersistedNativeWorktreeStartup(sanitized, leaderCwd, error)) throw startupCleanupIncompleteError(error);
     throw error;
   }
-  const workerNameSet = new Set(workerNames);
-
-  // Respect explicit owner fields first, then allocate remaining tasks
-  const startupAllocations: Array<{ workerName: string; taskIndex: number }> = [];
-  const unownedTaskIndices: number[] = [];
-  for (let i = 0; i < config.tasks.length; i++) {
-    const owner = config.tasks[i]?.owner;
-    if (typeof owner === 'string' && workerNameSet.has(owner)) {
-      startupAllocations.push({ workerName: owner, taskIndex: i });
-    } else {
-      unownedTaskIndices.push(i);
-    }
-  }
-
-  if (unownedTaskIndices.length > 0) {
-    const allocationTasks: TaskAllocationInput[] = unownedTaskIndices.map(idx => ({
-      id: String(idx),
-      subject: config.tasks[idx].subject,
-      description: config.tasks[idx].description,
-      ...(config.tasks[idx].role ? { role: config.tasks[idx].role } : {}),
-    }));
-    const allocationWorkers: WorkerAllocationInput[] = workerNames.map((name, i) => ({
-      name,
-      role: config.workerRoles?.[i]
-        ?? (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as string,
-      currentLoad: 0,
-    }));
-    for (const r of allocateTasksToWorkers(allocationTasks, allocationWorkers)) {
-      startupAllocations.push({ workerName: r.workerName, taskIndex: Number(r.taskId) });
-    }
-  }
-
-  const startupByWorker = new Map(startupAllocations.map(item => [item.workerName, item.taskIndex]));
   const preparedLaunches = new Map<string, { agentType: CliAgentType; role?: CanonicalTeamRole; descriptor: WorkerLaunchDescriptor; verdictAssignmentId?: string }>();
-  const externalModelsDefaults = resolveExternalModelsDefaults(pluginCfg.externalModels?.defaults, process.env);
-  const resolveDefaultModel = (agentType: CliAgentType): string | undefined => {
-    return resolveDefaultWorkerModel(agentType, process.env, externalModelsDefaults);
-  };
   for (let i = 0; i < workerNames.length; i++) {
     const workerName = workerNames[i]!;
     const taskIndex = startupByWorker.get(workerName);
-    const fallbackAgent = (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as CliAgentType;
-    const assignment = taskIndex === undefined
-      ? { agentType: fallbackAgent, model: resolveDefaultModel(fallbackAgent), role: undefined }
-      : resolveTaskAssignment(config.tasks[taskIndex]!, resolvedRouting,
-        pluginCfg.team?.roleRouting as Partial<Record<CanonicalTeamRole, TeamRoleAssignmentSpec>> | undefined,
-        resolvedBinaryPaths, fallbackAgent);
-    const effectiveModel = assignment.model || resolveDefaultModel(assignment.agentType);
+    const assignment = startupAssignments.get(workerName);
+    if (!assignment) throw new Error(`Missing startup assignment for ${workerName}`);
     const worktree = workerWorktrees.get(workerName);
     const verdictAssignmentId = taskIndex !== undefined ? randomUUID() : undefined;
     const outputFile = taskIndex !== undefined && assignment.role && shouldInjectContract(assignment.role, assignment.agentType)
@@ -3392,7 +3405,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     const promptArgs = transportPrompt ? getPromptModeArgs(assignment.agentType, transportPrompt) : [];
     const descriptor = buildValidatedWorkerLaunchDescriptor(assignment.agentType, {
       teamName: sanitized, workerName, cwd: worktree?.path ?? leaderCwd, resolvedBinaryPath: binary,
-      model: effectiveModel,
+      model: assignment.model,
     }, promptArgs);
     preparedLaunches.set(workerName, { agentType: assignment.agentType,
       ...(assignment.role ? { role: assignment.role } : {}), descriptor,
@@ -3568,23 +3581,14 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     throw error;
   }
 
-  // Spawn workers for initial tasks (at most one startup task per worker)
-  const initialStartupAllocations: typeof startupAllocations = [];
-  const seenStartupWorkers = new Set<string>();
-  for (const decision of startupAllocations) {
-    if (seenStartupWorkers.has(decision.workerName)) continue;
-    initialStartupAllocations.push(decision);
-    seenStartupWorkers.add(decision.workerName);
-    if (initialStartupAllocations.length >= config.workerCount) break;
-  }
-
   const launchedWorkers: Array<{ name: string; paneId: string; launchAttemptId?: string; provider: string }> = [];
   try {
-    for (const decision of initialStartupAllocations) {
-    const wName = decision.workerName;
+    // Reuse the same first-per-worker selection used by assignment and
+    // preflight; no second dedupe policy may diverge from startupByWorker.
+    for (const [wName, taskIndex] of startupByWorker) {
     const workerIndex = Number.parseInt(wName.replace('worker-', ''), 10) - 1;
-    const taskId = String(decision.taskIndex + 1);
-    const task = config.tasks[decision.taskIndex];
+    const taskId = String(taskIndex + 1);
+    const task = config.tasks[taskIndex];
     if (!task || workerIndex < 0) continue;
 
     const prepared = preparedLaunches.get(wName);

--- a/src/team/runtime-v2.ts
+++ b/src/team/runtime-v2.ts
@@ -3214,6 +3214,9 @@ async function rollbackStartedNativeWorktreeStartup(args: {
  * NO watchdog polling — the leader drives monitoring via monitorTeamV2().
  */
 export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntimeV2> {
+  if (!Array.isArray(config.agentTypes) || config.agentTypes.length === 0) {
+    throw new Error('Invalid agent types. Expected at least one provider.');
+  }
   if (!Number.isInteger(config.workerCount) || config.workerCount < 1 || config.workerCount > ABSOLUTE_MAX_WORKERS) {
     throw new Error(`Invalid worker count "${config.workerCount}". Expected 1-${ABSOLUTE_MAX_WORKERS}.`);
   }
@@ -3416,19 +3419,19 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
   try {
     for (let i = 0; i < workerNames.length; i++) {
       const wName = workerNames[i];
-      const agentType = (agentTypes[i % agentTypes.length] ?? agentTypes[0] ?? 'claude') as CliAgentType;
+      const prepared = preparedLaunches.get(wName);
+      if (!prepared) throw new Error(`Missing prepared launch for ${wName}`);
       await ensureWorkerStateDir(sanitized, wName, leaderCwd);
       const overlayPath = await writeWorkerOverlay({
-        teamName: sanitized, workerName: wName, agentType,
+        teamName: sanitized, workerName: wName, agentType: prepared.agentType,
         tasks: config.tasks.map((t, idx) => ({
           id: String(idx + 1), subject: t.subject, description: t.description,
         })),
         cwd: leaderCwd,
         ...(config.rolePrompt ? { bootstrapInstructions: config.rolePrompt } : {}),
         instructionStateRoot: workerInstructionStateRoot(leaderCwd, sanitized),
-        ...(preparedLaunches.get(wName)?.role && shouldInjectContract(
-          preparedLaunches.get(wName)!.role!, preparedLaunches.get(wName)!.agentType,
-        ) ? { reviewerRole: true } : {}),
+        ...(prepared.role && shouldInjectContract(prepared.role, prepared.agentType)
+          ? { reviewerRole: true } : {}),
       });
       const worktree = workerWorktrees.get(wName);
       if (worktree) {
@@ -3490,7 +3493,7 @@ export async function startTeamV2(config: StartTeamV2Config): Promise<TeamRuntim
     policy: DEFAULT_TEAM_TRANSPORT_POLICY,
     governance: DEFAULT_TEAM_GOVERNANCE,
     worker_count: config.workerCount,
-    max_workers: 20,
+    max_workers: ABSOLUTE_MAX_WORKERS,
     workers: workersInfo,
     created_at: new Date().toISOString(),
     tmux_session: sessionName,

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -1492,6 +1492,7 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
       let providerGateClosePromise: Promise<boolean> | null = null;
       let providerGateOperationPromise: Promise<boolean> | null = null;
       let providerGateOperationResolve: ((value: boolean) => void) | null = null;
+      let childExitObserved = false;
       let terminateProviderOnGateError: (() => void) | null = null;
       let supervisorTimer: NodeJS.Timeout | undefined;
       let terminationResult: Promise<Awaited<ReturnType<typeof terminateOwnedProcessGroup>>> | null = null;
@@ -1506,13 +1507,24 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
         // this listener until the supervisor is reaped is part of the
         // launch-ownership protocol.
         providerGate.on('error', error => {
-          providerGateError ??= error instanceof Error ? error : new Error(String(error));
+          const gateError = error instanceof Error ? error : new Error(String(error));
+          // Once the release callback has succeeded, the provider has taken
+          // ownership of the descriptor. Any later stream error is only a
+          // diagnostic from that handoff; keep owning the event without
+          // converting it into a startup failure or cleanup signal.
+          if (providerGateReleased) return;
+          providerGateError ??= gateError;
           // A failed stream cannot safely be treated as an EOF/no-execution
           // close. Wake a pending end operation so the caller can switch to
           // creation-bound process-group cleanup.
           providerGateOperationResolve?.(false);
           providerGateOperationResolve = null;
-          terminateProviderOnGateError?.();
+          // Node records exitCode/signalCode before emitting `exit`; include
+          // those fields so a listener-order race cannot signal a reaped PID
+          // before this bootstrap's own exit callback runs.
+          if (!childExitObserved && child.exitCode === null && child.signalCode === null) {
+            terminateProviderOnGateError?.();
+          }
         });
       }
       if (process.platform === 'win32' && child.stdout) {
@@ -1564,7 +1576,11 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
         resolveCompletion = resolve;
         child.once('exit', async (exitCode, signal) => {
           if (settled) return;
+          childExitObserved = true;
           settled = true;
+          // The child has been reaped. No later gate error may start a
+          // process-group signal; cleanup proof below is observation only.
+          terminateProviderOnGateError = null;
           if (supervisorTimer) clearInterval(supervisorTimer);
           if (process.platform === 'win32') {
             resolveWindowsReady(false);
@@ -1588,15 +1604,6 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
           const gateTransportFailed = invocation.providerGateFd !== undefined
             && providerGateError !== null;
           const gateCleanupRequired = gateAborted || gateReleaseFailed || gateTransportFailed;
-          if ((gateReleaseFailed || gateTransportFailed) && launchGroup !== null && terminationResult === null) {
-            terminationResult = terminateOwnedProcessGroup({
-              pid: launchGroup.pid,
-              expectedStartIdentity: launchGroup.processStartIdentity,
-              processGroupId: launchGroup.processGroupId,
-              deadlineAt: new Date(Date.now() + 2_000).toISOString(),
-              force: true,
-            });
-          }
           const groupAbsent = launchGroup !== null
             && await waitForProcessGroupAbsence(launchGroup.processGroupId, Date.now() + 2_000);
           // Windows cleanup remains bound to the supervisor/Job completion
@@ -1606,12 +1613,14 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
           const cleanupVerified = process.platform === 'win32'
             ? await awaitExternalTerminationCompletion(spec) || await readWorkerLaunchCleanupProof(spec)
             : (launchGroup !== null && groupAbsent) || (gateAborted && launchGroup === null);
+          const terminalExitCode = gateAborted ? null : effectiveExitCode;
+          const terminalSignal = gateAborted ? null : effectiveSignal;
           await atomicWriteJson(`${spec.started_path}.terminal`, {
             ...identityOf(spec), kind: 'worker_launch_provider_terminal',
             outcome: cleanupVerified ? 'exit' : 'cleanup_unverified', cleanup_verified: cleanupVerified,
             pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity,
             ...(process.platform !== 'win32' && launchGroup ? { process_group_id: launchGroup.processGroupId } : {}),
-            exit_code: effectiveExitCode, signal: effectiveSignal, written_at: new Date().toISOString(),
+            exit_code: terminalExitCode, signal: terminalSignal, written_at: new Date().toISOString(),
           }).catch(() => undefined);
           await invocation.cleanup().catch(() => undefined);
           resolve(gateCleanupRequired
@@ -1672,7 +1681,10 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
         }
         return false;
       };
-      terminateProviderOnGateError = () => { void terminateProvider(); };
+      terminateProviderOnGateError = () => {
+        if (childExitObserved) return;
+        void terminateProvider();
+      };
       const closeProviderGate = async (): Promise<boolean> => {
         if (providerGateClosePromise) return providerGateClosePromise;
         if (invocation.providerGateFd === undefined || providerGateReleased) return false;
@@ -1725,7 +1737,12 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
               providerGateError ??= error ?? null;
               providerGateOperationResolve = null;
               const released = providerGateError === null;
-              if (released) providerGateReleased = true;
+              if (released) {
+                providerGateReleased = true;
+                // Do not let a late peer-close event terminate a provider
+                // whose release has already completed successfully.
+                terminateProviderOnGateError = null;
+              }
               resolve(released);
             });
           } catch {


### PR DESCRIPTION
## Summary
Follow-up to merged PR #3983.

- Preflight only effective startup providers instead of every provider in the routing snapshot. Missing or untrusted selected binaries still fail before team-state, worktree, or pane creation; no implicit provider fallback.
- Compute each worker's first startup task and effective assignment once, preserving explicit-owner priority, and reuse them for preflight, launch descriptors, and overlays. Routed Cursor reviewers receive the correct verdict-only guidance.
- Remove POSIX process-group signaling after the supervisor has been reaped. Observe group absence and report unverified cleanup rather than risk signaling a reused PID.
- Treat stream errors after successful gate release as nonfatal; preserve strict release-time failure handling. Proven gate-aborted terminals no longer report a provider exit code.
- Reject empty provider lists and invalid worker counts, use the worker-limit constant, document startup grace and initial-only role routing, and refresh inventory provenance.

## Verification
- `npx vitest run src/team tests/lint/inventory-graph-drift.test.ts`: 1872 passed, 9 skipped.
- `npm run lint`: 0 errors, 30 existing warnings.
- `npx tsc --noEmit`: passed.
- `npm run generate:inventory:verify`: passed.
- `git diff --check origin/dev...HEAD`: passed.
- Independent source review: no new merge blockers.
- Post-reap regression mutation check: temporarily restoring the removed exit-handler termination call caused the regression to fail; the mutation was removed.

Tests cover real generated overlays in both routing directions, unavailable unused providers, selected-provider failures, first-task ownership, trust-prompt classification, late gate errors, and surviving descendants after supervisor exit.

## Scope and limitations
- Later tasks delivered to an existing pane keep that worker's provider; this change does not implement per-task provider switching.
- Live Cursor/Codex grace behavior and Windows hardware were not verified.
- Existing leader-side `terminateWorkerLaunchProvider` stale-PID risk after an unverified terminal remains a separate follow-up; this PR fixes the bootstrap reaping path only.
- Unused resolved-routing fallback fields are not removed in this PR.