### PR TITLE
fix(graph): support Darwin contained-FD traversal

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "54795969be2217e4d21f4edc506159b05d20b777",
-    "sourceSha256": "b6222d4b1191834d299b7cf435c36fb2ceebe5f5d2cd3ddc265477771bc86da4",
+    "head": "d10eb01f82d27e9911c1d492899a18d8844c592f",
+    "sourceSha256": "5bab9e0011b0de4e70f54d28db0019426e965479ed6c49026a430db16badfa20",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "54795969be2217e4d21f4edc506159b05d20b777",
-  "sourceSha256": "b6222d4b1191834d299b7cf435c36fb2ceebe5f5d2cd3ddc265477771bc86da4",
+  "head": "d10eb01f82d27e9911c1d492899a18d8844c592f",
+  "sourceSha256": "5bab9e0011b0de4e70f54d28db0019426e965479ed6c49026a430db16badfa20",
   "counts": {
     "public": {
       "skills": 38,
@@ -28,8 +28,8 @@
       "toolFiles": 61,
       "libFiles": 42,
       "templateHooks": 21,
-      "srcFiles": 1346,
-      "total": 1367
+      "srcFiles": 1347,
+      "total": 1368
     },
     "generated": {
       "distFiles": 4986,
@@ -36410,6 +36410,11 @@
         "path": "src/graph/runtime/approval.ts"
       },
       {
+        "id": "src/graph/runtime/contained-fd.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/contained-fd.ts"
+      },
+      {
         "id": "src/graph/runtime/executors/agent.ts",
         "kind": "src",
         "path": "src/graph/runtime/executors/agent.ts"
@@ -54827,6 +54832,11 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/graph/runtime/contained-fd.ts",
+        "to": "external:fs",
+        "kind": "imports"
+      },
+      {
         "from": "src/graph/runtime/executors/agent.ts",
         "to": "external:@anthropic-ai/claude-agent-sdk",
         "kind": "imports"
@@ -55032,6 +55042,11 @@
         "kind": "imports"
       },
       {
+        "from": "src/graph/runtime/run-dir.ts",
+        "to": "src/graph/runtime/contained-fd.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/graph/runtime/runner.ts",
         "to": "external:path",
         "kind": "imports"
@@ -55104,6 +55119,11 @@
       {
         "from": "src/graph/runtime/safe-fs.ts",
         "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
+        "to": "src/graph/runtime/contained-fd.ts",
         "kind": "imports"
       },
       {
@@ -78038,12 +78058,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6915,
-      "edgeCount": 7423,
-      "importEdgeCount": 6111,
+      "nodeCount": 6916,
+      "edgeCount": 7426,
+      "importEdgeCount": 6114,
       "registerEdgeCount": 59
     }
   },
-  "inventorySha256": "f43dbc64d3d2f1711aeb2b8dd548884f816919af76218064a6b6d8b0a1f5a8fe",
-  "manifestSha256": "cd87daa55408aea8bcb7ebea3dea4efb0672a0c44edec17df16efbcec9cdf880"
+  "inventorySha256": "dbd043a823e64ee7655a3be94e186db2a2ba70faf20e556099264fa62fb74296",
+  "manifestSha256": "f5762a65098d95e9a0da9ea63b4e4a14ccc3729643579d17065530e22f25afed"
 }

--- a/src/graph/__tests__/runtime/cli.test.ts
+++ b/src/graph/__tests__/runtime/cli.test.ts
@@ -180,10 +180,10 @@ describe('graphCommand run subcommand', () => {
     expect(mocks.runGraph).not.toHaveBeenCalled();
   });
 
