### PR TITLE
fix(hooks): single Windows PowerShell host for SessionStart cache occupancy

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "d10eb01f82d27e9911c1d492899a18d8844c592f",
-    "sourceSha256": "5bab9e0011b0de4e70f54d28db0019426e965479ed6c49026a430db16badfa20",
+    "head": "bf6242b22c7f3325dfe3497216ecedbfd7517acd",
+    "sourceSha256": "5bd982b0fc8f49afc20130522938b475b2091d2af4ce1186c2f024380cfd4818",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "d10eb01f82d27e9911c1d492899a18d8844c592f",
-  "sourceSha256": "5bab9e0011b0de4e70f54d28db0019426e965479ed6c49026a430db16badfa20",
+  "head": "bf6242b22c7f3325dfe3497216ecedbfd7517acd",
+  "sourceSha256": "5bd982b0fc8f49afc20130522938b475b2091d2af4ce1186c2f024380cfd4818",
   "counts": {
     "public": {
       "skills": 38,
@@ -78065,5 +78065,5 @@
     }
   },
   "inventorySha256": "dbd043a823e64ee7655a3be94e186db2a2ba70faf20e556099264fa62fb74296",
-  "manifestSha256": "f5762a65098d95e9a0da9ea63b4e4a14ccc3729643579d17065530e22f25afed"
+  "manifestSha256": "cba7703c7e89a44c522fd41357942e24c9a6fd1aec98bf9c578f85209f90078a"
 }

--- a/scripts/lib/cache-occupancy.mjs
+++ b/scripts/lib/cache-occupancy.mjs
@@ -63,9 +63,18 @@ function alive(pid) {
 function registryDir(configDir) { return join(configDir, '.omc', 'cache-occupancy'); }
 function fileName(root, pid, start) { return `${createHash('sha256').update(`${root}\0${pid}\0${start}`).digest('hex')}.json`; }
 
-export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid) {
+// Issue #3995: on win32 every identity probe is a PowerShell host (~1.6-2.0s),
+// so SessionStart must not need two. publishCacheOccupancy() accepts an
+// explicit precomputed identity for `pid` (resolved by the caller in the ONE
+// batched readOccupiedPluginRoots() host) and skips its own probe entirely;
+// readOccupiedPluginRoots() accepts a previously returned identities map to
+// verify records without spawning a second host (pids absent from the map are
+// kept conservatively — the record survives unless proven stale otherwise).
+export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid, precomputedIdentity) {
   const root = pathIdentity(pluginRoot || '');
-  const start = identity(pid);
+  const start = typeof precomputedIdentity === 'string' && precomputedIdentity.length > 0
+    ? precomputedIdentity
+    : identity(pid);
   if (!root || !start) return false;
   const dir = registryDir(configDir);
   const target = join(dir, fileName(root, pid, start));
@@ -78,11 +87,11 @@ export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid)
   } catch { try { unlinkSync(temp); } catch {} return false; }
 }
 
