### PR TITLE
fix(team): preserve reap ownership during leader cleanup

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "11723fa7f9f32a298bad18d8906207f81ccb2272",
-    "sourceSha256": "cf938872b3b6f41e946586658c5db84c85be8d5d7aa0502415a5882b0ea3bbad",
+    "head": "89f4093ac5510ea55f6e71109638628b80119d8a",
+    "sourceSha256": "5245888385f77358b67051ce5172d10d4fe6dbc4ccbde2ab57a987486a8532a3",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "11723fa7f9f32a298bad18d8906207f81ccb2272",
-  "sourceSha256": "cf938872b3b6f41e946586658c5db84c85be8d5d7aa0502415a5882b0ea3bbad",
+  "head": "89f4093ac5510ea55f6e71109638628b80119d8a",
+  "sourceSha256": "5245888385f77358b67051ce5172d10d4fe6dbc4ccbde2ab57a987486a8532a3",
   "counts": {
     "public": {
       "skills": 38,
@@ -71773,6 +71773,11 @@
       },
       {
         "from": "src/team/__tests__/worker-launch-posix-transport.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-posix-transport.test.ts",
         "to": "external:node:fs/promises",
         "kind": "imports"
       },
@@ -78014,11 +78019,11 @@
     ],
     "stats": {
       "nodeCount": 6914,
-      "edgeCount": 7419,
-      "importEdgeCount": 6107,
+      "edgeCount": 7420,
+      "importEdgeCount": 6108,
       "registerEdgeCount": 59
     }
   },
   "inventorySha256": "f86cfdc79146e041d78375e173a6dcbe03153691d908f85d49255913bf7e76f0",
-  "manifestSha256": "8cd367d99c1c38c5c3d73a00df86e1ef8792968b9d20585e5b978d389b70089c"
+  "manifestSha256": "56ed1ffef27f2e13d45ce5ad632e11bf1156fc8e4d141f4a9335072a2b0d16ba"
 }

