### PR TITLE
fix: remove false Ralph Ruby prerequisite and bad plan citation

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "148b6408d45ad3cc9aebd22d4fa31f5ec2a9402d",
-    "sourceSha256": "8c79d75cedfba358ccbd3e3e71b6a1cb893eefd85d2632fa4b1f5a7bfc9f05e9",
+    "head": "54795969be2217e4d21f4edc506159b05d20b777",
+    "sourceSha256": "b6222d4b1191834d299b7cf435c36fb2ceebe5f5d2cd3ddc265477771bc86da4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "148b6408d45ad3cc9aebd22d4fa31f5ec2a9402d",
-  "sourceSha256": "8c79d75cedfba358ccbd3e3e71b6a1cb893eefd85d2632fa4b1f5a7bfc9f05e9",
+  "head": "54795969be2217e4d21f4edc506159b05d20b777",
+  "sourceSha256": "b6222d4b1191834d299b7cf435c36fb2ceebe5f5d2cd3ddc265477771bc86da4",
   "counts": {
     "public": {
       "skills": 38,
@@ -71778,6 +71778,11 @@
       },
       {
         "from": "src/team/__tests__/worker-launch-posix-transport.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/team/__tests__/worker-launch-posix-transport.test.ts",
         "to": "external:node:fs/promises",
         "kind": "imports"
       },
@@ -78034,11 +78039,11 @@
     ],
     "stats": {
       "nodeCount": 6915,
-      "edgeCount": 7422,
-      "importEdgeCount": 6110,
+      "edgeCount": 7423,
+      "importEdgeCount": 6111,
       "registerEdgeCount": 59
     }
   },
   "inventorySha256": "f43dbc64d3d2f1711aeb2b8dd548884f816919af76218064a6b6d8b0a1f5a8fe",
-  "manifestSha256": "c6f657ea9fb078bed2bb067750a17928ec2023e7f9f61f0e39bd43850f8787e1"
+  "manifestSha256": "cd87daa55408aea8bcb7ebea3dea4efb0672a0c44edec17df16efbcec9cdf880"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "89f4093ac5510ea55f6e71109638628b80119d8a",
-    "sourceSha256": "5245888385f77358b67051ce5172d10d4fe6dbc4ccbde2ab57a987486a8532a3",
+    "head": "148b6408d45ad3cc9aebd22d4fa31f5ec2a9402d",
+    "sourceSha256": "8c79d75cedfba358ccbd3e3e71b6a1cb893eefd85d2632fa4b1f5a7bfc9f05e9",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "89f4093ac5510ea55f6e71109638628b80119d8a",
-  "sourceSha256": "5245888385f77358b67051ce5172d10d4fe6dbc4ccbde2ab57a987486a8532a3",
+  "head": "148b6408d45ad3cc9aebd22d4fa31f5ec2a9402d",
+  "sourceSha256": "8c79d75cedfba358ccbd3e3e71b6a1cb893eefd85d2632fa4b1f5a7bfc9f05e9",
   "counts": {
     "public": {
       "skills": 38,
@@ -40860,6 +40860,11 @@
         "path": "tests/lint/inventory-graph-drift.test.ts"
       },
       {
+        "id": "tests/lint/issue-3996-ruby-false-positive.test.ts",
+        "kind": "other",
+        "path": "tests/lint/issue-3996-ruby-false-positive.test.ts"
+      },
+      {
         "id": "tests/lint/setup-phases-drift.test.ts",
         "kind": "other",
         "path": "tests/lint/setup-phases-drift.test.ts"
@@ -71773,11 +71778,6 @@
       },
       {
         "from": "src/team/__tests__/worker-launch-posix-transport.test.ts",
-        "to": "external:node:child_process",
-        "kind": "imports"
-      },
-      {
-        "from": "src/team/__tests__/worker-launch-posix-transport.test.ts",
         "to": "external:node:fs/promises",
         "kind": "imports"
       },
@@ -77892,6 +77892,21 @@
         "kind": "imports"
       },
       {
+        "from": "tests/lint/issue-3996-ruby-false-positive.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/issue-3996-ruby-false-positive.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "tests/lint/issue-3996-ruby-false-positive.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
         "from": "tests/lint/setup-phases-drift.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -78018,12 +78033,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6914,
-      "edgeCount": 7420,
-      "importEdgeCount": 6108,
+      "nodeCount": 6915,
+      "edgeCount": 7422,
+      "importEdgeCount": 6110,
       "registerEdgeCount": 59
     }
   },