-  it('fails closed on unsupported POSIX before creating run state', async () => {
+  it('accepts Darwin as a supported confined runtime platform', async () => {
     const runsRoot = join(workDir, '.omc', 'graph-runs');
     const fixturePath = join(workDir, 'descriptor.json');
-    writeFileSync(fixturePath, JSON.stringify(descriptorInput('run-darwin', 'unsupported')));
+    writeFileSync(fixturePath, JSON.stringify(descriptorInput('run-darwin', 'darwin support')));
     const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
 
     try {
@@ -192,11 +192,8 @@ describe('graphCommand run subcommand', () => {
       platform.mockRestore();
     }
 
-    expect(process.exitCode).toBe(1);
-    expect(mocks.runGraph).not.toHaveBeenCalled();
-    expect(existsSync(runsRoot)).toBe(false);
-    expect(errorSpy.mock.calls.map((args) => args.join(' ')).join('\n')).toContain(
-      'graph runtime is unavailable on darwin',
-    );
+    expect(process.exitCode).toBe(EXIT_CODES.OK);
+    expect(mocks.runGraph).toHaveBeenCalledOnce();
+    expect(existsSync(runsRoot)).toBe(true);
   });
 });

--- a/src/graph/__tests__/runtime/safe-fs.test.ts
+++ b/src/graph/__tests__/runtime/safe-fs.test.ts
@@ -21,6 +21,7 @@ import {
   containedPathForPlatform,
   assertSafeContainedFileName,
   assertContainedFsSupported,
+  readFileNoFollow,
   readContainedFileNoFollow,
   withContainedDirectory,
   withContainedPathForPlatform,
@@ -42,15 +43,16 @@ describe("graph runtime safe filesystem", () => {
     return { root, handle };
   }
 
-  it("uses traversable procfs only for Linux and does not mutate platform state", () => {
+  it("uses kernel FD paths on Linux and Darwin without mutating platform state", () => {
     const before = process.platform;
 
     expect(
       containedPathForPlatform(7, "/runs/example", "artifact", "linux"),
     ).toBe("/proc/self/fd/7/artifact");
 
-    expect(() => containedPathForPlatform(7, "/runs/example", "artifact", "darwin"))
-      .toThrow("refusing pathname fallback");
+    expect(
+      containedPathForPlatform(7, "/runs/example", "artifact", "darwin"),
+    ).toBe("/dev/fd/7/artifact");
     expect(() => containedPathForPlatform(7, "C:/runs/example", "artifact", "win32"))
       .toThrow("refusing pathname fallback");
 
@@ -85,15 +87,15 @@ describe("graph runtime safe filesystem", () => {
     expect(existsSync(join(handle.path, "renamed.txt"))).toBe(false);
   });
 
-  it("rejects a final artifact symlink on Linux and refuses darwin fallback", () => {
+  it("rejects a final artifact symlink on Linux and Darwin", () => {
     const { root, handle } = makeRunDir();
     const outside = join(root, "outside.txt");
     writeFileSync(outside, "outside");
     symlinkSync(outside, join(handle.path, "artifact.txt"));
 
     expect(() => readContainedFileNoFollow(handle, "artifact.txt")).toThrow();
-    expect(() => withContainedPathForPlatform(handle, "artifact.txt", () => undefined, "darwin"))
-      .toThrow("refusing pathname fallback");
+    expect(() => withContainedPathForPlatform(handle, "artifact.txt", readFileNoFollow, "darwin"))
+      .toThrow();
     expect(readFileSync(outside, "utf8")).toBe("outside");
   });
 
@@ -117,16 +119,18 @@ describe("graph runtime safe filesystem", () => {
     }
   });
 
-  it("rejects non-Linux POSIX operations before any pathname fallback", () => {
+  it("performs Darwin operations through the descriptor alias", () => {
     const { handle } = makeRunDir();
+    const artifact = join(handle.path, "artifact.txt");
+    writeFileSync(artifact, "darwin-contained");
     expect(() =>
       withContainedPathForPlatform(
         handle,
         "artifact.txt",
-        () => undefined,
+        (path) => expect(readFileSync(path, "utf8")).toBe("darwin-contained"),
         "darwin",
       ),
-    ).toThrow("refusing pathname fallback");
+    ).not.toThrow();
   });
 
   it("fails closed on Windows instead of using a raceable pathname fallback", () => {
@@ -193,9 +197,7 @@ describe("graph runtime safe filesystem", () => {
   );
 
   it("exposes an explicit fail-closed capability check", () => {
-    expect(() => assertContainedFsSupported("darwin")).toThrow(
-      "refusing pathname fallback",
-    );
+    expect(() => assertContainedFsSupported("darwin")).not.toThrow();
     expect(() => assertContainedFsSupported("linux")).not.toThrow();
     expect(() => assertContainedFsSupported("win32")).toThrow(
       "refusing pathname fallback",
@@ -223,11 +225,11 @@ describe("graph runtime safe filesystem", () => {
     );
   });
 
-  it("fails closed for every operation on non-Linux POSIX", () => {
+  it("fails closed for every operation on unsupported platforms", () => {
     const { handle } = makeRunDir();
     for (const operation of ["read", "write", "rename", "delete"]) {
       expect(() =>
-        withContainedPathForPlatform(handle, "artifact.txt", () => operation, "darwin"),
+        withContainedPathForPlatform(handle, "artifact.txt", () => operation, "win32"),
       ).toThrow("refusing pathname fallback");
     }
   });

--- a/src/graph/runtime/contained-fd.ts
+++ b/src/graph/runtime/contained-fd.ts
@@ -1,0 +1,35 @@
+import { constants as fsConstants, statSync } from "fs";
+
+/**
+ * Return the kernel-provided path for an already-open directory FD.
+ *
+ * Both Linux procfs and Darwin devfs resolve the descriptor at lookup time,
+ * so the returned path remains anchored to the opened directory rather than
+ * to its mutable pathname. No pathname fallback is provided.
+ */
+export function containedFdPath(
+  directoryFd: number,
+  platform: NodeJS.Platform,
+  child?: string,
+): string {
+  const root = platform === "linux" ? "/proc/self/fd" : "/dev/fd";
+  return child === undefined
+    ? `${root}/${directoryFd}`
+    : `${root}/${directoryFd}/${child}`;
+}
+
+export function containedFsPlatformSupported(platform: NodeJS.Platform): boolean {
+  if (platform === "linux") return true;
+  if (platform !== "darwin") return false;
+  if (
+    typeof fsConstants.O_DIRECTORY !== "number" ||
+    typeof fsConstants.O_NOFOLLOW !== "number"
+  ) {
+    return false;
+  }
+  try {
+    return statSync("/dev/fd").isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/src/graph/runtime/run-dir.ts
+++ b/src/graph/runtime/run-dir.ts
@@ -19,6 +19,10 @@ import {
   realpathSync,
 } from "fs";
 import { join, resolve, sep } from "path";
+import {
+  containedFdPath,
+  containedFsPlatformSupported,
+} from "./contained-fd.js";
 
 const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 
@@ -28,9 +32,7 @@ const DIRECTORY_FLAGS =
   (fsConstants.O_NOFOLLOW ?? 0);
 
 function fdPath(directoryFd: number, child?: string): string {
-  return child === undefined
-    ? `/proc/self/fd/${directoryFd}`
-    : `/proc/self/fd/${directoryFd}/${child}`;
+  return containedFdPath(directoryFd, process.platform, child);
 }
 
 function isErrno(error: unknown, code: string): boolean {
@@ -147,7 +149,7 @@ export function resolveRunDirHandle(
     throw new RangeError("invalid run_id");
   }
 
-  if (process.platform !== "linux") {
+  if (!containedFsPlatformSupported(process.platform)) {
     throw new Error(
       `contained directory-FD traversal is unavailable on ${process.platform}; refusing pathname fallback`,
     );

--- a/src/graph/runtime/safe-fs.ts
+++ b/src/graph/runtime/safe-fs.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
 } from "fs";
 import { isAbsolute, join, normalize, win32 } from "path";
+import { containedFdPath, containedFsPlatformSupported } from "./contained-fd.js";
 import type { RunDirHandle } from "./run-dir.js";
 
 const NO_FOLLOW = process.platform === "win32" ? 0 : fsConstants.O_NOFOLLOW;
@@ -17,7 +18,7 @@ const WINDOWS_DEVICE_NAME = /^(?:con|prn|aux|nul|clock\$|com[1-9¹²³]|lpt[1-9�
 export function assertContainedFsSupported(
   platform: NodeJS.Platform = process.platform,
 ): void {
-  if (platform !== "linux") {
+  if (!containedFsPlatformSupported(platform)) {
     throw new Error(
       `contained directory-FD traversal is unavailable on ${platform}; refusing pathname fallback`,
     );
@@ -111,11 +112,8 @@ export function containedPathForPlatform(
   platform: NodeJS.Platform = process.platform,
 ): string {
   assertSafeContainedFileName(fileName, platform);
-  if (platform === "linux") {
-    return join(`/proc/self/fd/${directoryFd}`, fileName);
-  }
   assertContainedFsSupported(platform);
-  throw new Error("unreachable");
+  return join(containedFdPath(directoryFd, platform), fileName);
 }
 
 /**
@@ -153,7 +151,7 @@ export function withContainedDirectory<T>(
     if (stats.dev !== runDir.device || stats.ino !== runDir.inode) {
       throw new Error("run directory identity changed");
     }
-    return operation(`/proc/self/fd/${directoryFd}`);
+    return operation(containedFdPath(directoryFd, platform));
   } finally {
     closeSync(directoryFd);
   }


### PR DESCRIPTION
Closes #3998

## Summary
- use macOS `/dev/fd/<directory-fd>` aliases for the same descriptor-anchored traversal used by Linux `/proc/self/fd`
- retain capability detection and fail-closed behavior for unsupported platforms
- preserve `O_NOFOLLOW`, directory identity checks, basename validation, and private-file checks
- add focused Darwin path, operation, symlink, and capability tests

## Verification
- `npx vitest run src/graph/__tests__/runtime/safe-fs.test.ts src/graph/__tests__/runtime/run-dir.test.ts`
- `npx tsc --noEmit`
- `npm run lint -- --quiet`
- platform-injected reproduction on Linux confirmed the pre-fix Darwin rejection at the old origin/dev code; no live macOS run claimed

No pathname fallback or security-check removal is included. One issue, one PR, targeting `dev`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*