--- a/src/team/__tests__/worker-launch-ack.test.ts
+++ b/src/team/__tests__/worker-launch-ack.test.ts
@@ -40,6 +40,7 @@ import {
 import { getOmcRoot } from '../../lib/worktree-paths.js';
 
 let cwd = '';
+const disposableProviders = new Set<ReturnType<typeof spawn>>();
 let fixtureEnvCaptured = false;
 let originalHome: string | undefined;
 let originalUserProfile: string | undefined;
@@ -78,6 +79,7 @@ function restoreFixtureEnv(): void {
 }
 
 afterEach(async () => {
+  for (const child of [...disposableProviders]) await stopDisposableProvider(child).catch(() => undefined);
   restoreFixtureEnv();
   if (cwd) await rm(cwd, { recursive: true, force: true });
   cwd = '';
@@ -93,6 +95,60 @@ async function attempt() {
     provider: 'codex',
     runtimeCliPath: '/runtime-cli.cjs',
   });
+}
+
+async function spawnDisposableProvider(): Promise<{
+  child: ReturnType<typeof spawn>;
+  pid: number;
+  processStartIdentity: string;
+  processGroupId: number;
+}> {
+  const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], {
+    stdio: 'ignore',
+    detached: process.platform !== 'win32',
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.once('spawn', () => resolve());
+    child.once('error', reject);
+  });
+  const pid = child.pid;
+  if (!pid) throw new Error('disposable_provider_pid_missing');
+  const processStartIdentity = await getProcessStartIdentity(pid);
+  const ownedGroup = captureOwnedProcessGroup(pid);
+  if (!processStartIdentity || (process.platform !== 'win32' && !ownedGroup)) {
+    child.kill('SIGKILL');
+    throw new Error('disposable_provider_identity_missing');
+  }
+  child.unref();
+  disposableProviders.add(child);
+  return {
+    child,
+    pid,
+    processStartIdentity,
+    processGroupId: ownedGroup?.processGroupId ?? 1,
+  };
+}
+
+async function stopDisposableProvider(child: ReturnType<typeof spawn>): Promise<void> {
+  try {
+    if (child.exitCode === null && child.signalCode === null) {
+      try { child.kill('SIGKILL'); } catch { /* already exited */ }
+    }
+    await new Promise<void>(resolve => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(resolve, 500);
+      timer.unref();
+      child.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  } finally {
+    disposableProviders.delete(child);
+  }
 }
 
 describe('worker launch acknowledgement', () => {
@@ -547,6 +603,441 @@ describe('worker launch acknowledgement', () => {
     await expect(terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
   });
 
+  it.runIf(process.platform !== 'win32')('signals only a live provider when no terminal evidence exists', async () => {
+    vi.resetModules();
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('identity-mismatch');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    let disposable: Awaited<ReturnType<typeof spawnDisposableProvider>> | undefined;
+    try {
+      const launchAttempt = await attempt();
+      const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+      disposable = await spawnDisposableProvider();
+      await writeFile(launchAttempt.startedPath, JSON.stringify({
+        ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+        process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+        written_at: new Date().toISOString(),
+      }), 'utf8');
+
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
+      expect(terminateSpy).toHaveBeenCalledOnce();
+    } finally {
+      if (disposable) await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('accepts verified terminal cleanup without signaling its provider PID', async () => {
+    vi.resetModules();
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('terminated');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    let disposable: Awaited<ReturnType<typeof spawnDisposableProvider>> | undefined;
+    try {
+      const launchAttempt = await attempt();
+      const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+      disposable = await spawnDisposableProvider();
+      const started = {
+        ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+        process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+        written_at: new Date().toISOString(),
+      };
+      await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+      await writeFile(`${launchAttempt.startedPath}.terminal`, JSON.stringify({
+        ...started, kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
+        child_reaped: true,
+      }), 'utf8');
+
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(true);
+      expect(terminateSpy).not.toHaveBeenCalled();
+    } finally {
+      if (disposable) await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32').each([
+    ['malformed terminal', 'malformed'] as const,
+    ['null terminal', 'null'] as const,
+    ['unreadable terminal', 'unreadable'] as const,
+    ['wrong-identity terminal', 'wrong-identity'] as const,
+    ['unbound live terminal', 'unbound-live'] as const,
+  ])('fails closed without signaling for a %s', async (_name, terminalKind) => {
+    vi.resetModules();
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('terminated');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    let disposable: Awaited<ReturnType<typeof spawnDisposableProvider>> | undefined;
+    try {
+      const launchAttempt = await attempt();
+      const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+      disposable = await spawnDisposableProvider();
+      const started = {
+        ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+        process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+        written_at: new Date().toISOString(),
+      };
+      await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+      const terminalPath = `${launchAttempt.startedPath}.terminal`;
+      if (terminalKind === 'malformed') {
+        await writeFile(terminalPath, '{not-json', 'utf8');
+      } else if (terminalKind === 'null') {
+        await writeFile(terminalPath, 'null', 'utf8');
+      } else if (terminalKind === 'unreadable') {
+        await mkdir(terminalPath);
+      } else if (terminalKind === 'wrong-identity') {
+        await writeFile(terminalPath, JSON.stringify({
+          ...started, attempt_id: '00000000-0000-4000-8000-000000000000',
+          kind: 'worker_launch_provider_terminal', outcome: 'exit', cleanup_verified: true,
+        }), 'utf8');
+      } else {
+        await writeFile(terminalPath, JSON.stringify({
+          ...started, kind: 'worker_launch_provider_terminal',
+          outcome: 'cleanup_unverified', cleanup_verified: false, child_reaped: false,
+        }), 'utf8');
+        const terminal = JSON.parse(await readFile(terminalPath, 'utf8')) as Record<string, unknown>;
+        delete terminal.process_group_id;
+        await writeFile(terminalPath, JSON.stringify(terminal), 'utf8');
+      }
+
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
+      expect(terminateSpy).not.toHaveBeenCalled();
+    } finally {
+      if (disposable) await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('retries a matching live-unreaped cleanup terminal with its bound group', async () => {
+    vi.resetModules();
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const nativeTerminate = dynamicProcessUtils.terminateOwnedProcessGroup;
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockImplementation(options => nativeTerminate(options));
+    const workerLaunch = await import('../worker-launch-ack.js');
+    let disposable: Awaited<ReturnType<typeof spawnDisposableProvider>> | undefined;
+    try {
+      const launchAttempt = await attempt();
+      const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+      disposable = await spawnDisposableProvider();
+      const started = {
+        ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+        process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+        written_at: new Date().toISOString(),
+      };
+      await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+      await writeFile(`${launchAttempt.startedPath}.terminal`, JSON.stringify({
+        ...started, kind: 'worker_launch_provider_terminal',
+        outcome: 'cleanup_unverified', cleanup_verified: false, child_reaped: false,
+      }), 'utf8');
+
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 2_000)).resolves.toBe(true);
+      expect(terminateSpy).toHaveBeenCalledOnce();
+      await expect(readFile(`${launchAttempt.startedPath}.termination-complete`, 'utf8')).resolves.toContain(
+        'worker_launch_termination_complete',
+      );
+    } finally {
+      if (disposable) await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32').each([
+    ['already-dead', 'verified/reaped', true],
+    ['already-dead', 'absent', false],
+    ['already-dead', 'unverified', false],
+    ['already-dead', 'wrong-bound', false],
+    ['identity-mismatch', 'verified/reaped', true],
+    ['identity-mismatch', 'absent', false],
+    ['identity-mismatch', 'unverified', false],
+    ['identity-mismatch', 'wrong-bound', false],
+  ] as const)(
+    're-reads cleanup proof after %s and accepts only a %s terminal',
+    async (terminationResult, proofKind, expectedResult) => {
+      vi.resetModules();
+      const dynamicProcessUtils = await import('../../platform/process-utils.js');
+      let disposable: Awaited<ReturnType<typeof spawnDisposableProvider>> | undefined;
+      let terminateSpy: { mockRestore: () => void } | undefined;
+      try {
+        const launchAttempt = await attempt();
+        const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+        disposable = await spawnDisposableProvider();
+        const started = {
+          ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+          process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+          written_at: new Date().toISOString(),
+        };
+        await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+        const terminalPath = `${launchAttempt.startedPath}.terminal`;
+        await writeFile(terminalPath, JSON.stringify({
+          ...started, kind: 'worker_launch_provider_terminal',
+          outcome: 'cleanup_unverified', cleanup_verified: false, child_reaped: false,
+        }), 'utf8');
+
+        terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+          .mockImplementation(async () => {
+            if (proofKind === 'absent') {
+              await rm(terminalPath, { force: true });
+            } else {
+              await writeFile(terminalPath, JSON.stringify({
+                ...started,
+                kind: 'worker_launch_provider_terminal',
+                outcome: proofKind === 'verified/reaped' ? 'exit' : 'cleanup_unverified',
+                cleanup_verified: proofKind === 'verified/reaped',
+                child_reaped: true,
+                ...(proofKind === 'wrong-bound'
+                  ? { process_group_id: disposable!.processGroupId + 1 }
+                  : {}),
+              }), 'utf8');
+            }
+            return terminationResult;
+          });
+        const workerLaunch = await import('../worker-launch-ack.js');
+
+        await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(expectedResult);
+        expect(terminateSpy).toHaveBeenCalledOnce();
+        await expect(readFile(`${launchAttempt.startedPath}.termination-complete`, 'utf8'))
+          .rejects.toMatchObject({ code: 'ENOENT' });
+      } finally {
+        if (disposable) await stopDisposableProvider(disposable.child);
+        terminateSpy?.mockRestore();
+        vi.resetModules();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== 'win32')('rechecks terminal evidence before signaling after the request read', async () => {
+    const launchAttempt = await attempt();
+    const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+    const disposable = await spawnDisposableProvider();
+    const started = {
+      ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+      process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+      written_at: new Date().toISOString(),
+    };
+    await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+    const terminalPath = `${launchAttempt.startedPath}.terminal`;
+    const terminationRequestPath = `${launchAttempt.startedPath}.termination-request`;
+    let terminalInjected = false;
+
+    vi.resetModules();
+    const actualFsPromises = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.doMock('node:fs/promises', () => ({
+      ...actualFsPromises,
+      readFile: async (path: string, encoding?: BufferEncoding) => {
+        try {
+          return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+        } catch (error) {
+          if (!terminalInjected && path === terminalPath
+            && existsSync(terminationRequestPath)
+            && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+            terminalInjected = true;
+            await actualFsPromises.writeFile(terminalPath, JSON.stringify({
+              ...started, kind: 'worker_launch_provider_terminal',
+              outcome: 'cleanup_unverified', cleanup_verified: false, child_reaped: true,
+            }), 'utf8');
+            return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+          }
+          throw error;
+        }
+      },
+    }));
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('terminated');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    try {
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
+      expect(terminalInjected).toBe(true);
+      expect(terminateSpy).not.toHaveBeenCalled();
+      expect(isProcessAlive(disposable.pid)).toBe(true);
+      await expect(readFile(`${launchAttempt.startedPath}.termination-complete`, 'utf8'))
+        .rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('returns a verified terminal that arrives at the first recovery gate', async () => {
+    const launchAttempt = await attempt();
+    const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+    const disposable = await spawnDisposableProvider();
+    const started = {
+      ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+      process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+      written_at: new Date().toISOString(),
+    };
+    await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+    const terminalPath = `${launchAttempt.startedPath}.terminal`;
+    const terminationRequestPath = `${launchAttempt.startedPath}.termination-request`;
+    let terminalReadCount = 0;
+    const terminalReadPhases: string[] = [];
+
+    vi.resetModules();
+    const actualFsPromises = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.doMock('node:fs/promises', () => ({
+      ...actualFsPromises,
+      readFile: async (path: string, encoding?: BufferEncoding) => {
+        try {
+          return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+        } catch (error) {
+          if (path === terminalPath
+            && !existsSync(terminationRequestPath)
+            && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+            terminalReadCount++;
+            if (terminalReadCount === 1) {
+              terminalReadPhases.push('initial-proof-absent');
+            } else if (terminalReadCount === 2) {
+              terminalReadPhases.push('first-gate-inject');
+              await actualFsPromises.writeFile(terminalPath, JSON.stringify({
+                ...started, kind: 'worker_launch_provider_terminal',
+                outcome: 'exit', cleanup_verified: true, child_reaped: true,
+              }), 'utf8');
+              return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+            }
+          }
+          throw error;
+        }
+      },
+    }));
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('terminated');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    try {
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(true);
+      expect(terminalReadPhases).toEqual(['initial-proof-absent', 'first-gate-inject']);
+      expect(terminateSpy).not.toHaveBeenCalled();
+      await expect(readFile(terminationRequestPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('returns an unverified reaped terminal at the first recovery gate without signaling', async () => {
+    const launchAttempt = await attempt();
+    const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+    const disposable = await spawnDisposableProvider();
+    const started = {
+      ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+      process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+      written_at: new Date().toISOString(),
+    };
+    await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+    const terminalPath = `${launchAttempt.startedPath}.terminal`;
+    const terminationRequestPath = `${launchAttempt.startedPath}.termination-request`;
+    let terminalReadCount = 0;
+    const terminalReadPhases: string[] = [];
+
+    vi.resetModules();
+    const actualFsPromises = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.doMock('node:fs/promises', () => ({
+      ...actualFsPromises,
+      readFile: async (path: string, encoding?: BufferEncoding) => {
+        try {
+          return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+        } catch (error) {
+          if (path === terminalPath
+            && !existsSync(terminationRequestPath)
+            && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+            terminalReadCount++;
+            if (terminalReadCount === 1) {
+              terminalReadPhases.push('initial-proof-absent');
+            } else if (terminalReadCount === 2) {
+              terminalReadPhases.push('first-gate-inject');
+              await actualFsPromises.writeFile(terminalPath, JSON.stringify({
+                ...started, kind: 'worker_launch_provider_terminal',
+                outcome: 'cleanup_unverified', cleanup_verified: false, child_reaped: true,
+              }), 'utf8');
+              return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+            }
+          }
+          throw error;
+        }
+      },
+    }));
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('terminated');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    try {
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(false);
+      expect(terminalReadPhases).toEqual(['initial-proof-absent', 'first-gate-inject']);
+      expect(terminateSpy).not.toHaveBeenCalled();
+      await expect(readFile(terminationRequestPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('returns a verified terminal that arrives at the signal gate', async () => {
+    const launchAttempt = await attempt();
+    const expected = JSON.parse(await readFile(launchAttempt.expectedPath, 'utf8'));
+    const disposable = await spawnDisposableProvider();
+    const started = {
+      ...expected, kind: 'worker_launch_provider_started', pid: disposable.pid,
+      process_start_identity: disposable.processStartIdentity, process_group_id: disposable.processGroupId,
+      written_at: new Date().toISOString(),
+    };
+    await writeFile(launchAttempt.startedPath, JSON.stringify(started), 'utf8');
+    const terminalPath = `${launchAttempt.startedPath}.terminal`;
+    const terminationRequestPath = `${launchAttempt.startedPath}.termination-request`;
+    let terminalInjected = false;
+
+    vi.resetModules();
+    const actualFsPromises = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+    vi.doMock('node:fs/promises', () => ({
+      ...actualFsPromises,
+      readFile: async (path: string, encoding?: BufferEncoding) => {
+        try {
+          return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+        } catch (error) {
+          if (!terminalInjected && path === terminalPath
+            && existsSync(terminationRequestPath)
+            && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+            terminalInjected = true;
+            await actualFsPromises.writeFile(terminalPath, JSON.stringify({
+              ...started, kind: 'worker_launch_provider_terminal',
+              outcome: 'exit', cleanup_verified: true, child_reaped: true,
+            }), 'utf8');
+            return await actualFsPromises.readFile(path, encoding ?? 'utf8');
+          }
+          throw error;
+        }
+      },
+    }));
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('terminated');
+    const workerLaunch = await import('../worker-launch-ack.js');
+    try {
+      await expect(workerLaunch.terminateWorkerLaunchProvider(launchAttempt, 100)).resolves.toBe(true);
+      expect(terminalInjected).toBe(true);
+      expect(terminateSpy).not.toHaveBeenCalled();
+    } finally {
+      await stopDisposableProvider(disposable.child);
+      terminateSpy.mockRestore();
+      vi.doUnmock('node:fs/promises');
+      vi.resetModules();
+    }
+  });
+
   it('rejects replay when the acknowledgement path is already owned', async () => {
     const launchAttempt = await attempt();
     const spec = buildWorkerLaunchBootstrapSpec(
@@ -957,6 +1448,7 @@ describe('worker launch acknowledgement', () => {
         expect(terminal).toMatchObject({
           outcome: 'cleanup_unverified',
           cleanup_verified: false,
+          child_reaped: true,
           signal: 'SIGKILL',
         });
       }, { timeout: 2_000, interval: 5 });
@@ -969,6 +1461,87 @@ describe('worker launch acknowledgement', () => {
       if (providerGroupId) {
         try { process.kill(-providerGroupId, 'SIGKILL'); } catch { /* group already absent */ }
       }
+      await bootstrap?.catch(() => undefined);
+      terminateSpy.mockRestore();
+      vi.doUnmock('node:child_process');
+      vi.resetModules();
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('upgrades a live timer terminal to reaped evidence after the supervisor exits', async () => {
+    vi.resetModules();
+    const actualChildProcess = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    const dynamicProcessUtils = await import('../../platform/process-utils.js');
+    const terminateSpy = vi.spyOn(dynamicProcessUtils, 'terminateOwnedProcessGroup')
+      .mockResolvedValue('unknown');
+    let supervisor: ReturnType<typeof spawn> | undefined;
+    const spawnMock = vi.fn((
+      command: string,
+      args: string[],
+      options: Parameters<typeof spawn>[2],
+    ) => {
+      const child = actualChildProcess.spawn(command, args, options);
+      supervisor = child;
+      return child;
+    });
+    vi.doMock('node:child_process', () => ({ ...actualChildProcess, spawn: spawnMock }));
+    let bootstrap: ReturnType<typeof runWorkerLaunchBootstrap> | undefined;
+    const launchAttempt = await attempt();
+    const descendantPidPath = join(cwd, 'timer-transition-descendant.pid');
+    let providerGroupId: number | undefined;
+    try {
+      const workerLaunch = await import('../worker-launch-ack.js');
+      bootstrap = workerLaunch.runWorkerLaunchBootstrap(buildWorkerLaunchBootstrapSpec(
+        launchAttempt,
+        [process.execPath, '-e', [
+          "const fs=require('node:fs'),cp=require('node:child_process')",
+          "const descendant=cp.spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{stdio:'ignore'})",
+          'descendant.unref()',
+          `fs.writeFileSync(${JSON.stringify(descendantPidPath)},String(descendant.pid))`,
+          'process.exit(0)',
+        ].join(';')],
+        cwd,
+        { releaseAfterSpawn: true },
+      ));
+      await expect(awaitWorkerLaunchAcknowledgement(launchAttempt, {
+        timeoutMs: 2_000,
+        pollIntervalMs: 5,
+      })).resolves.toEqual({ ok: true });
+      await expect(awaitWorkerLaunchProviderStarted(launchAttempt, {
+        timeoutMs: 2_000,
+        pollIntervalMs: 5,
+      })).resolves.toBe(true);
+      const started = JSON.parse(await readFile(launchAttempt.startedPath, 'utf8')) as {
+        process_group_id: number;
+      };
+      providerGroupId = started.process_group_id;
+      await vi.waitFor(async () => {
+        const terminal = JSON.parse(await readFile(`${launchAttempt.startedPath}.terminal`, 'utf8'));
+        expect(terminal).toMatchObject({
+          outcome: 'cleanup_unverified',
+          cleanup_verified: false,
+          child_reaped: false,
+          process_group_id: providerGroupId,
+        });
+      }, { timeout: 5_000, interval: 20 });
+      expect(supervisor).toBeDefined();
+      supervisor!.kill('SIGKILL');
+      await expect(bootstrap).resolves.toEqual({ outcome: 'provider_cleanup_unverified' });
+      expect(() => process.kill(-providerGroupId!, 0)).not.toThrow();
+      await vi.waitFor(async () => {
+        const terminal = JSON.parse(await readFile(`${launchAttempt.startedPath}.terminal`, 'utf8'));
+        expect(terminal).toMatchObject({
+          outcome: 'cleanup_unverified',
+          cleanup_verified: false,
+          child_reaped: true,
+          process_group_id: providerGroupId,
+        });
+      }, { timeout: 5_000, interval: 20 });
+    } finally {
+      try {
+        if (providerGroupId) process.kill(-providerGroupId, 'SIGKILL');
+      } catch { /* group already absent */ }
+      supervisor?.kill('SIGKILL');
       await bootstrap?.catch(() => undefined);
       terminateSpy.mockRestore();
       vi.doUnmock('node:child_process');

--- a/src/team/__tests__/worker-launch-posix-transport.test.ts
+++ b/src/team/__tests__/worker-launch-posix-transport.test.ts
@@ -12,7 +12,8 @@
  * runtime CLI its path, exactly like the native Windows path already does.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -250,6 +251,117 @@ describe('POSIX supervised worker-launch transport (issue #3655)', () => {
         killSpy?.mockRestore();
         killSpy = undefined;
       }
+    }
+  });
+
+  it.runIf(process.platform !== 'win32')('keeps the real runtime CLI alive until a failed cleanup wrapper is reaped', async () => {
+    const attempt = await makeAttempt();
+    const providerMarker = join(cwd, 'actual-runtime-cli-provider-ran');
+    const providerExitTrigger = join(cwd, 'actual-runtime-cli-provider-exit');
+    const terminationFailurePreload = join(cwd, 'fail-first-worker-termination.mjs');
+    const runtimeCliEntry = join(cwd, 'run-worker-launch-runtime-cli.mjs');
+    const runtimeCliSource = join(process.cwd(), 'src/team/runtime-cli.ts');
+    const tsxLoader = join(process.cwd(), 'node_modules/tsx/dist/loader.mjs');
+    await writeFile(terminationFailurePreload, [
+      'const nativeKill = process.kill.bind(process);',
+      'let blocked = false;',
+      'process.kill = ((pid, signal) => {',
+      "  if (!blocked && typeof pid === 'number' && pid < 0 && signal === 'SIGKILL') {",
+      '    blocked = true;',
+      "    const error = Object.assign(new Error('fixture_first_termination_failure'), { code: 'EPERM' });",
+      '    throw error;',
+      '  }',
+      '  return nativeKill(pid, signal);',
+      '});',
+      '',
+    ].join('\n'), 'utf8');
+    await writeFile(runtimeCliEntry, [
+      'globalThis.require = { main: {} };',
+      'globalThis.module = {};',
+      `const { runWorkerLaunchFromEnvironment } = await import(${JSON.stringify(runtimeCliSource)});`,
+      'await runWorkerLaunchFromEnvironment();',
+      '',
+    ].join('\n'), 'utf8');
+
+    let materialized: Awaited<ReturnType<typeof materializeWorkerLaunchTransport>> | undefined;
+    let cli: ReturnType<typeof spawn> | undefined;
+    let cliExit: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | undefined;
+    try {
+      const providerScript = [
+        "require('node:fs').writeFileSync(" + JSON.stringify(providerMarker) + ",'ran')",
+        `setInterval(() => { if (require('node:fs').existsSync(${JSON.stringify(providerExitTrigger)})) process.exit(0); }, 10)`,
+      ].join(';');
+      materialized = await materializeWorkerLaunchTransport({
+        attempt,
+        providerArgv: [process.execPath, '-e', providerScript],
+        cwd,
+        releaseAfterSpawn: true,
+        windowsDelivery: false,
+      });
+      const childEnv = { ...process.env };
+      delete childEnv.OMC_WORKER_LAUNCH_SPEC;
+      delete childEnv.OMC_WORKER_LAUNCH_SPEC_B64;
+      childEnv.OMC_WORKER_LAUNCH_SPEC_FILE = materialized.bootstrapDescriptorPath;
+      cli = spawn(process.execPath, ['--import', tsxLoader, '--import', terminationFailurePreload, runtimeCliEntry], {
+        cwd: process.cwd(),
+        env: childEnv,
+        stdio: 'ignore',
+      });
+      cliExit = new Promise((resolve, reject) => {
+        cli!.once('exit', (code, signal) => resolve({ code, signal }));
+        cli!.once('error', reject);
+      });
+
+      await expect(awaitWorkerLaunchAcknowledgement(attempt, { timeoutMs: 5_000, pollIntervalMs: 5 }))
+        .resolves.toEqual({ ok: true });
+      await expect(awaitWorkerLaunchProviderStarted(attempt, { timeoutMs: 5_000, pollIntervalMs: 5 }))
+        .resolves.toBe(true);
+      await vi.waitFor(async () => {
+        expect(await readFile(providerMarker, 'utf8')).toBe('ran');
+      }, { timeout: 5_000, interval: 20 });
+
+      const started = JSON.parse(await readFile(attempt.startedPath, 'utf8')) as {
+        pid: number;
+        process_group_id: number;
+      };
+      // Enter the completion-timer path only after startup evidence has been
+      // observed; an immediate exit can instead race the startup handoff.
+      await writeFile(providerExitTrigger, 'exit', 'utf8');
+      await vi.waitFor(async () => {
+        const terminal = JSON.parse(await readFile(`${attempt.startedPath}.terminal`, 'utf8'));
+        expect(terminal).toMatchObject({
+          outcome: 'cleanup_unverified',
+          cleanup_verified: false,
+          child_reaped: false,
+          pid: started.pid,
+          process_group_id: started.process_group_id,
+        });
+      }, { timeout: 5_000, interval: 20 });
+
+      // The real runtime CLI must still own its observer while the wrapper
+      // remains live; resolving here would make runtime-cli throw/exit(1).
+      await new Promise(resolve => setTimeout(resolve, 150));
+      expect(cli.exitCode).toBeNull();
+
+      await expect(terminateWorkerLaunchProvider(attempt, 2_000)).resolves.toBe(true);
+      await expect(cliExit).resolves.toEqual({ code: 0, signal: null });
+      await vi.waitFor(async () => {
+        const terminal = JSON.parse(await readFile(`${attempt.startedPath}.terminal`, 'utf8'));
+        expect(terminal).toMatchObject({
+          outcome: 'exit',
+          cleanup_verified: true,
+          child_reaped: true,
+          pid: started.pid,
+          process_group_id: started.process_group_id,
+        });
+      }, { timeout: 5_000, interval: 20 });
+    } finally {
+      await terminateWorkerLaunchProvider(attempt, 2_000).catch(() => false);
+      if (cli && cli.exitCode === null && cli.signalCode === null) {
+        try { cli.kill('SIGKILL'); } catch { /* already exited */ }
+      }
+      await cliExit?.catch(() => undefined);
+      await cleanupWorkerLaunchTransport(attempt, 'test_cleanup_finally').catch(() => false);
     }
   });
 

--- a/src/team/worker-launch-ack.ts
+++ b/src/team/worker-launch-ack.ts
@@ -980,7 +980,10 @@ async function readWorkerLaunchCleanupProof(
         && value.process_group_id === started.process_group_id);
   };
   const terminal = await readJson(`${startedPath}.terminal`);
-  if (terminal.kind === 'value') {
+  if (terminal.kind === 'value'
+    && terminal.value
+    && typeof terminal.value === 'object'
+    && !Array.isArray(terminal.value)) {
     const value = terminal.value as Partial<WorkerLaunchIdentity> & Record<string, unknown>;
     const matchesStarted = !started || (value.pid === started.pid
       && value.process_start_identity === started.process_start_identity);
@@ -988,10 +991,16 @@ async function readWorkerLaunchCleanupProof(
       && value.outcome === 'exit' && value.cleanup_verified === true
       && Number.isSafeInteger(value.pid) && Number(value.pid) > 0
       && isValidProcessStartIdentity(value.process_start_identity)
+      && (process.platform === 'win32'
+        || value.child_reaped === undefined
+        || value.child_reaped === true)
       && matchesProcessGroup(value)) return true;
   }
   const completed = await readJson(`${startedPath}.termination-complete`);
-  if (completed.kind === 'value') {
+  if (completed.kind === 'value'
+    && completed.value
+    && typeof completed.value === 'object'
+    && !Array.isArray(completed.value)) {
     const value = completed.value as Partial<WorkerLaunchIdentity> & Record<string, unknown>;
     const matchesStarted = !started || (value.pid === started.pid
       && value.process_start_identity === started.process_start_identity);
@@ -1001,6 +1010,39 @@ async function readWorkerLaunchCleanupProof(
       && matchesProcessGroup(value)) return true;
   }
   return false;
+}
+
+type WorkerLaunchTerminalState = 'absent' | 'live-unreaped' | 'reaped' | 'invalid';
+
+async function readWorkerLaunchTerminalState(
+  attempt: WorkerLaunchAttempt,
+  started: Partial<WorkerLaunchProviderStarted>,
+): Promise<WorkerLaunchTerminalState> {
+  if (process.platform === 'win32') return 'absent';
+  const terminal = await readJson(`${attempt.startedPath}.terminal`);
+  if (terminal.kind === 'absent') return 'absent';
+  if (terminal.kind !== 'value') return 'invalid';
+  if (!terminal.value || typeof terminal.value !== 'object' || Array.isArray(terminal.value)) return 'invalid';
+  const value = terminal.value as Partial<WorkerLaunchIdentity> & Record<string, unknown>;
+  const matchesProcessGroup = Number.isSafeInteger(started.process_group_id)
+    && Number(started.process_group_id) > 0
+    && value.process_group_id === started.process_group_id;
+  if (!identityMatches(value, attempt)
+    || value.kind !== 'worker_launch_provider_terminal'
+    || value.pid !== started.pid
+    || value.process_start_identity !== started.process_start_identity
+    || !Number.isSafeInteger(value.pid)
+    || Number(value.pid) <= 0
+    || !isValidProcessStartIdentity(value.process_start_identity)
+    || !matchesProcessGroup
+    || typeof value.child_reaped !== 'boolean'
+    || typeof value.cleanup_verified !== 'boolean') return 'invalid';
+  if (value.child_reaped === true
+    && (value.outcome === 'exit' || value.outcome === 'cleanup_unverified')) return 'reaped';
+  if (value.child_reaped === false
+    && value.outcome === 'cleanup_unverified'
+    && value.cleanup_verified === false) return 'live-unreaped';
+  return 'invalid';
 }
 
 export async function terminateWorkerLaunchProvider(
@@ -1021,6 +1063,12 @@ export async function terminateWorkerLaunchProvider(
     || Number(record.pid) <= 0
     || !isValidProcessStartIdentity(record.process_start_identity)) return false;
   if (terminalCleanupVerified) return true;
+  if (process.platform !== 'win32') {
+    const terminalState = await readWorkerLaunchTerminalState(attempt, record);
+    if (terminalState === 'reaped' || terminalState === 'invalid') {
+      return await readWorkerLaunchCleanupProof(attempt, record);
+    }
+  }
   if (process.platform !== 'win32' && (!Number.isSafeInteger(record.process_group_id) || Number(record.process_group_id) <= 0)) return false;
   const terminationRequestPath = `${attempt.startedPath}.termination-request`;
   const terminationCompletePath = `${attempt.startedPath}.termination-complete`;
@@ -1070,13 +1118,20 @@ export async function terminateWorkerLaunchProvider(
     if (!value || !identityMatches(value, attempt) || value.kind !== 'worker_launch_termination_request'
       || value.pid !== record.pid || value.process_start_identity !== record.process_start_identity) return false;
   }
+  // Recheck as close as possible to the signal. This narrows the asynchronous
+  // pre-signal window, but cannot make a cross-process file read and signal
+  // atomic; a terminal can still arrive after this observation.
+  const terminalState = await readWorkerLaunchTerminalState(attempt, record);
+  if (terminalState === 'reaped' || terminalState === 'invalid') {
+    return await readWorkerLaunchCleanupProof(attempt, record);
+  }
   const deadlineAt = new Date(Date.now() + timeoutMs).toISOString();
   const result = await terminateOwnedProcessGroup({
     pid: record.pid!, expectedStartIdentity: record.process_start_identity,
     processGroupId: record.process_group_id!, deadlineAt, force: true,
   });
   if (result === 'already-dead' || result === 'identity-mismatch') {
-    return terminalCleanupVerified;
+    return await readWorkerLaunchCleanupProof(attempt, record);
   }
   if (result !== 'terminated') return false;
   const deadline = Date.parse(deadlineAt);
@@ -1144,6 +1199,7 @@ async function readValidProviderStarted(
   const started = await readJson(attempt.startedPath);
   if ((await readJson(`${attempt.startedPath}.terminal`)).kind !== 'absent') return null;
   if (started.kind !== 'value') return null;
+  if (!started.value || typeof started.value !== 'object' || Array.isArray(started.value)) return null;
   const record = started.value as Partial<WorkerLaunchProviderStarted>;
   if (record.supervisor_completion_path !== undefined
     && (typeof record.supervisor_completion_path !== 'string'
@@ -1496,6 +1552,24 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
       let terminateProviderOnGateError: (() => void) | null = null;
       let supervisorTimer: NodeJS.Timeout | undefined;
       let terminationResult: Promise<Awaited<ReturnType<typeof terminateOwnedProcessGroup>>> | null = null;
+      let terminalWritePromise: Promise<void> = Promise.resolve();
+      const writeTerminal = (record: Record<string, unknown>): Promise<void> => {
+        if (process.platform === 'win32') return atomicWriteJson(`${spec.started_path}.terminal`, record);
+        const write = terminalWritePromise.then(async () => {
+          const existing = await readJson(`${spec.started_path}.terminal`);
+          if (existing.kind === 'value'
+            && existing.value
+            && typeof existing.value === 'object'
+            && !Array.isArray(existing.value)
+            && (existing.value as Record<string, unknown>).child_reaped === true
+            && (record.child_reaped !== true
+              || ((existing.value as Record<string, unknown>).cleanup_verified === true
+                && record.cleanup_verified !== true))) return;
+          await atomicWriteJson(`${spec.started_path}.terminal`, record);
+        });
+        terminalWritePromise = write.catch(() => undefined);
+        return write;
+      };
       let resolveCompletion!: (result: WorkerLaunchBootstrapResult) => void;
       let resolveWindowsReady!: (ready: boolean) => void;
       let resolveWindowsTerminal!: (verified: boolean) => void;
@@ -1575,7 +1649,7 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
       const completion = new Promise<WorkerLaunchBootstrapResult>(resolve => {
         resolveCompletion = resolve;
         child.once('exit', async (exitCode, signal) => {
-          if (settled) return;
+          if ((settled && process.platform === 'win32') || childExitObserved) return;
           childExitObserved = true;
           settled = true;
           // The child has been reaped. No later gate error may start a
@@ -1588,16 +1662,30 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
           }
           const effectiveExitCode = supervisedExitCode ?? exitCode;
           const effectiveSignal = supervisedExitCode === null ? signal : null;
+          const gateAborted = invocation.providerGateFd !== undefined
+            && providerGateClosed
+            && !providerGateReleased
+            && !providerGateReleaseAttempted;
+          const terminalExitCode = gateAborted ? null : effectiveExitCode;
+          const terminalSignal = gateAborted ? null : effectiveSignal;
+          const terminalPid = providerPid ?? child.pid ?? null;
+          const terminalProcessStartIdentity = providerStartIdentity;
+          const terminalProcessGroupId = launchGroup?.processGroupId;
+          if (process.platform !== 'win32') {
+            await writeTerminal({
+              ...identityOf(spec), kind: 'worker_launch_provider_terminal',
+              outcome: 'cleanup_unverified', cleanup_verified: false, child_reaped: true,
+              pid: terminalPid, process_start_identity: terminalProcessStartIdentity,
+              ...(terminalProcessGroupId !== undefined ? { process_group_id: terminalProcessGroupId } : {}),
+              exit_code: terminalExitCode, signal: terminalSignal, written_at: new Date().toISOString(),
+            }).catch(() => undefined);
+          }
           const gateOperationResult = providerGateOperationPromise
             ? await Promise.race([
               providerGateOperationPromise,
               sleep(2_000).then(() => false),
             ])
             : true;
-          const gateAborted = invocation.providerGateFd !== undefined
-            && providerGateClosed
-            && !providerGateReleased
-            && !providerGateReleaseAttempted;
           const gateReleaseFailed = invocation.providerGateFd !== undefined
             && providerGateReleaseAttempted
             && (!providerGateReleased || providerGateError !== null || !gateOperationResult);
@@ -1613,13 +1701,13 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
           const cleanupVerified = process.platform === 'win32'
             ? await awaitExternalTerminationCompletion(spec) || await readWorkerLaunchCleanupProof(spec)
             : (launchGroup !== null && groupAbsent) || (gateAborted && launchGroup === null);
-          const terminalExitCode = gateAborted ? null : effectiveExitCode;
-          const terminalSignal = gateAborted ? null : effectiveSignal;
-          await atomicWriteJson(`${spec.started_path}.terminal`, {
+          await writeTerminal({
             ...identityOf(spec), kind: 'worker_launch_provider_terminal',
             outcome: cleanupVerified ? 'exit' : 'cleanup_unverified', cleanup_verified: cleanupVerified,
-            pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity,
-            ...(process.platform !== 'win32' && launchGroup ? { process_group_id: launchGroup.processGroupId } : {}),
+            pid: terminalPid, process_start_identity: terminalProcessStartIdentity,
+            ...(process.platform !== 'win32' ? { child_reaped: true } : {}),
+            ...(process.platform !== 'win32' && terminalProcessGroupId !== undefined
+              ? { process_group_id: terminalProcessGroupId } : {}),
             exit_code: terminalExitCode, signal: terminalSignal, written_at: new Date().toISOString(),
           }).catch(() => undefined);
           await invocation.cleanup().catch(() => undefined);
@@ -1637,7 +1725,7 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
           if (supervisorTimer) clearInterval(supervisorTimer);
           resolveWindowsReady(false);
           resolveWindowsTerminal(false);
-          await atomicWriteJson(`${spec.started_path}.terminal`, {
+          await writeTerminal({
             ...identityOf(spec), kind: 'worker_launch_provider_terminal', outcome: 'error', cleanup_verified: false,
             pid: providerPid ?? child.pid ?? null, process_start_identity: providerStartIdentity, written_at: new Date().toISOString(),
           }).catch(() => undefined);
@@ -1647,6 +1735,21 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
       });
       const terminateProvider = async (): Promise<boolean> => {
         if (settled) {
+          // A failed timer cleanup publishes a live-unreaped terminal but
+          // deliberately leaves this observer pending. A later signal is an
+          // explicit retry opportunity while the wrapper is still live; once
+          // the child exit has been observed, only the reap callback may
+          // settle completion.
+          if (process.platform !== 'win32' && !childExitObserved
+            && child.exitCode === null && child.signalCode === null && launchGroup !== null) {
+            const retryResult = await terminateOwnedProcessGroup({
+              pid: launchGroup.pid, expectedStartIdentity: launchGroup.processStartIdentity,
+              processGroupId: launchGroup.processGroupId,
+              deadlineAt: new Date(Date.now() + 2_000).toISOString(), force: true,
+            });
+            if (retryResult !== 'terminated' && retryResult !== 'already-dead') return false;
+            return await waitForProcessGroupAbsence(launchGroup.processGroupId, Date.now() + 2_000);
+          }
           return process.platform !== 'win32'
             && launchGroup !== null
             && await waitForProcessGroupAbsence(launchGroup.processGroupId, Date.now() + 2_000);
@@ -1888,12 +1991,19 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
             if (!cleaned && !settled) {
               settled = true;
               if (supervisorTimer) clearInterval(supervisorTimer);
-              await atomicWriteJson(`${spec.started_path}.terminal`, {
+              await writeTerminal({
                 ...identityOf(spec), kind: 'worker_launch_provider_terminal', outcome: 'cleanup_unverified', cleanup_verified: false,
                 pid: child.pid ?? null, process_start_identity: providerStartIdentity, exit_code: exitCode, signal: null, written_at: new Date().toISOString(),
+                ...(process.platform !== 'win32' && launchGroup ? { child_reaped: false, process_group_id: launchGroup.processGroupId } : {}),
               }).catch(() => undefined);
-              await invocation.cleanup().catch(() => undefined);
-              resolveCompletion({ outcome: 'provider_cleanup_unverified' });
+              // Keep the child handle, transport, and completion observer
+              // alive until the wrapper actually exits. The runtime CLI exits
+              // immediately on a resolved failure, which would otherwise
+              // discard the only reap callback and leave this terminal live.
+              if (process.platform === 'win32') {
+                await invocation.cleanup().catch(() => undefined);
+                resolveCompletion({ outcome: 'provider_cleanup_unverified' });
+              }
             }
           }).catch(() => undefined).finally(() => { pollingCompletion = false; });
         }, DEFAULT_POLL_INTERVAL_MS);
@@ -1914,7 +2024,7 @@ export async function runWorkerLaunchBootstrap(value: unknown): Promise<WorkerLa
               || record.containment_nonce !== spec.containment_nonce) return;
             const cleaned = await terminateProvider();
             if (!cleaned && !settled) {
-              await atomicWriteJson(`${spec.started_path}.terminal`, {
+              await writeTerminal({
                 ...identityOf(spec), kind: 'worker_launch_provider_terminal', outcome: 'cleanup_unverified', cleanup_verified: false,
                 pid: providerPid, process_start_identity: providerStartIdentity, exit_code: null, signal: null, written_at: new Date().toISOString(),
               }).catch(() => undefined);


### PR DESCRIPTION
## Summary
Follow-up to #3993 addressing leader-side cleanup authority after provider termination.

- Distinguish POSIX reaped children from still-live wrappers using bound `child_reaped` terminal evidence. Reaped, malformed, or mismatched evidence blocks signaling; a matching live/unreaped cleanup failure remains recoverable.
- Publish reap evidence before asynchronous group cleanup and serialize terminal writes so delayed timer writes cannot downgrade reaped evidence.
- Keep the owning POSIX bootstrap and transport alive after timer cleanup failure until the child is reaped. Returning early would cause the runtime CLI to exit and lose its reap observer.
- Refresh cleanup proof at both terminal gates and after `already-dead` / `identity-mismatch` termination results instead of returning a stale initial snapshot.
- Preserve the Windows supervisor protocol and validated independent termination-complete proofs.
- Refresh inventory provenance.

## Regression coverage
- Disposable child process groups avoid targeting the test runner PID/PGID.
- Bound live-wrapper recovery, reaped/invalid terminal veto, and late verified/unverified proof at both gates.
- Eight post-signal proof cases covering both termination results and verified, absent, unverified, and wrong-bound evidence.
- Real runtime CLI subprocess: fail the first group SIGKILL, verify observer retention, retry from the leader, and require reaped/verified evidence before CLI exit.
- Explicit provider-exit trigger makes the CLI test enter the intended post-start completion-timer path deterministically.

## Verification
Final changes verified in an isolated non-root Linux Node 22 container with an init process and jq:
- `npm test -- --run`: **14094 passed, 20 skipped**.
- Subagent-lock performance suite: **4 passed**, including Linux latency guardrails.
- `npm run lint`: **0 errors, 30 existing warnings**.
- `npx tsc --noEmit`, `npm run build`, `npm run plugin:shipping:verify`, and `npm run generate:inventory:verify`: passed.
- Shipping verification reports 3 ignored/untracked generated declarations awaiting staging; these unrelated build outputs are not included.
- `git diff --check`: passed.
- Independent lifecycle review approved the scoped implementation; subsequent post-signal proof and deterministic-fixture corrections passed the full Linux gates above.

## Limitations
- Terminal-file observation and cross-process signaling are not atomic. A race remains between the final read and the signal; this PR does not claim to solve it atomically.
- An unkillable live wrapper intentionally retains its owning observer until external recovery or exit.
- Windows hardware was not exercised. macOS full-suite failures include Linux-specific `/proc` and directory-FD assumptions; the Linux CI-equivalent suite is green.
- No unrelated routing/fallback-field cleanup or generated runtime artifact refresh is included.