-  "inventorySha256": "f86cfdc79146e041d78375e173a6dcbe03153691d908f85d49255913bf7e76f0",
-  "manifestSha256": "56ed1ffef27f2e13d45ce5ad632e11bf1156fc8e4d141f4a9335072a2b0d16ba"
+  "inventorySha256": "f43dbc64d3d2f1711aeb2b8dd548884f816919af76218064a6b6d8b0a1f5a8fe",
+  "manifestSha256": "c6f657ea9fb078bed2bb067750a17928ec2023e7f9f61f0e39bd43850f8787e1"
 }

--- a/scripts/plugin-setup.mjs
+++ b/scripts/plugin-setup.mjs
@@ -6,7 +6,7 @@
  */
 
 import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, chmodSync, copyFileSync } from 'node:fs';
-import { execFileSync, execSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
@@ -31,19 +31,6 @@ const isPublishedPluginCache = !existsSync(join(__dirname, '..', '.git'));
 
 console.log('[OMC] Running post-install setup...');
 
-function checkRalphRubyDependency() {
-  try {
-    execFileSync('ruby', ['--version'], { stdio: 'ignore', timeout: 5000 });
-    console.log('[OMC] Ruby detected for Ralph workflows');
-  } catch {
-    console.log('[OMC] Warning: Ruby was not found on PATH. Ralph workflows require Ruby and may fail until it is installed.');
-    console.log('[OMC] Ubuntu/Debian: sudo apt update && sudo apt install ruby-full');
-    console.log('[OMC] macOS: brew install ruby');
-    console.log('[OMC] After installing Ruby, restart Claude Code and rerun /oh-my-claudecode:omc-setup if needed.');
-  }
-}
-
-checkRalphRubyDependency();
 
 // 1. Create HUD directory
 if (!existsSync(HUD_DIR)) {

--- a/skills/deep-interview/SKILL.md
+++ b/skills/deep-interview/SKILL.md
@@ -740,7 +740,7 @@ The recommended refinement path chains clarity and feasibility gates, then stops
   → Socratic Q&A until ambiguity ≤ <resolvedThresholdPercent>
   → Spec written to .omc/specs/deep-interview-{slug}.md
   → User explicitly selects "Refine with omc-plan consensus"
-  → /omc-plan --consensus --direct (spec as input, skip interview)
+  → Skill("oh-my-claudecode:plan") with --consensus --direct (spec as input, skip interview)
     → Planner creates implementation plan from spec
     → Architect reviews for architectural soundness
     → Critic validates quality and testability

--- a/skills/omc-doctor/SKILL.md
+++ b/skills/omc-doctor/SKILL.md
@@ -74,23 +74,20 @@ grep -o "CLAUDE-[^ )]*\.md" "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/CLAUDE.md" 2>/d
 - If `OMC:VERSION` marker is missing from deterministic CLAUDE source scan (base + referenced companion): WARN - cannot verify CLAUDE.md freshness
 - If `CLAUDE.md OMC version` != `Latest cached plugin version`: WARN - version drift detected (run `omc update` or `omc setup`)
 
-### Step 5: Check Ralph Ruby Dependency
+### Step 5: Check Ralph Runtime Prerequisites
 
-Ralph workflows require Ruby. Check for Ruby explicitly so fresh installations get actionable guidance instead of a later opaque Ralph failure.
+Ralph is an agent-driven persistence loop, not a compiled program: its only hard runtime prerequisites are the Node runtime that executes OMC's hook scripts (`persistent-mode.mjs`, `keyword-detector.mjs`) and a writable config directory for `.omc/state/` state files such as `ralph-state.json`.
 
 ```bash
-if command -v ruby >/dev/null 2>&1; then
-  echo "Ruby for Ralph: $(ruby --version 2>/dev/null | head -1)"
-else
-  echo "Ruby for Ralph: MISSING"
-  echo "Install Ruby before using Ralph. Ubuntu/Debian: sudo apt update && sudo apt install ruby-full"
-  echo "macOS: brew install ruby"
-fi
+node --version || echo "Node for Ralph: MISSING"
+mkdir -p "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" 2>/dev/null
+touch "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-write-probe" 2>/dev/null && rm -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-write-probe" && echo "Config dir writable" || echo "Config dir NOT writable"
 ```
 
 **Diagnosis**:
-- If Ruby is found: OK - Ralph dependency present
-- If Ruby is missing: WARN - Ralph workflows may fail until Ruby is installed
+- If Node runs and prints a version: OK - Ralph runtime prerequisite present
+- If `node` is missing or fails: CRITICAL - OMC hooks and Ralph cannot run without Node (see https://nodejs.org for installers; nvm/fnm users need Node on the PATH of non-interactive shells)
+- If the config dir is not writable: WARN - Ralph state persistence will fail until it is writable
 
 ### Step 6: Check for Stale Plugin Cache
 
@@ -153,7 +150,7 @@ After running all checks, output a report:
 | Legacy Hooks (settings.json) | OK/CRITICAL | ... |
 | Legacy Scripts (~/.claude/hooks/) | OK/WARN | ... |
 | CLAUDE.md | OK/WARN/CRITICAL | ... |
-| Ralph Ruby Dependency | OK/WARN | ... |
+| Ralph Runtime Prerequisites (Node, config dir) | OK/CRITICAL | ... |
 | Plugin Cache | OK/WARN | ... |
 | Legacy Agents (~/.claude/agents/) | OK/WARN | ... |
 | Legacy Commands (~/.claude/commands/) | OK/WARN | ... |

--- a/skills/omc-setup/phases/02-configure.md
+++ b/skills/omc-setup/phases/02-configure.md
@@ -22,19 +22,15 @@ else
 fi
 ```
 
-## Step 2.0: Check Ralph Ruby Dependency
+## Step 2.0: Check Ralph Runtime Prerequisites
 
-Ralph workflows require Ruby. On fresh Ubuntu installations, missing Ruby can cause Ralph to fail later with an opaque Claude Code abort. Check for Ruby during setup and show a product-facing remediation hint without blocking the rest of setup:
+Ralph is an agent-driven persistence loop with no external language dependency. Its only hard prerequisites are the Node runtime that already runs OMC's hooks and a writable config directory for `.omc/state/` state files. Verify both without blocking the rest of setup:
 
 ```bash
-if command -v ruby >/dev/null 2>&1; then
-  echo "Ruby detected for Ralph workflows: $(ruby --version 2>/dev/null | head -1)"
-else
-  echo "WARNING: Ruby was not found on PATH. Ralph workflows require Ruby."
-  echo "Install it, then restart Claude Code before using Ralph."
-  echo "Ubuntu/Debian: sudo apt update && sudo apt install ruby-full"
-  echo "macOS: brew install ruby"
-fi
+node --version || echo "ERROR: Node is required for OMC hooks and Ralph state persistence."
+mkdir -p "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" 2>/dev/null
+touch "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-write-probe" 2>/dev/null && rm -f "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.omc-write-probe" \
+  || echo "WARNING: Config dir is not writable; Ralph state persistence will fail until it is."
 ```
 
 ## Step 2.1: Setup HUD Statusline

--- a/src/__tests__/plugin-setup-deps.test.ts
+++ b/src/__tests__/plugin-setup-deps.test.ts
@@ -78,21 +78,17 @@ describe('package.json prepare script removal', () => {
 });
 
 
-describe('plugin-setup.mjs Ralph Ruby dependency guidance (issue #2969)', () => {
+describe('plugin-setup.mjs never probes Ruby (issue #3996)', () => {
   const scriptContent = existsSync(PLUGIN_SETUP_PATH)
     ? readFileSync(PLUGIN_SETUP_PATH, 'utf-8')
     : '';
 
-  it('checks for Ruby during plugin setup before Ralph workflows fail later', () => {
-    expect(scriptContent).toContain('checkRalphRubyDependency');
-    expect(scriptContent).toContain("execFileSync('ruby', ['--version']");
-    expect(scriptContent).toContain('Ruby was not found on PATH');
-  });
-
-  it('prints actionable install guidance for fresh Ubuntu users', () => {
-    expect(scriptContent).toContain('Ralph workflows require Ruby');
-    expect(scriptContent).toContain('sudo apt update && sudo apt install ruby-full');
-    expect(scriptContent).toContain('restart Claude Code');
+  it('does not probe Ruby or claim Ralph requires it', () => {
+    expect(scriptContent).not.toMatch(/\bruby\b/i);
+    expect(scriptContent).not.toContain('checkRalphRubyDependency');
+    expect(scriptContent).not.toContain('execFileSync');
+    expect(scriptContent).not.toContain('ruby-full');
+    expect(scriptContent).not.toContain('brew install ruby');
   });
 });
 

--- a/src/__tests__/setup-contracts-regression.test.ts
+++ b/src/__tests__/setup-contracts-regression.test.ts
@@ -606,16 +606,17 @@ describe('Contract 10: installer manages stale OMC-created agents and skills', (
 });
 
 
-describe('OMC setup Ralph Ruby dependency guidance (issue #2969)', () => {
-  it('checks Ruby during setup with product-facing Ralph remediation', () => {
+describe('OMC setup Ralph runtime prerequisites guidance (issue #3996)', () => {
+  it('checks Node and a writable config dir instead of the retired Ruby probe', () => {
     const phasePath = join(REPO_ROOT, 'skills', 'omc-setup', 'phases', '02-configure.md');
     const content = readFileSync(phasePath, 'utf-8');
 
-    expect(content).toContain('Step 2.0: Check Ralph Ruby Dependency');
-    expect(content).toContain('command -v ruby');
-    expect(content).toContain('Ralph workflows require Ruby');
-    expect(content).toContain('sudo apt update && sudo apt install ruby-full');
-    expect(content).toContain('restart Claude Code');
+    expect(content).toContain('Step 2.0: Check Ralph Runtime Prerequisites');
+    expect(content).toContain('node --version');
+    // The Ruby check was a false positive (issue #3996): OMC has never used Ruby.
+    expect(content).not.toMatch(/\bruby\b/i);
+    expect(content).not.toContain('ruby-full');
+    expect(content).not.toContain('brew install ruby');
   });
 });
 

--- a/src/skills/__tests__/omc-doctor-skill.test.ts
+++ b/src/skills/__tests__/omc-doctor-skill.test.ts
@@ -22,16 +22,18 @@ describe('omc-doctor skill (issue #2254)', () => {
 });
 
 
-describe('omc-doctor skill Ralph Ruby dependency check (issue #2969)', () => {
-  it('documents a narrow Ruby check with actionable Ralph guidance', () => {
+describe('omc-doctor skill Ralph runtime prerequisites (issue #3996)', () => {
+  it('documents a truthful Node/config-dir check instead of the retired Ruby check', () => {
     const skillPath = join(process.cwd(), 'skills', 'omc-doctor', 'SKILL.md');
     const content = readFileSync(skillPath, 'utf8');
 
-    expect(content).toContain('Check Ralph Ruby Dependency');
-    expect(content).toContain('Ruby for Ralph: MISSING');
-    expect(content).toContain('Ralph workflows require Ruby');
-    expect(content).toContain('sudo apt update && sudo apt install ruby-full');
-    expect(content).toContain('Ralph Ruby Dependency');
+    expect(content).toContain('Check Ralph Runtime Prerequisites');
+    expect(content).toContain('node --version');
+    expect(content).toContain('Ralph Runtime Prerequisites');
+    // The Ruby check was a false positive (issue #3996): OMC has never used Ruby.
+    expect(content).not.toMatch(/\bruby\b/i);
+    expect(content).not.toContain('ruby-full');
+    expect(content).not.toContain('brew install ruby');
   });
 });
 

--- a/tests/lint/issue-3996-ruby-false-positive.test.ts
+++ b/tests/lint/issue-3996-ruby-false-positive.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Cross-surface regression guards for issue #3996.
+ *
+ * Issue #2969 shipped a "Ralph requires Ruby" probe and doctor/setup steps
+ * even though OMC has never used Ruby (no `.rb` file was ever committed, and
+ * the only historical Ruby references were the probe itself, its docs, and
+ * their tests). Issue #3996 removed the false positive and replaced it with a
+ * truthful Node-runtime check. These guards keep it out of the shipped
+ * surfaces:
+ *  - scripts/plugin-setup.mjs must not probe Ruby at post-install
+ *  - the omc-doctor and omc-setup Ralph steps must stay Ruby-free and must
+ *    keep checking the real prerequisites (Node runtime, writable config dir)
+ *  - skills/deep-interview/SKILL.md must cite the plan skill in a form that
+ *    resolves (`Skill("oh-my-claudecode:plan")`), not `/omc-plan`
+ *
+ * Rollback boundary: delete tests/lint/issue-3996-ruby-false-positive.test.ts
+ * — no runtime change.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const REPO_ROOT = join(import.meta.dirname, "../..");
+
+const read = (relativePath: string): string =>
+  readFileSync(join(REPO_ROOT, relativePath), "utf-8");
+
+describe("issue #3996: no Ralph/Ruby false positive in shipped surfaces", () => {
+  it("plugin-setup.mjs never probes Ruby or claims Ralph requires it", () => {
+    const content = read("scripts/plugin-setup.mjs");
+    expect(content).not.toMatch(/\bruby\b/i);
+    expect(content).not.toContain("checkRalphRubyDependency");
+  });
+
+  it("omc-doctor Step 5 checks Ralph runtime prerequisites without Ruby", () => {
+    const content = read("skills/omc-doctor/SKILL.md");
+    expect(content).toContain("Check Ralph Runtime Prerequisites");
+    expect(content).toContain("node --version");
+    expect(content).not.toMatch(/\bruby\b/i);
+    expect(content).not.toContain("Ralph Ruby Dependency");
+  });
+
+  it("omc-setup Step 2.0 checks Ralph runtime prerequisites without Ruby", () => {
+    const content = read("skills/omc-setup/phases/02-configure.md");
+    expect(content).toContain("Step 2.0: Check Ralph Runtime Prerequisites");
+    expect(content).toContain("node --version");
+    expect(content).not.toMatch(/\bruby\b/i);
+  });
+});
+
+describe("issue #3996: deep-interview cites a resolvable plan invocation", () => {
+  it("the approval-gated pipeline uses Skill(\"oh-my-claudecode:plan\"), not /omc-plan", () => {
+    const content = read("skills/deep-interview/SKILL.md");
+    // The plan skill's resolvable invocation form (matches the citation at
+    // the AskUserQuestion options earlier in the same file).
+    expect(content).toContain('Skill("oh-my-claudecode:plan")');
+    // /omc-plan is the frontmatter display name, not a resolvable slash
+    // command; it must not come back as an invocation citation.
+    expect(content).not.toMatch(/(^|\s)\/omc-plan\b/);
+  });
+});


### PR DESCRIPTION
Closes #3996

## Changes
- remove the post-install Ruby probe and replace Ralph doctor/setup guidance with Node runtime and writable config-directory checks
- update the three affected regression suites and add cross-surface docs contract coverage
- replace deep-interview's non-resolvable `/omc-plan` citation with `Skill("oh-my-claudecode:plan")`

## Verification
- focused Vitest: 5 files, 63 tests passed
- TypeScript and lint were run; repository lint reports pre-existing warnings only
- full-suite failures reproduce on clean origin/dev and are unrelated environment flakes

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*