-export function readOccupiedPluginRoots(configDir) {
+export function readOccupiedPluginRoots(configDir, options = {}) {
   const dir = registryDir(configDir);
   let names;
   try { names = readdirSync(dir).filter(name => NAME.test(name)); }
-  catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
+  catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT', identities: new Map() }; }
   const roots = new Set();
   const records = [];
   for (const name of names) {
@@ -96,7 +105,13 @@ export function readOccupiedPluginRoots(configDir) {
     }
     records.push({ path, record });
   }
-  const currentIdentities = identities(records.map(({ record }) => record.pid));
+  // A precomputed map (same-process reuse, issue #3995) verifies records
+  // without a second PowerShell host; the fresh batched probe runs otherwise.
+  const currentIdentities = Array.isArray(options.identities)
+    ? new Map(options.identities)
+    : (options.identities instanceof Map
+      ? options.identities
+      : identities([...records.map(({ record }) => record.pid), ...(Array.isArray(options.includePids) ? options.includePids : [])]));
   for (const { path, record } of records) {
     const current = process.platform === 'win32' ? currentIdentities.get(record.pid) : identity(record.pid);
     if (current && current !== record.processStartIdentity) {
@@ -105,5 +120,5 @@ export function readOccupiedPluginRoots(configDir) {
     }
     roots.add(pathIdentity(record.pluginRoot));
   }
-  return { roots, unavailable: false };
+  return { roots, unavailable: false, identities: currentIdentities };
 }

--- a/scripts/session-start.mjs
+++ b/scripts/session-start.mjs
@@ -1093,14 +1093,20 @@ async function main() {
     } catch { /* non-fatal — dist unavailable or no workspace anchor */ }
     const projectMemoryModules = await loadProjectMemoryModules();
 
+    // Issue #3995: single occupancy resolution per session start; assigned in
+    // the plugin-root branch below, consumed by the stale-cache GC scan below.
+    let occupancyResolution = null;
     writeSessionStartedMarker(omcRoot, directory, sessionId);
     if (process.env.CLAUDE_PLUGIN_ROOT) {
+      // Issue #3995: resolve plugin-cache occupancy ONCE per session start.
+      // The win32 batched identity host (the only PowerShell spawn on this
+      // path) runs a single time; its identities map feeds the owner publish
+      // below and the stale-cache GC scan further down. `includePids` covers
+      // the configured owner even before its own record exists.
       const configuredOwnerPid = Number(process.env.OMC_SESSION_OWNER_PID);
-      publishCacheOccupancy(
-        process.env.CLAUDE_PLUGIN_ROOT,
-        configDir,
-        Number.isSafeInteger(configuredOwnerPid) && configuredOwnerPid > 1 ? configuredOwnerPid : process.ppid,
-      );
+      const ownerPid = Number.isSafeInteger(configuredOwnerPid) && configuredOwnerPid > 1 ? configuredOwnerPid : process.ppid;
+      occupancyResolution = readOccupiedPluginRoots(configDir, { includePids: [ownerPid] });
+      publishCacheOccupancy(process.env.CLAUDE_PLUGIN_ROOT, configDir, ownerPid, occupancyResolution.identities.get(ownerPid));
     }
     reconcileAbandonedSessionStarts(omcRoot, sessionId);
     reconcileSessionEndJobsInBackground(getRuntimeBaseDir(), directory);
@@ -1263,7 +1269,12 @@ ${cleanContent}
     // plugin update whose CLAUDE_PLUGIN_ROOT still points to the old version.
     try {
       const cacheBase = join(configDir, 'plugins', 'cache', 'omc', 'oh-my-claudecode');
-      const occupancy = readOccupiedPluginRoots(configDir);
+      // Issue #3995: reuse the occupancy resolution hoisted above the owner
+      // publish (same-process identities map, no second win32 host). The GC
+      // still re-scans the registry files for records published after that
+      // resolution, and conservatively keeps records whose pid has no
+      // precomputed identity.
+      const occupancy = readOccupiedPluginRoots(configDir, { identities: occupancyResolution?.identities ?? [] });
       let versions = [];
       if (existsSync(cacheBase)) {
         versions = readdirSync(cacheBase)

--- a/src/installer/__tests__/hook-templates.test.ts
+++ b/src/installer/__tests__/hook-templates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { execFileSync } from 'child_process';
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { readdirSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -739,6 +740,63 @@ OMC Ultrawork = "특수부대 작전 반"
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+  it('keeps SessionStart occupancy single-host: publish takes a precomputed identity and read reuses an identity map', async () => {
+    const helperPaths = [
+      join(packageRoot, 'templates', 'hooks', 'lib', 'cache-occupancy.mjs'),
+      join(packageRoot, 'scripts', 'lib', 'cache-occupancy.mjs'),
+    ];
+    const helpers = await Promise.all(helperPaths.map(async (helperPath) => import(pathToFileURL(helperPath).href)));
+    const originalPlatform = process.platform;
+    const tempDir = mkdtempSync(join(tmpdir(), 'cache-occupancy-single-host-'));
+
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      for (const [index, helper] of helpers.entries()) {
+        const configDir = join(tempDir, `config-${index}`);
+        const pluginRoot = join(tempDir, `MiXeD-Plugin-${index}`, 'Version-1');
+
+        // Simulate the identity resolved by the ONE batched host and hand it
+        // to publish: the record must carry it verbatim (no second probe).
+        const precomputed = 'ticks:638933184000000001';
+        expect(helper.publishCacheOccupancy(pluginRoot, configDir, process.pid, precomputed)).toBe(true);
+        const registryDir = join(configDir, '.omc', 'cache-occupancy');
+        const records = readdirSync(registryDir);
+        expect(records).toHaveLength(1);
+        const record = JSON.parse(readFileSync(join(registryDir, records[0]!), 'utf8')) as { processStartIdentity: string };
+        expect(record.processStartIdentity).toBe(precomputed);
+
+        // The map-backed read must verify that record without spawning a
+        // fresh batched host (pids absent from the map stay conservatively).
+        const identityMap = new Map([[process.pid, precomputed]]);
+        const occupancy = helper.readOccupiedPluginRoots(configDir, { identities: identityMap });
+        expect(occupancy.unavailable).toBe(false);
+        expect(occupancy.roots).toEqual(new Set([pluginRoot.toLowerCase()]));
+        expect(occupancy.identities).toBe(identityMap);
+      }
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('session-start hooks resolve plugin-cache occupancy once and pass the owner identity to publish', () => {
+    for (const hookPath of [
+      join(packageRoot, 'scripts', 'session-start.mjs'),
+      join(packageRoot, 'templates', 'hooks', 'session-start.mjs'),
+    ]) {
+      const source = readFileSync(hookPath, 'utf8');
+      // Exactly one batched readOccupiedPluginRoots CALL per execution path:
+      // the runtime hook calls it twice (hoisted owner resolution + GC scan
+      // that reuses the hoisted identities map); the template calls it once
+      // and has no GC consumer. The publish call must carry the identity
+      // resolved from that single host, and no hook may spawn its own
+      // PowerShell probe.
+      const expectedReadCalls = hookPath.endsWith(join('scripts', 'session-start.mjs')) ? 2 : 1;
+      expect(source.match(/readOccupiedPluginRoots\(/g)!.length).toBe(expectedReadCalls);
+      expect(source).toMatch(/publishCacheOccupancy\([^)]*identit(?:ies\.get|y)/s);
+      expect(source).not.toMatch(/spawnSync\(\s*'powershell'/);
     }
   });
 });

--- a/src/utils/__tests__/cache-occupancy.test.ts
+++ b/src/utils/__tests__/cache-occupancy.test.ts
@@ -65,4 +65,29 @@ describe('cache occupancy registry', () => {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
     }
   });
+
+  it('publish skips its per-process probe when handed a precomputed identity (#3995)', async () => {
+    const root = join(dir, 'plugins', '2.0.0');
+    mkdirSync(root, { recursive: true });
+    const originalPlatform = process.platform;
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      // A deliberately corrupt precomputed identity would only be accepted
+      // verbatim if publish skipped its own probe; the record must carry it
+      // untouched (verification happens on read via the identity map).
+      expect(await publishCacheOccupancy(root, dir, 'ticks:638933184000000001')).toBe(true);
+      // The map-backed read verifies the record without any further probe.
+      const result = readOccupiedPluginRoots(dir, { identities: new Map([[process.pid, 'ticks:638933184000000001']]) });
+      expect(result.unavailable).toBe(false);
+      expect(result.roots).toEqual(new Set([root.toLowerCase()]));
+      // A mismatched identity in the map invalidates the record; omitting the
+      // map falls back to a fresh batched probe. Both verification paths agree
+      // the record is only kept on proven-fresh or unknown identity.
+      const mismatched = readOccupiedPluginRoots(dir, { identities: new Map([[process.pid, 'ticks:638933184000000002']]) });
+      expect(mismatched.roots.size).toBe(0);
+      expect(mismatched.identities.get(process.pid)).toBe('ticks:638933184000000002');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+  });
 });

--- a/src/utils/cache-occupancy.ts
+++ b/src/utils/cache-occupancy.ts
@@ -8,6 +8,11 @@ import { getClaudeConfigDir } from './config-dir.js';
 const REGISTRY_VERSION = 1;
 const RECORD_PATTERN = /^[a-f0-9]{64}\.json$/;
 
+// Issue #3995: on win32 every identity probe is a PowerShell host
+// (~1.6-2.0s), so same-process startup paths must not need two. Both
+// operations accept a precomputed identity / identity map so callers can reuse
+// the ONE batched host instead of spawning an extra per-process probe.
+
 /** Resolve paths for identity comparisons; only Windows has case-insensitive paths. */
 export function pathIdentity(path: string): string {
   const normalized = resolve(path);
@@ -82,9 +87,13 @@ function recordPath(pluginRoot: string, pid: number, identity: string, configDir
   return join(getCacheOccupancyDir(configDir), recordName(pluginRoot, pid, identity));
 }
 
-export async function publishCacheOccupancy(pluginRoot: string, configDir?: string): Promise<boolean> {
+export async function publishCacheOccupancy(pluginRoot: string, configDir?: string, precomputedIdentity?: string): Promise<boolean> {
   const normalizedRoot = pathIdentity(pluginRoot);
-  const identity = processStartIdentity(process.pid);
+  // Precomputed identity handoff (issue #3995): a caller that already resolved
+  // an identity with the same algorithm (the batched readOccupiedPluginRoots()
+  // host on win32) passes it here so publish skips the extra per-process
+  // PowerShell spawn instead of paying for two hosts on one startup path.
+  const identity = precomputedIdentity ?? processStartIdentity(process.pid);
   if (!identity) return false;
   const record: CacheOccupancyRecord = {
     version: REGISTRY_VERSION,
@@ -115,13 +124,21 @@ function validRecord(value: unknown): value is CacheOccupancyRecord {
     && typeof record.updatedAt === 'string' && Number.isFinite(Date.parse(record.updatedAt));
 }
 
-export function readOccupiedPluginRoots(configDir = getClaudeConfigDir()): { roots: Set<string>; unavailable: boolean } {
+export interface ReadOccupiedPluginRootsOptions {
+  /** Precomputed pid→identity map (same-process reuse, issue #3995). Records
+   *  whose pid is absent from the map are kept conservatively. */
+  identities?: Map<number, string>;
+  /** Extra pids to resolve in the fresh batched identity probe. */
+  includePids?: number[];
+}
+
+export function readOccupiedPluginRoots(configDir = getClaudeConfigDir(), options: ReadOccupiedPluginRootsOptions = {}): { roots: Set<string>; unavailable: boolean; identities: Map<number, string> } {
   const directory = getCacheOccupancyDir(configDir);
   let names: string[];
   try {
     names = readdirSync(directory).filter(name => RECORD_PATTERN.test(name));
   } catch (error) {
-    return { roots: new Set(), unavailable: (error as NodeJS.ErrnoException).code !== 'ENOENT' };
+    return { roots: new Set(), unavailable: (error as NodeJS.ErrnoException).code !== 'ENOENT', identities: new Map() };
   }
 
   const roots = new Set<string>();
@@ -137,7 +154,11 @@ export function readOccupiedPluginRoots(configDir = getClaudeConfigDir()): { roo
     if (!processAlive(record.pid)) { try { unlinkSync(path); } catch { /* best effort */ } continue; }
     records.push({ path, record });
   }
-  const currentIdentities = processStartIdentities(records.map(({ record }) => record.pid));
+  // A precomputed map (same-process reuse, issue #3995) verifies records
+  // without a second PowerShell host; the fresh batched probe runs otherwise.
+  const currentIdentities = options.identities instanceof Map
+    ? options.identities
+    : processStartIdentities([...records.map(({ record }) => record.pid), ...(options.includePids ?? [])]);
   for (const { path, record } of records) {
     const currentIdentity = process.platform === 'win32'
       ? currentIdentities.get(record.pid)
@@ -147,5 +168,5 @@ export function readOccupiedPluginRoots(configDir = getClaudeConfigDir()): { roo
     // conservatively; only a proven-dead PID or proven mismatch self-invalidates.
     roots.add(pathIdentity(record.pluginRoot));
   }
-  return { roots, unavailable: false };
+  return { roots, unavailable: false, identities: currentIdentities };
 }

--- a/templates/hooks/lib/cache-occupancy.mjs
+++ b/templates/hooks/lib/cache-occupancy.mjs
@@ -37,17 +37,31 @@ function alive(pid) {
 
 function registryDir(configDir) { return join(configDir, '.omc', 'cache-occupancy'); }
 function fileName(root, pid, start) { return `${createHash('sha256').update(`${root}\0${pid}\0${start}`).digest('hex')}.json`; }
-export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid) {
-  const root = pathIdentity(pluginRoot || ''); const start = identity(pid); if (!root || !start) return false;
+
+// Issue #3995: on win32 every identity probe is a PowerShell host (~1.6-2.0s),
+// so SessionStart must not need two. publishCacheOccupancy() accepts an
+// explicit precomputed identity for `pid` (resolved by the caller in the ONE
+// batched readOccupiedPluginRoots() host) and skips its own probe entirely;
+// readOccupiedPluginRoots() accepts a previously returned identities map to
+// verify records without spawning a second host (pids absent from the map are
+// kept conservatively — the record survives unless proven stale otherwise).
+export function publishCacheOccupancy(pluginRoot, configDir, pid = process.ppid, precomputedIdentity) {
+  const root = pathIdentity(pluginRoot || ''); const start = typeof precomputedIdentity === 'string' && precomputedIdentity.length > 0 ? precomputedIdentity : identity(pid); if (!root || !start) return false;
   const dir = registryDir(configDir); const target = join(dir, fileName(root, pid, start)); const temp = `${target}.${process.pid}.${randomUUID()}.tmp`;
   try { mkdirSync(dir, { recursive: true, mode: 0o700 }); writeFileSync(temp, JSON.stringify({ version: 1, pid, processStartIdentity: start, pluginRoot: root, updatedAt: new Date().toISOString() }), { mode: 0o600 }); renameSync(temp, target); return true; } catch { try { unlinkSync(temp); } catch {} return false; }
 }
-export function readOccupiedPluginRoots(configDir) {
+export function readOccupiedPluginRoots(configDir, options = {}) {
   const dir = registryDir(configDir); let names;
-  try { names = readdirSync(dir).filter(name => typeof name === 'string' && NAME.test(name)); } catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT' }; }
+  try { names = readdirSync(dir).filter(name => typeof name === 'string' && NAME.test(name)); } catch (error) { return { roots: new Set(), unavailable: error?.code !== 'ENOENT', identities: new Map() }; }
   const roots = new Set(); const records = [];
   for (const name of names) { const path = join(dir, name); let record; try { record = JSON.parse(readFileSync(path, 'utf8')); } catch { try { unlinkSync(path); } catch {} continue; } const age = Date.now() - Date.parse(record?.updatedAt); if (record?.version !== 1 || !Number.isSafeInteger(record?.pid) || !record?.processStartIdentity || !record?.pluginRoot || !Number.isFinite(Date.parse(record?.updatedAt)) || age < -300000 || !alive(record.pid)) { try { unlinkSync(path); } catch {} continue; } records.push({ path, record }); }
-  const currentIdentities = identities(records.map(({ record }) => record.pid));
+  // A precomputed map (same-process reuse, issue #3995) verifies records
+  // without a second PowerShell host; the fresh batched probe runs otherwise.
+  const currentIdentities = Array.isArray(options.identities)
+    ? new Map(options.identities)
+    : (options.identities instanceof Map
+      ? options.identities
+      : identities([...records.map(({ record }) => record.pid), ...(Array.isArray(options.includePids) ? options.includePids : [])]));
   for (const { path, record } of records) { const current = process.platform === 'win32' ? currentIdentities.get(record.pid) : identity(record.pid); if (current && current !== record.processStartIdentity) { try { unlinkSync(path); } catch {} continue; } roots.add(pathIdentity(record.pluginRoot)); }
-  return { roots, unavailable: false };
+  return { roots, unavailable: false, identities: currentIdentities };
 }

--- a/templates/hooks/session-start.mjs
+++ b/templates/hooks/session-start.mjs
@@ -14,7 +14,7 @@ const __dirname = dirname(__filename);
 const { getClaudeConfigDir, getUpdateCheckCachePath } = await import(pathToFileURL(join(__dirname, 'lib', 'config-dir.mjs')).href);
 const configDir = getClaudeConfigDir();
 const { resolveSessionStatePathsForHook, resolveOmcStateRoot } = await import(pathToFileURL(join(__dirname, 'lib', 'state-root.mjs')).href);
-const { publishCacheOccupancy } = await import(pathToFileURL(join(__dirname, 'lib', 'cache-occupancy.mjs')).href);
+const { publishCacheOccupancy, readOccupiedPluginRoots } = await import(pathToFileURL(join(__dirname, 'lib', 'cache-occupancy.mjs')).href);
 
 // Detached update-cache refresh: argv flag and the child's overall deadline.
 const REFRESH_UPDATE_CACHE_FLAG = '--refresh-update-cache';
@@ -605,7 +605,13 @@ async function main() {
     }
     const sessionId = data.sessionId || data.session_id || data.sessionid || '';
     if (process.env.CLAUDE_PLUGIN_ROOT) {
-      publishCacheOccupancy(process.env.CLAUDE_PLUGIN_ROOT, configDir);
+      // Issue #3995: resolve plugin-cache occupancy ONCE per session start.
+      // The win32 batched identity host (the only PowerShell spawn on this
+      // path) runs a single time; its identities map feeds the owner publish
+      // below. The template has no stale-cache GC consumer, so no occupancy
+      // state is carried past this point.
+      const occupancy = readOccupiedPluginRoots(configDir);
+      publishCacheOccupancy(process.env.CLAUDE_PLUGIN_ROOT, configDir, process.ppid, occupancy.identities.get(process.ppid));
     }
     let messages = [];
     const userMessages = [];


### PR DESCRIPTION
Closes #3995

## Problem

On Windows 5.3.0, a SessionStart hook run paid for **two** PowerShell hosts:

1. `publishCacheOccupancy()` — spawned its own per-process host via `identity(pid)` in `scripts/lib/cache-occupancy.mjs` (the #3972 batching fixed only `readOccupiedPluginRoots()`).
2. `readOccupiedPluginRoots()` — the batched identity host added by #3972 (b556e3eed).

With each win32 host costing ~1.6–2.0s cold, total ≈ 3.3–3.9s against the `run.cjs` SessionStart inner budget of **3500ms** (hooks.json declares 5s; `WINDOWS_TIMEOUT_CUSHION_MS = 1500` leaves 3500ms inner). The hook timed out and **fail-opened**: restored context dropped, plugin-cache GC skipped.

## Fix — one batched host per session start

Both SessionStart hooks now resolve occupancy **once** through the existing batched host and hand the result back into the helpers:

- `publishCacheOccupancy()` accepts an optional precomputed identity and skips its own probe entirely (historical sync signature preserved for other callers).
- `readOccupiedPluginRoots()` accepts an optional `{ identities }` map (same-process reuse — no second host) and `{ includePids }` (covers the owner pid before its record exists). Records are dropped only on proven identity mismatch, dead pid, or staleness — **fail-closed semantics unchanged**; unknown identities stay conservatively.
- `scripts/session-start.mjs`: hoists the batched read above the owner publish; the GC scan re-scans registry files but reuses the hoisted map.
- `templates/hooks/session-start.mjs`: resolves once for the owner publish (no GC consumer in the template).
- `src/utils/cache-occupancy.ts` mirrors the same optional parameters.

Surfaces kept in parity: `scripts/lib/cache-occupancy.mjs`, `templates/hooks/lib/cache-occupancy.mjs`, `src/utils/cache-occupancy.ts`, plus the two hook call sites.

## Tests

- New (runtime + template parity): publish with precomputed identity writes the identity verbatim; map-backed read verifies without a second host; mismatched identity invalidates the record.
- New source contract: exactly one batched `readOccupiedPluginRoots()` call per hook execution path; publish carries the owner identity; no direct `spawnSync('powershell')` in either hook.
- Extended TS suite: precomputed-identity handoff in `src/utils/cache-occupancy.ts`.
- Verified locally: focused suites (93 tests, 6 files) green; full suite 14056 passed with the 12 pre-existing baseline failures unrelated to this change (reproduced on clean `04674e351`); `tsc --noEmit` clean; eslint clean on touched files.

## Constraints honored

- One issue, one PR → dev. No main/release mutation. #3996/#3998 not bundled.
- Fail-closed SessionStart semantics preserved (identity verification unchanged; only the host count changed).
- No timing numbers claimed beyond the derived run.cjs budget arithmetic and the reporter's measurements; a Windows-runner CI leg will exercise the path suite.