### PR TITLE
feat(shipyard): seed the testing discipline volume in the process standards

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "589d7fa5872fd73e91b786af234758c5d94fec4f",
-    "sourceSha256": "a6b6bce35e0107ba2366eabd0d20cff9c481de2147fcc8ee4ca4d2518ea8f2ae",
+    "head": "166653965135e5b8d2ad30974e09b6877a953b2a",
+    "sourceSha256": "19055c14a44568b8e2d5246c0e9a2b384540d81523cda19b41aa251331bbbf5b",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "589d7fa5872fd73e91b786af234758c5d94fec4f",
-  "sourceSha256": "a6b6bce35e0107ba2366eabd0d20cff9c481de2147fcc8ee4ca4d2518ea8f2ae",
+  "head": "166653965135e5b8d2ad30974e09b6877a953b2a",
+  "sourceSha256": "19055c14a44568b8e2d5246c0e9a2b384540d81523cda19b41aa251331bbbf5b",
   "counts": {
     "public": {
       "skills": 41,
@@ -78553,5 +78553,5 @@
     }
   },
   "inventorySha256": "b54c934dddcbb51bf4a10243b5eb1015488bc7e7a0f9160a61eff3f2730e9384",
-  "manifestSha256": "33cefeed198527b61695cd2516fa414165949b3a5029dbecb0e4aa8dc8ff993f"
+  "manifestSha256": "b8a4c90dbb553e16925b408f01c3b1c4af5e16d2c6fd63a278ef25ec71b3ca4e"
 }

--- a/skills/drydock/SKILL.md
+++ b/skills/drydock/SKILL.md
@@ -259,7 +259,7 @@ documentLanguage: zh-Hant
 ```
 <!-- shipyard-seed-b:zh-Hant:end -->
 
-Seed C — docs/standards/architecture.md (data.md / process.md same shape; prose renders in the document language):
+Seed C — docs/standards/architecture.md (data.md same shape; process.md additionally seeds a Testing volume — see Seed C2; prose renders in the document language):
 
 ```markdown
 # Architecture Standards
@@ -274,6 +274,18 @@ Rule-shaped, checkable writing; every rule carries a "why". Empty sections are l
 - A seam is a real boundary two modules already cross in both directions. One adapter is a hypothetical seam; two adapters make it real. (Checkable: count the callers. Why: speculative abstraction is a tax paid before the need exists.)
 - A deep module puts much behavior behind a small interface; deepen before widening. (Why: the interface is the permanent tax.)
 - Logic lives behind the seam that owns its data; stable dependencies point inward. (Why: logic that reaches across a boundary it does not own couples every caller to the wrong neighbor.)
+```
+
+Seed C2 — docs/standards/process.md, Testing volume (rendered when the repo tests code; prose renders in the document language):
+
+```markdown
+## Testing
+
+- Tests enter through the interface only: assert observable behavior at the seam. Reaching past the seam — querying the store directly, reading internal state — is false confidence. (Why: a test that survives refactors describes behavior, not plumbing.)
+- Expected values come from an independent source of truth: a known-good literal or a worked example from the spec. (Why: a test that recomputes its expectation the way the code does can never disagree with the code.)
+- One slice at a time: one failing test, one minimal implementation, repeat. Bulk-writing all tests first tests the imagination, not the behavior. (Why: the loop is a feedback engine; batching cuts the feedback.)
+- Refactoring happens at the review axis, not inside the red-green loop. (Why: the loop answers "is the behavior right"; mixing redesign in hides regressions.)
+- Tests open only at seams the reviewing captain approved. (Why: unapproved seams spend effort where the risk is not.)
 ```
 
 Seed D — docs/business/README.md:

--- a/src/__tests__/shipyard-skills.test.ts
+++ b/src/__tests__/shipyard-skills.test.ts
@@ -620,6 +620,19 @@ describe('shipyard skills — behavior & packaging contract', () => {
     expect(LAUNCH).toContain('the vocabulary is seeded in `docs/standards/architecture.md`');
   });
 
+  it('the testing discipline is seeded as its own process volume that launch can point at', () => {
+    expect(DRYDOCK).toContain('Seed C2 — docs/standards/process.md, Testing volume');
+    expect(DRYDOCK).toContain('## Testing');
+    expect(DRYDOCK).toContain('Tests enter through the interface only');
+    expect(DRYDOCK).toContain('Expected values come from an independent source of truth');
+    expect(DRYDOCK).toContain('Refactoring happens at the review axis, not inside the red-green loop');
+    expect(DRYDOCK).toContain('Tests open only at seams the reviewing captain approved');
+    // launch already points callers at the process volume; the seed must exist,
+    // or that reference dangles.
+    expect(LAUNCH).toContain('The testing rules themselves are seeded in `docs/standards/process.md`');
+    expect(DRYDOCK).not.toContain('data.md / process.md same shape');
+  });
+
   it('docs/REFERENCE.md skills count matches the filesystem', () => {
     const ref = readFileSync(join(ROOT, 'docs', 'REFERENCE.md'), 'utf-8');
     const dirCount = existsSync(join(ROOT, 'skills'))


### PR DESCRIPTION
## Summary

Seeds a **Testing volume** into the process standards (`docs/standards/process.md`) that drydock generates — five checkable test rules, each carrying a why, in the same rule-shaped voice as the rest of the classification society's volumes:

- **Interface-only assertions** — tests enter through the seam; reaching past it (querying the store directly, reading internal state) is false confidence.
- **Independent expectations** — expected values come from a known-good literal or a worked example, never recomputed the way the code computes them.
- **Vertical slices** — one failing test, one minimal implementation, repeat; bulk-written tests test the imagination.
- **Refactoring at the review axis** — the red-green loop answers "is the behavior right"; mixing redesign in hides regressions.
- **Approved seams only** — tests open only at seams the reviewing captain approved, matching launch C2's "a seam the human has not approved gets no tests".

Seed C's parenthetical is updated (data.md same shape; process.md additionally seeds the Testing volume — Seed C2), and the volume renders in the document language like every other seed.

Stacked on #4012 (the launch C2 cross-reference to `docs/standards/process.md` lands there); once #4012 merges, this PR shows only its own commits.

## Test plan

- [x] `npx vitest run src/__tests__/shipyard-skills.test.ts tests/lint/inventory-graph-drift.test.ts` — 50 tests green
- [x] `npm run generate:inventory` — baseline regenerated and repointed after the seed change

## Notes

The testing discipline is adapted from public inspiration sources and fully rewritten in this repo's own terms; the underlying ideas are credited to their primary sources (Beck's red-green-refactor and vertical slicing; the interface-as-test-surface rule shared with the already-seeded seam vocabulary). No external text is embedded.
