### PR TITLE
fix(launch): keep forwarded credentials off every launch command line

### DIFF
--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "99d8efc967d912b08de70f420d48f94b9e9924b8",
+    "head": "b2d1d93d7ed4c551e2a6e99598c5755226d37b53",
     "sourceSha256": "1e22b0cc6f1aa2cf123a97bc6b7317259f6e50f2b27ad478c626e0f51fb2852c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "99d8efc967d912b08de70f420d48f94b9e9924b8",
+  "head": "b2d1d93d7ed4c551e2a6e99598c5755226d37b53",
   "sourceSha256": "1e22b0cc6f1aa2cf123a97bc6b7317259f6e50f2b27ad478c626e0f51fb2852c",
   "counts": {
     "public": {
@@ -78856,5 +78856,5 @@
     }
   },
   "inventorySha256": "1cf792d0a5f5622af60dddd9e745930b12ccc8cd31345a413e8334b39bdfc2dc",
-  "manifestSha256": "de0c07331513d898e86468cb02ac5edf49f105c7873929ab37ae4d9f6c3b5f69"
+  "manifestSha256": "9c9f238f376afbf26f206e90b03a39d27221ce1742f1d3aa062e827b5eac581e"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "adaeaa91f24dbbffe7e11a97af0d3d5afe710930",
-    "sourceSha256": "942da01efa16af6d185dd01456632bea3a9e7bda9afe57424020fd090fe72d12",
+    "head": "bd005d12c22994aae60193b331c09e23484586b1",
+    "sourceSha256": "bc0ffc41f3f308b2bd7cca182cff43911190c84010e383dbd2981b23ec7013a4",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "adaeaa91f24dbbffe7e11a97af0d3d5afe710930",
-  "sourceSha256": "942da01efa16af6d185dd01456632bea3a9e7bda9afe57424020fd090fe72d12",
+  "head": "bd005d12c22994aae60193b331c09e23484586b1",
+  "sourceSha256": "bc0ffc41f3f308b2bd7cca182cff43911190c84010e383dbd2981b23ec7013a4",
   "counts": {
     "public": {
       "skills": 41,
@@ -28,8 +28,8 @@
       "toolFiles": 61,
       "libFiles": 43,
       "templateHooks": 22,
-      "srcFiles": 1349,
-      "total": 1371
+      "srcFiles": 1352,
+      "total": 1374
     },
     "generated": {
       "distFiles": 5032,
@@ -728,6 +728,7 @@
       "scripts/build-bridge-entry.mjs",
       "scripts/build-claude-md-coordinator.mjs",
       "scripts/build-cli.mjs",
+      "scripts/build-contained-fs.mjs",
       "scripts/build-mcp-server.mjs",
       "scripts/build-prompt-ssot.ts",
       "scripts/build-runtime-cli.mjs",
@@ -824,6 +825,7 @@
       "scripts/verify-deliverables.mjs",
       "scripts/verify-epic-3698-closure.mjs",
       "scripts/verify-generated-artifact-authorization.mjs",
+      "scripts/verify-graph-contained-fs.mjs",
       "scripts/wiki-pre-compact.mjs",
       "scripts/wiki-session-end.mjs",
       "scripts/wiki-session-start.mjs",
@@ -32639,6 +32641,11 @@
         "path": "docs/geobench.md"
       },
       {
+        "id": "docs/graph-contained-filesystem.md",
+        "kind": "other",
+        "path": "docs/graph-contained-filesystem.md"
+      },
+      {
         "id": "docs/issues/issue-3668-ralph-namespace.md",
         "kind": "other",
         "path": "docs/issues/issue-3668-ralph-namespace.md"
@@ -32827,6 +32834,11 @@
         "id": "external:net",
         "kind": "external",
         "path": "net"
+      },
+      {
+        "id": "external:node:assert/strict",
+        "kind": "external",
+        "path": "node:assert/strict"
       },
       {
         "id": "external:node:async_hooks",
@@ -33079,6 +33091,11 @@
         "path": "missions/prove-reliability-by-finding-and-fixing-flaky-te/sandbox.md"
       },
       {
+        "id": "native/contained-fs.c",
+        "kind": "other",
+        "path": "native/contained-fs.c"
+      },
+      {
         "id": "package-lock.json",
         "kind": "other",
         "path": "package-lock.json"
@@ -33192,6 +33209,11 @@
         "id": "scripts/build-cli.mjs",
         "kind": "script",
         "path": "scripts/build-cli.mjs"
+      },
+      {
+        "id": "scripts/build-contained-fs.mjs",
+        "kind": "script",
+        "path": "scripts/build-contained-fs.mjs"
       },
       {
         "id": "scripts/build-mcp-server.mjs",
@@ -33672,6 +33694,11 @@
         "id": "scripts/verify-generated-artifact-authorization.mjs",
         "kind": "script",
         "path": "scripts/verify-generated-artifact-authorization.mjs"
+      },
+      {
+        "id": "scripts/verify-graph-contained-fs.mjs",
+        "kind": "script",
+        "path": "scripts/verify-graph-contained-fs.mjs"
       },
       {
         "id": "scripts/wiki-pre-compact.mjs",
@@ -35864,6 +35891,11 @@
         "path": "src/cli/__tests__/hud-watch.test.ts"
       },
       {
+        "id": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "kind": "src",
+        "path": "src/cli/__tests__/launch-secure-transport.test.ts"
+      },
+      {
         "id": "src/cli/__tests__/launch.test.ts",
         "kind": "src",
         "path": "src/cli/__tests__/launch.test.ts"
@@ -36659,6 +36691,11 @@
         "path": "src/graph/__tests__/runtime/journal.test.ts"
       },
       {
+        "id": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
+        "kind": "src",
+        "path": "src/graph/__tests__/runtime/native-contained-fs.test.ts"
+      },
+      {
         "id": "src/graph/__tests__/runtime/progress.test.ts",
         "kind": "src",
         "path": "src/graph/__tests__/runtime/progress.test.ts"
@@ -36742,6 +36779,11 @@
         "id": "src/graph/runtime/journal.ts",
         "kind": "src",
         "path": "src/graph/runtime/journal.ts"
+      },
+      {
+        "id": "src/graph/runtime/native-contained-fs.ts",
+        "kind": "src",
+        "path": "src/graph/runtime/native-contained-fs.ts"
       },
       {
         "id": "src/graph/runtime/progress.ts",
@@ -41751,6 +41793,31 @@
         "kind": "imports"
       },
       {
+        "from": "scripts/build-contained-fs.mjs",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/build-contained-fs.mjs",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/build-contained-fs.mjs",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/build-contained-fs.mjs",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/build-contained-fs.mjs",
+        "to": "external:node:url",
+        "kind": "imports"
+      },
+      {
         "from": "scripts/build-mcp-server.mjs",
         "to": "external:esbuild",
         "kind": "imports"
@@ -43438,6 +43505,36 @@
       {
         "from": "scripts/verify-generated-artifact-authorization.mjs",
         "to": "external:node:url",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/verify-graph-contained-fs.mjs",
+        "to": "external:node:assert/strict",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/verify-graph-contained-fs.mjs",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/verify-graph-contained-fs.mjs",
+        "to": "external:node:crypto",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/verify-graph-contained-fs.mjs",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/verify-graph-contained-fs.mjs",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/verify-graph-contained-fs.mjs",
+        "to": "external:node:path",
         "kind": "imports"
       },
       {
@@ -51401,6 +51498,26 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "src/cli/launch.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/cli/__tests__/launch.test.ts",
         "to": "external:child_process",
         "kind": "imports"
@@ -54886,6 +55003,31 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
+        "to": "src/graph/runtime/native-contained-fs.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/graph/__tests__/runtime/progress.test.ts",
         "to": "external:stream",
         "kind": "imports"
@@ -55137,12 +55279,22 @@
       },
       {
         "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
+        "to": "src/graph/runtime/contained-fd.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
         "to": "src/graph/runtime/run-dir.ts",
         "kind": "imports"
       },
       {
         "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
         "to": "src/graph/runtime/safe-fs.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
+        "to": "src/lib/atomic-write.ts",
         "kind": "imports"
       },
       {
@@ -55271,6 +55423,11 @@
         "kind": "imports"
       },
       {
+        "from": "src/graph/runtime/contained-fd.ts",
+        "to": "src/graph/runtime/native-contained-fs.ts",
+        "kind": "imports"
+      },
+      {
         "from": "src/graph/runtime/executors/agent.ts",
         "to": "external:@anthropic-ai/claude-agent-sdk",
         "kind": "imports"
@@ -55337,13 +55494,8 @@
       },
       {
         "from": "src/graph/runtime/fence.ts",
-        "to": "external:fs",
+        "to": "src/graph/runtime/contained-fd.ts",
         "kind": "type-imports"
-      },
-      {
-        "from": "src/graph/runtime/fence.ts",
-        "to": "external:path",
-        "kind": "imports"
       },
       {
         "from": "src/graph/runtime/fence.ts",
@@ -55426,6 +55578,26 @@
         "kind": "type-imports"
       },
       {
+        "from": "src/graph/runtime/native-contained-fs.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/native-contained-fs.ts",
+        "to": "external:node:module",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/native-contained-fs.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/native-contained-fs.ts",
+        "to": "external:node:url",
+        "kind": "imports"
+      },
+      {
         "from": "src/graph/runtime/progress.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "type-imports"
@@ -55439,6 +55611,11 @@
         "from": "src/graph/runtime/remote-approval.ts",
         "to": "external:path",
         "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/graph/runtime/contained-fd.ts",
+        "kind": "type-imports"
       },
       {
         "from": "src/graph/runtime/remote-approval.ts",
@@ -55459,11 +55636,6 @@
         "from": "src/graph/runtime/remote-approval.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "type-imports"
-      },
-      {
-        "from": "src/graph/runtime/remote-approval.ts",
-        "to": "src/lib/atomic-write.ts",
-        "kind": "imports"
       },
       {
         "from": "src/graph/runtime/run-dir.ts",
@@ -55547,6 +55719,11 @@
       },
       {
         "from": "src/graph/runtime/safe-fs.ts",
+        "to": "external:crypto",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
         "to": "external:fs",
         "kind": "imports"
       },
@@ -55558,6 +55735,16 @@
       {
         "from": "src/graph/runtime/safe-fs.ts",
         "to": "src/graph/runtime/contained-fd.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
+        "to": "src/graph/runtime/contained-fd.ts",
+        "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/safe-fs.ts",
+        "to": "src/graph/runtime/run-dir.ts",
         "kind": "imports"
       },
       {
@@ -78657,12 +78844,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6970,
-      "edgeCount": 7481,
-      "importEdgeCount": 6164,
+      "nodeCount": 6978,
+      "edgeCount": 7510,
+      "importEdgeCount": 6190,
       "registerEdgeCount": 62
     }
   },
-  "inventorySha256": "6757c236df49e65dfb77ff8000590c31fb4caa7d014d0c2eb995dee72a7cd5ec",
-  "manifestSha256": "c5d3cf2af168d067a05611eb79d4c8881df8a46c02ceac0464169c56097390d7"
+  "inventorySha256": "1cf792d0a5f5622af60dddd9e745930b12ccc8cd31345a413e8334b39bdfc2dc",
+  "manifestSha256": "c0706ea8cb901fb6fedddd53b4a771dd54f875e2b5667a1df3c9fff75a606e3b"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "bd005d12c22994aae60193b331c09e23484586b1",
-    "sourceSha256": "bc0ffc41f3f308b2bd7cca182cff43911190c84010e383dbd2981b23ec7013a4",
+    "head": "99d8efc967d912b08de70f420d48f94b9e9924b8",
+    "sourceSha256": "1e22b0cc6f1aa2cf123a97bc6b7317259f6e50f2b27ad478c626e0f51fb2852c",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "bd005d12c22994aae60193b331c09e23484586b1",
-  "sourceSha256": "bc0ffc41f3f308b2bd7cca182cff43911190c84010e383dbd2981b23ec7013a4",
+  "head": "99d8efc967d912b08de70f420d48f94b9e9924b8",
+  "sourceSha256": "1e22b0cc6f1aa2cf123a97bc6b7317259f6e50f2b27ad478c626e0f51fb2852c",
   "counts": {
     "public": {
       "skills": 41,
@@ -51509,6 +51509,11 @@
       },
       {
         "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
         "to": "external:vitest",
         "kind": "imports"
       },
@@ -78845,11 +78850,11 @@
     ],
     "stats": {
       "nodeCount": 6978,
-      "edgeCount": 7510,
-      "importEdgeCount": 6190,
+      "edgeCount": 7511,
+      "importEdgeCount": 6191,
       "registerEdgeCount": 62
     }
   },
   "inventorySha256": "1cf792d0a5f5622af60dddd9e745930b12ccc8cd31345a413e8334b39bdfc2dc",
-  "manifestSha256": "c0706ea8cb901fb6fedddd53b4a771dd54f875e2b5667a1df3c9fff75a606e3b"
+  "manifestSha256": "de0c07331513d898e86468cb02ac5edf49f105c7873929ab37ae4d9f6c3b5f69"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "47925107bbf626bf3df6e57d1bc6717a51b90493",
-    "sourceSha256": "bb2db215e8ec767761d8b07e2d00a939ff7ccd15f118ef1a37a002d26d9585d3",
+    "head": "adaeaa91f24dbbffe7e11a97af0d3d5afe710930",
+    "sourceSha256": "942da01efa16af6d185dd01456632bea3a9e7bda9afe57424020fd090fe72d12",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "47925107bbf626bf3df6e57d1bc6717a51b90493",
-  "sourceSha256": "bb2db215e8ec767761d8b07e2d00a939ff7ccd15f118ef1a37a002d26d9585d3",
+  "head": "adaeaa91f24dbbffe7e11a97af0d3d5afe710930",
+  "sourceSha256": "942da01efa16af6d185dd01456632bea3a9e7bda9afe57424020fd090fe72d12",
   "counts": {
     "public": {
       "skills": 41,
@@ -28,8 +28,8 @@
       "toolFiles": 61,
       "libFiles": 43,
       "templateHooks": 22,
-      "srcFiles": 1351,
-      "total": 1373
+      "srcFiles": 1349,
+      "total": 1371
     },
     "generated": {
       "distFiles": 5032,
@@ -728,7 +728,6 @@
       "scripts/build-bridge-entry.mjs",
       "scripts/build-claude-md-coordinator.mjs",
       "scripts/build-cli.mjs",
-      "scripts/build-contained-fs.mjs",
       "scripts/build-mcp-server.mjs",
       "scripts/build-prompt-ssot.ts",
       "scripts/build-runtime-cli.mjs",
@@ -825,7 +824,6 @@
       "scripts/verify-deliverables.mjs",
       "scripts/verify-epic-3698-closure.mjs",
       "scripts/verify-generated-artifact-authorization.mjs",
-      "scripts/verify-graph-contained-fs.mjs",
       "scripts/wiki-pre-compact.mjs",
       "scripts/wiki-session-end.mjs",
       "scripts/wiki-session-start.mjs",
@@ -32641,11 +32639,6 @@
         "path": "docs/geobench.md"
       },
       {
-        "id": "docs/graph-contained-filesystem.md",
-        "kind": "other",
-        "path": "docs/graph-contained-filesystem.md"
-      },
-      {
         "id": "docs/issues/issue-3668-ralph-namespace.md",
         "kind": "other",
         "path": "docs/issues/issue-3668-ralph-namespace.md"
@@ -32834,11 +32827,6 @@
         "id": "external:net",
         "kind": "external",
         "path": "net"
-      },
-      {
-        "id": "external:node:assert/strict",
-        "kind": "external",
-        "path": "node:assert/strict"
       },
       {
         "id": "external:node:async_hooks",
@@ -33091,11 +33079,6 @@
         "path": "missions/prove-reliability-by-finding-and-fixing-flaky-te/sandbox.md"
       },
       {
-        "id": "native/contained-fs.c",
-        "kind": "other",
-        "path": "native/contained-fs.c"
-      },
-      {
         "id": "package-lock.json",
         "kind": "other",
         "path": "package-lock.json"
@@ -33209,11 +33192,6 @@
         "id": "scripts/build-cli.mjs",
         "kind": "script",
         "path": "scripts/build-cli.mjs"
-      },
-      {
-        "id": "scripts/build-contained-fs.mjs",
-        "kind": "script",
-        "path": "scripts/build-contained-fs.mjs"
       },
       {
         "id": "scripts/build-mcp-server.mjs",
@@ -33694,11 +33672,6 @@
         "id": "scripts/verify-generated-artifact-authorization.mjs",
         "kind": "script",
         "path": "scripts/verify-generated-artifact-authorization.mjs"
-      },
-      {
-        "id": "scripts/verify-graph-contained-fs.mjs",
-        "kind": "script",
-        "path": "scripts/verify-graph-contained-fs.mjs"
       },
       {
         "id": "scripts/wiki-pre-compact.mjs",
@@ -36686,11 +36659,6 @@
         "path": "src/graph/__tests__/runtime/journal.test.ts"
       },
       {
-        "id": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
-        "kind": "src",
-        "path": "src/graph/__tests__/runtime/native-contained-fs.test.ts"
-      },
-      {
         "id": "src/graph/__tests__/runtime/progress.test.ts",
         "kind": "src",
         "path": "src/graph/__tests__/runtime/progress.test.ts"
@@ -36774,11 +36742,6 @@
         "id": "src/graph/runtime/journal.ts",
         "kind": "src",
         "path": "src/graph/runtime/journal.ts"
-      },
-      {
-        "id": "src/graph/runtime/native-contained-fs.ts",
-        "kind": "src",
-        "path": "src/graph/runtime/native-contained-fs.ts"
       },
       {
         "id": "src/graph/runtime/progress.ts",
@@ -41788,31 +41751,6 @@
         "kind": "imports"
       },
       {
-        "from": "scripts/build-contained-fs.mjs",
-        "to": "external:node:child_process",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/build-contained-fs.mjs",
-        "to": "external:node:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/build-contained-fs.mjs",
-        "to": "external:node:os",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/build-contained-fs.mjs",
-        "to": "external:node:path",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/build-contained-fs.mjs",
-        "to": "external:node:url",
-        "kind": "imports"
-      },
-      {
         "from": "scripts/build-mcp-server.mjs",
         "to": "external:esbuild",
         "kind": "imports"
@@ -43500,36 +43438,6 @@
       {
         "from": "scripts/verify-generated-artifact-authorization.mjs",
         "to": "external:node:url",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/verify-graph-contained-fs.mjs",
-        "to": "external:node:assert/strict",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/verify-graph-contained-fs.mjs",
-        "to": "external:node:child_process",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/verify-graph-contained-fs.mjs",
-        "to": "external:node:crypto",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/verify-graph-contained-fs.mjs",
-        "to": "external:node:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/verify-graph-contained-fs.mjs",
-        "to": "external:node:os",
-        "kind": "imports"
-      },
-      {
-        "from": "scripts/verify-graph-contained-fs.mjs",
-        "to": "external:node:path",
         "kind": "imports"
       },
       {
@@ -54978,31 +54886,6 @@
         "kind": "type-imports"
       },
       {
-        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
-        "to": "external:node:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
-        "to": "external:node:os",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
-        "to": "external:node:path",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
-        "to": "external:vitest",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/__tests__/runtime/native-contained-fs.test.ts",
-        "to": "src/graph/runtime/native-contained-fs.ts",
-        "kind": "imports"
-      },
-      {
         "from": "src/graph/__tests__/runtime/progress.test.ts",
         "to": "external:stream",
         "kind": "imports"
@@ -55254,22 +55137,12 @@
       },
       {
         "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
-        "to": "src/graph/runtime/contained-fd.ts",
-        "kind": "type-imports"
-      },
-      {
-        "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
         "to": "src/graph/runtime/run-dir.ts",
         "kind": "imports"
       },
       {
         "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
         "to": "src/graph/runtime/safe-fs.ts",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/__tests__/runtime/safe-fs.test.ts",
-        "to": "src/lib/atomic-write.ts",
         "kind": "imports"
       },
       {
@@ -55398,11 +55271,6 @@
         "kind": "imports"
       },
       {
-        "from": "src/graph/runtime/contained-fd.ts",
-        "to": "src/graph/runtime/native-contained-fs.ts",
-        "kind": "imports"
-      },
-      {
         "from": "src/graph/runtime/executors/agent.ts",
         "to": "external:@anthropic-ai/claude-agent-sdk",
         "kind": "imports"
@@ -55469,8 +55337,13 @@
       },
       {
         "from": "src/graph/runtime/fence.ts",
-        "to": "src/graph/runtime/contained-fd.ts",
+        "to": "external:fs",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/fence.ts",
+        "to": "external:path",
+        "kind": "imports"
       },
       {
         "from": "src/graph/runtime/fence.ts",
@@ -55553,26 +55426,6 @@
         "kind": "type-imports"
       },
       {
-        "from": "src/graph/runtime/native-contained-fs.ts",
-        "to": "external:node:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/native-contained-fs.ts",
-        "to": "external:node:module",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/native-contained-fs.ts",
-        "to": "external:node:path",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/native-contained-fs.ts",
-        "to": "external:node:url",
-        "kind": "imports"
-      },
-      {
         "from": "src/graph/runtime/progress.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "type-imports"
@@ -55586,11 +55439,6 @@
         "from": "src/graph/runtime/remote-approval.ts",
         "to": "external:path",
         "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/remote-approval.ts",
-        "to": "src/graph/runtime/contained-fd.ts",
-        "kind": "type-imports"
       },
       {
         "from": "src/graph/runtime/remote-approval.ts",
@@ -55611,6 +55459,11 @@
         "from": "src/graph/runtime/remote-approval.ts",
         "to": "src/graph/runtime/types.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/graph/runtime/remote-approval.ts",
+        "to": "src/lib/atomic-write.ts",
+        "kind": "imports"
       },
       {
         "from": "src/graph/runtime/run-dir.ts",
@@ -55694,11 +55547,6 @@
       },
       {
         "from": "src/graph/runtime/safe-fs.ts",
-        "to": "external:crypto",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/safe-fs.ts",
         "to": "external:fs",
         "kind": "imports"
       },
@@ -55710,16 +55558,6 @@
       {
         "from": "src/graph/runtime/safe-fs.ts",
         "to": "src/graph/runtime/contained-fd.ts",
-        "kind": "imports"
-      },
-      {
-        "from": "src/graph/runtime/safe-fs.ts",
-        "to": "src/graph/runtime/contained-fd.ts",
-        "kind": "type-imports"
-      },
-      {
-        "from": "src/graph/runtime/safe-fs.ts",
-        "to": "src/graph/runtime/run-dir.ts",
         "kind": "imports"
       },
       {
@@ -78819,12 +78657,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6977,
-      "edgeCount": 7506,
-      "importEdgeCount": 6186,
+      "nodeCount": 6970,
+      "edgeCount": 7481,
+      "importEdgeCount": 6164,
       "registerEdgeCount": 62
     }
   },
-  "inventorySha256": "9ba57e900b66850d0257cd8ef48c1a7b5c7f1e0165cfce5448ae47e451624607",
-  "manifestSha256": "85168c1855256671a90ac667e6f108b027a6b7522b1d9a0cdecf6d8c851f9c54"
+  "inventorySha256": "6757c236df49e65dfb77ff8000590c31fb4caa7d014d0c2eb995dee72a7cd5ec",
+  "manifestSha256": "c5d3cf2af168d067a05611eb79d4c8881df8a46c02ceac0464169c56097390d7"
 }

--- a/src/cli/__tests__/launch-secure-transport.test.ts
+++ b/src/cli/__tests__/launch-secure-transport.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const { writeFileSyncMock } = vi.hoisted(() => ({
+  writeFileSyncMock: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    writeFileSync: writeFileSyncMock,
+  };
+});
+
+import { buildSensitiveEnvFilePrefix } from '../launch.js';
+
+describe('secure credential transport failure cleanup', () => {
+  it('removes the private temp directory when writing the transport fails', () => {
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    const before = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith('omc-launch-env-')));
+    process.env.ANTHROPIC_API_KEY = 'write-failure-secret';
+    writeFileSyncMock.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    try {
+      expect(() => buildSensitiveEnvFilePrefix(['ANTHROPIC_API_KEY'])).toThrow(
+        'Unable to prepare secure credential transport: disk full',
+      );
+      const after = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith('omc-launch-env-')));
+      expect(after).toEqual(before);
+    } finally {
+      writeFileSyncMock.mockReset();
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  });
+});

--- a/src/cli/__tests__/launch-secure-transport.test.ts
+++ b/src/cli/__tests__/launch-secure-transport.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-import { readdirSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readdirSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const { writeFileSyncMock } = vi.hoisted(() => ({
   writeFileSyncMock: vi.fn(),
@@ -16,10 +17,33 @@ vi.mock('fs', async (importOriginal) => {
 
 import { buildSensitiveEnvFilePrefix } from '../launch.js';
 
+const TEMP_ENV_VARS = ['TMPDIR', 'TMP', 'TEMP'] as const;
+
 describe('secure credential transport failure cleanup', () => {
+  const savedTempEnv: Record<string, string | undefined> = {};
+  let transportRoot: string;
+
+  beforeEach(() => {
+    // os.tmpdir() is process-wide, so asserting on its contents would observe
+    // transports created by concurrently running test files. Redirect it to a
+    // private root so the assertion covers only this call's artifacts.
+    transportRoot = realpathSync(mkdtempSync(join(tmpdir(), 'omc-transport-root-')));
+    for (const name of TEMP_ENV_VARS) {
+      savedTempEnv[name] = process.env[name];
+      process.env[name] = transportRoot;
+    }
+  });
+
+  afterEach(() => {
+    for (const name of TEMP_ENV_VARS) {
+      if (savedTempEnv[name] === undefined) delete process.env[name];
+      else process.env[name] = savedTempEnv[name] as string;
+    }
+    rmSync(transportRoot, { recursive: true, force: true });
+  });
+
   it('removes the private temp directory when writing the transport fails', () => {
     const savedApiKey = process.env.ANTHROPIC_API_KEY;
-    const before = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith('omc-launch-env-')));
     process.env.ANTHROPIC_API_KEY = 'write-failure-secret';
     writeFileSyncMock.mockImplementation(() => {
       throw new Error('disk full');
@@ -29,8 +53,7 @@ describe('secure credential transport failure cleanup', () => {
       expect(() => buildSensitiveEnvFilePrefix(['ANTHROPIC_API_KEY'])).toThrow(
         'Unable to prepare secure credential transport: disk full',
       );
-      const after = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith('omc-launch-env-')));
-      expect(after).toEqual(before);
+      expect(readdirSync(transportRoot)).toEqual([]);
     } finally {
       writeFileSyncMock.mockReset();
       if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;

--- a/src/cli/__tests__/launch.test.ts
+++ b/src/cli/__tests__/launch.test.ts
@@ -37,7 +37,7 @@ vi.mock('../tmux-utils.js', async (importOriginal) => {
   };
 });
 
-import { runClaude, launchCommand, extractNotifyFlag, extractOpenClawFlag, extractTelegramFlag, extractDiscordFlag, extractSlackFlag, extractWebhookFlag, normalizeClaudeLaunchArgs, isPrintMode, prepareOmcLaunchConfigDir, buildEnvExportPrefix, buildTmuxClaudeCommand, hasMadmaxFlag, TMUX_ENV_FORWARD } from '../launch.js';
+import { runClaude, launchCommand, extractNotifyFlag, extractOpenClawFlag, extractTelegramFlag, extractDiscordFlag, extractSlackFlag, extractWebhookFlag, normalizeClaudeLaunchArgs, isPrintMode, prepareOmcLaunchConfigDir, buildEnvExportPrefix, buildSensitiveEnvFilePrefix, buildTmuxClaudeCommand, hasMadmaxFlag, TMUX_ENV_FORWARD } from '../launch.js';
 import {
   resolveLaunchPolicy,
   buildTmuxShellCommand,
@@ -380,6 +380,34 @@ describe('runClaude — exit code propagation', () => {
       }
     });
 
+    it('keeps provider credentials off the native psmux respawn command line', () => {
+      const originalPlatform = process.platform;
+      const savedApiKey = process.env.ANTHROPIC_API_KEY;
+      const secret = 'native-respawn-secret';
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      process.env.ANTHROPIC_API_KEY = secret;
+      vi.mocked(isNativeWindowsShell).mockReturnValue(true);
+
+      try {
+        runClaude('/tmp', [], 'sid');
+        const command = String(
+          vi.mocked(tmuxExec).mock.calls.find(([args]) => args[0] === 'respawn-pane')?.[0].at(-1),
+        );
+        expect(command).not.toContain(secret);
+        expect(command).toContain('call ');
+        expect(command).toContain('env.cmd');
+        const envFileMatch = command.match(/call (?:"([^"]+)"|(\S+env\.cmd))/);
+        const envFile = envFileMatch?.[1] ?? envFileMatch?.[2];
+        expect(envFile).toBeDefined();
+        expect(readFileSync(envFile as string, 'utf8')).toContain(`set "ANTHROPIC_API_KEY=${secret}"`);
+        rmSync(dirname(envFile as string), { recursive: true, force: true });
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+        if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+        else process.env.ANTHROPIC_API_KEY = savedApiKey;
+      }
+    });
+
     it('keeps non-sensitive forwarded variables in the inline export prefix', () => {
       const savedNotify = process.env.OMC_NOTIFY;
       process.env.OMC_NOTIFY = 'plain value';
@@ -567,6 +595,30 @@ describe('runClaude outside-tmux — mouse scrolling (issue #890)', () => {
 
     expect(vi.mocked(tmuxExec).mock.calls).toHaveLength(1);
     expect(vi.mocked(execFileSync).mock.calls.find(([cmd, args]) => cmd === 'claude' && (args as string[])[0] === '--dangerously-skip-permissions')).toBeDefined();
+  });
+
+  it('cleans secure credential artifacts before falling back after new-session failure', () => {
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    const secret = 'new-session-failure-secret';
+    process.env.ANTHROPIC_API_KEY = secret;
+    vi.mocked(isNativeWindowsShell).mockReturnValue(false);
+    vi.mocked(tmuxExec).mockImplementation((args: string[]) => {
+      if (args[0] === 'new-session') throw new Error('tmux launch failed');
+      return '';
+    });
+
+    try {
+      runClaude('/tmp', [], 'sid');
+
+      const command = String(vi.mocked(tmuxExec).mock.calls[0][0].at(-1));
+      const envFile = command.match(/(\/[^'\s]*omc-launch-env-[^'\s]*\/env\.sh)/)?.[1];
+      expect(envFile).toBeDefined();
+      expect(existsSync(envFile as string)).toBe(false);
+      expect(existsSync(dirname(envFile as string))).toBe(false);
+    } finally {
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
   });
 });
 
@@ -2159,6 +2211,54 @@ describe('runClaude outside-tmux — env forwarding', () => {
     expect(sleepIdx).toBeGreaterThan(exportIdx);
   });
 
+  it('forwards POSIX credentials through a path-only new-session transport', () => {
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    const secret = "new-session secret; it's not inline";
+    process.env.ANTHROPIC_API_KEY = secret;
+    vi.mocked(isNativeWindowsShell).mockReturnValue(false);
+
+    try {
+      runClaude('/tmp', [], 'sid');
+
+      const newSessionArgs = vi.mocked(tmuxExec).mock.calls.find(([args]) => args[0] === 'new-session')?.[0];
+      const command = String(newSessionArgs?.at(-1));
+      expect(command).not.toContain(secret);
+      expect(command).toContain('omc-launch-env-');
+      expect(command).toContain('/env.sh');
+
+      const envFile = command.match(/(\/[^'\s]*omc-launch-env-[^'\s]*\/env\.sh)/)?.[1];
+      expect(envFile).toBeDefined();
+      expect(lstatSync(envFile as string).mode & 0o777).toBe(0o600);
+      expect(readFileSync(envFile as string, 'utf8')).toContain("export ANTHROPIC_API_KEY='");
+      expect(readFileSync(envFile as string, 'utf8')).toContain('new-session secret');
+      rmSync(dirname(envFile as string), { recursive: true, force: true });
+    } finally {
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  });
+
+  it('returns an idempotent secure transport cleanup handle', () => {
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'cleanup-secret';
+    vi.mocked(isNativeWindowsShell).mockReturnValue(false);
+
+    try {
+      const transport = buildSensitiveEnvFilePrefix(['ANTHROPIC_API_KEY']);
+      expect(transport.paths).toHaveLength(2);
+      expect(transport.prefix).toContain('omc-launch-env-');
+      expect(existsSync(transport.paths[0])).toBe(true);
+      expect(existsSync(transport.paths[1])).toBe(true);
+      transport.cleanup();
+      transport.cleanup();
+      expect(existsSync(transport.paths[0])).toBe(false);
+      expect(existsSync(transport.paths[1])).toBe(false);
+    } finally {
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  });
+
   it('does not inject exports when no forwarded vars are set', () => {
     const saved = { ...process.env };
     for (const name of Object.keys(process.env)) delete process.env[name];
@@ -2238,42 +2338,10 @@ describe('runClaude outside-tmux — env forwarding', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
   });
 
-  it('preserves literal percent signs in forwarded values on native psmux', () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    process.env.CLAUDE_CONFIG_DIR = 'literal%PATH%';
-    vi.mocked(isNativeWindowsShell).mockReturnValue(true);
-
-    try {
-      runClaude('/tmp', [], 'sid');
-
-      const rawCommand = String(vi.mocked(tmuxExec).mock.calls.find(([args]) => args[0] === 'new-session')?.[0].at(-1));
-      expect(rawCommand).toContain('literal%%%%PATH%%%%');
-      expect(rawCommand).not.toContain('literal%PATH%');
-    } finally {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
-    }
-  });
-
-  it('rejects newline values before composing a native psmux command', () => {
-    const originalPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-    process.env.CLAUDE_CONFIG_DIR = 'line\nbreak';
-    vi.mocked(isNativeWindowsShell).mockReturnValue(true);
-
-    try {
-      expect(() => runClaude('/tmp', [], 'sid')).toThrow(
-        'Native Windows tmux command values cannot contain NUL, CR, or LF characters',
-      );
-    } finally {
-      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
-    }
-  });
-
-  it('keeps credential values off the native psmux command line', () => {
+  it('keeps credential values off the native psmux command line while preserving percent escaping', () => {
     const originalPlatform = process.platform;
     const savedApiKey = process.env.ANTHROPIC_API_KEY;
-    const secret = 'sk-native-windows-secret-value';
+    const secret = 'literal%PATH%';
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
     process.env.ANTHROPIC_API_KEY = secret;
     vi.mocked(isNativeWindowsShell).mockReturnValue(true);
@@ -2281,22 +2349,37 @@ describe('runClaude outside-tmux — env forwarding', () => {
     try {
       runClaude('/tmp', [], 'sid');
 
-      const paneCommand = String(vi.mocked(tmuxExec).mock.calls.find(([args]) => args[0] === 'new-session')?.[0].at(-1));
-      // `set "ANTHROPIC_API_KEY=..."` inside the command string is readable
-      // through the process command line and #{pane_start_command}; the value
-      // must travel through the sourced fragment instead.
-      expect(paneCommand).not.toContain(secret);
-      const rawCommand = vi.mocked(wrapWithLoginShell).mock.calls.at(-1)?.[0] as string;
+      const rawCommand = String(vi.mocked(tmuxExec).mock.calls.find(([args]) => args[0] === 'new-session')?.[0].at(-1));
       expect(rawCommand).not.toContain(secret);
-      expect(rawCommand).toMatch(/call "[^"]*omc-launch-env-[^"]*env\.cmd"/);
+      expect(rawCommand).not.toContain('literal%%%%PATH%%%%');
+      expect(rawCommand).toContain('call ');
+      expect(rawCommand).toContain('env.cmd');
 
-      const envFile = rawCommand.match(/call "([^"]*omc-launch-env-[^"]*env\.cmd)"/)?.[1];
+      const envFileMatch = rawCommand.match(/call (?:"([^"]+)"|(\S+env\.cmd))/);
+      const envFile = envFileMatch?.[1] ?? envFileMatch?.[2];
       expect(envFile).toBeDefined();
-      const body = readFileSync(envFile as string, 'utf8');
-      expect(body).toContain(`set "ANTHROPIC_API_KEY=${secret}"`);
+      expect(readFileSync(envFile as string, 'utf8')).toContain(`set "ANTHROPIC_API_KEY=literal%%PATH%%"`);
       rmSync(dirname(envFile as string), { recursive: true, force: true });
+      const envArgs = vi.mocked(buildTmuxShellCommandWithEnv).mock.calls.at(-1)?.[2] as Record<string, string>;
+      expect(envArgs).not.toHaveProperty('ANTHROPIC_API_KEY');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
+    }
+  });
 
-      expect(vi.mocked(buildTmuxShellCommandWithEnv).mock.calls.at(-1)?.[2]).not.toHaveProperty('ANTHROPIC_API_KEY');
+  it('rejects newline values before composing a native psmux command', () => {
+    const originalPlatform = process.platform;
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    process.env.ANTHROPIC_API_KEY = 'line\nbreak';
+    vi.mocked(isNativeWindowsShell).mockReturnValue(true);
+
+    try {
+      expect(() => runClaude('/tmp', [], 'sid')).toThrow(
+        'Native Windows tmux command values cannot contain NUL, CR, or LF characters',
+      );
     } finally {
       Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
       if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;

--- a/src/cli/__tests__/tmux-env-forward.integration.test.ts
+++ b/src/cli/__tests__/tmux-env-forward.integration.test.ts
@@ -3,8 +3,9 @@
  *
  * Verifies that env vars set on the omc process actually arrive inside
  * a tmux session created the same way runClaudeOutsideTmux does.
- * No Claude CLI or API tokens are involved — the test runs `printenv`
- * inside the tmux pane and reads the output from a temp file.
+ * No Claude CLI is involved — the test runs `printenv` inside the tmux pane
+ * and reads the output from a temp file. The credential case uses a synthetic
+ * token and only asserts that it arrives through the private transport.
  *
  * Skipped when tmux is not available (CI without tmux, Windows, etc.).
  */
@@ -15,7 +16,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { wrapWithLoginShell, quoteShellArg } from '../tmux-utils.js';
-import { buildEnvExportPrefix } from '../launch.js';
+import { buildEnvExportPrefix, buildSensitiveEnvFilePrefix } from '../launch.js';
 
 function isTmuxAvailable(): boolean {
   try {
@@ -130,6 +131,47 @@ describe.skipIf(!HAS_TMUX)('tmux env forwarding — integration', () => {
       try {
         execFileSync('tmux', ['kill-session', '-t', specialSession], { stdio: 'ignore' });
       } catch { /* already gone */ }
+    }
+  });
+
+  it('forwards sensitive credentials through the path-only new-session transport', () => {
+    const sensitiveSession = `${SESSION_NAME}-sensitive`;
+    const secret = "sk-new-session-secret; it's not inline";
+    const sensitiveOutFile = join(tempDir, 'env-sensitive');
+    const savedApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = secret;
+    const transport = buildSensitiveEnvFilePrefix(['ANTHROPIC_API_KEY']);
+
+    try {
+      const innerCmd = `${transport.prefix}printenv ANTHROPIC_API_KEY > ${quoteShellArg(sensitiveOutFile)}`;
+      expect(innerCmd).not.toContain(secret);
+      const shellCmd = wrapWithLoginShell(innerCmd);
+
+      execFileSync('tmux', [
+        'new-session', '-d', '-s', sensitiveSession, shellCmd,
+      ]);
+
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        try {
+          execFileSync('tmux', ['has-session', '-t', sensitiveSession], { stdio: 'ignore' });
+          execFileSync('sleep', ['0.1']);
+        } catch {
+          break;
+        }
+      }
+
+      expect(existsSync(sensitiveOutFile)).toBe(true);
+      expect(readFileSync(sensitiveOutFile, 'utf-8').trim()).toBe(secret);
+      expect(existsSync(transport.paths[0])).toBe(false);
+      expect(existsSync(transport.paths[1])).toBe(false);
+    } finally {
+      transport.cleanup();
+      try {
+        execFileSync('tmux', ['kill-session', '-t', sensitiveSession], { stdio: 'ignore' });
+      } catch { /* already gone */ }
+      if (savedApiKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = savedApiKey;
     }
   });
 });

--- a/src/cli/launch.ts
+++ b/src/cli/launch.ts
@@ -5,6 +5,7 @@
 
 import { execFileSync } from 'child_process';
 import {
+  chmodSync,
   cpSync,
   copyFileSync,
   existsSync,
@@ -31,11 +32,13 @@ import {
   buildTmuxSessionName,
   buildTmuxShellCommand,
   buildTmuxShellCommandWithEnv,
+  escapeForCmdSet,
   isNativeWindowsShell,
   wrapWithLoginShell,
   isClaudeAvailable,
   isTmuxAvailable,
   quoteShellArg,
+  quoteForCmd,
   tmuxExec,
 } from './tmux-utils.js';
 import { configureTmuxClipboardForCurrentSession, configureTmuxClipboardForSession } from './tmux-clipboard.js';
@@ -959,11 +962,19 @@ function runClaudeInsideTmux(cwd: string, args: string[]): void {
     // target/session argument. Its command must follow the literal separator.
     respawnArgs.push('--');
   }
-  respawnArgs.push(buildTmuxClaudeCommand(args));
+  let launch: TmuxClaudeLaunch;
+  try {
+    launch = buildTmuxClaudeLaunch(args, { useExec: true, preflight: '' });
+  } catch (error) {
+    console.error(`[omc] Error: unable to prepare Claude launch: ${error instanceof Error ? error.message : error}`);
+    throw error;
+  }
+  respawnArgs.push(launch.command);
 
   try {
     tmuxExec(respawnArgs, { stdio: 'inherit' });
   } catch (error) {
+    launch.cleanup();
     const err = error as NodeJS.ErrnoException & { status?: number | null };
     if (err.code === 'ENOENT') {
       console.error('[omc] Error: unable to respawn Claude in the current tmux pane.');
@@ -1090,58 +1101,101 @@ export function buildEnvExportPrefix(vars: string[]): string {
   return parts.length > 0 ? parts.join('; ') + '; ' : '';
 }
 
-/**
- * Forward credential-shaped variables through a 0600 file that the launched
- * shell sources and immediately removes, so only the path appears in any
- * command line. Returns an empty prefix when there is nothing sensitive to
- * forward, and on any write failure — a launch must not be blocked by an
- * unwritable temp directory, it just proceeds without those values.
- *
- * The native Windows variant emits a `.cmd` fragment invoked with `call`.
- * cmd.exe has no `source`, and a `set "KEY=value"` prefix inside the command
- * string would put the value straight back on the psmux/tmux command line —
- * exactly what this indirection exists to prevent. File mode is best-effort
- * there; the file lives in the per-user temp directory and is deleted by the
- * launched shell before Claude starts.
- */
-export function buildSensitiveEnvFilePrefix(vars: string[]): string {
-  const sensitive = vars.filter(
-    (name) => isSensitiveTmuxEnvironmentVariable(name) && getProcessEnvironmentValue(name) !== undefined,
-  );
-  if (sensitive.length === 0) return '';
-  const nativeWindows = isNativeWindowsShell();
-  try {
-    const dir = mkdtempSync(join(tmpdir(), 'omc-launch-env-'));
-    if (nativeWindows) {
-      const file = join(dir, 'env.cmd');
-      const body = sensitive
-        .map((name) => `set "${name}=${getProcessEnvironmentValue(name) as string}"`)
-        .join('\r\n');
-      writeFileSync(file, `@echo off\r\n${body}\r\n`, { mode: 0o600 });
-      // `&` rather than `&&`: cleanup and the launch must still happen even if
-      // the fragment cannot be read, matching the POSIX fallback behaviour.
-      return `call "${file}" & del /q "${file}" >nul 2>nul & rmdir "${dir}" >nul 2>nul & `;
+export interface SensitiveEnvTransport {
+  /** Shell fragment that loads the credentials and schedules artifact cleanup. */
+  prefix: string;
+  /** The secret-bearing file and its private parent directory. */
+  paths: string[];
+  /** Remove all artifacts immediately; safe to call more than once. */
+  cleanup(): void;
+}
+
+function emptySensitiveEnvTransport(): SensitiveEnvTransport {
+  return { prefix: '', paths: [], cleanup: () => undefined };
+}
+
+function removeSensitiveEnvArtifacts(file: string | undefined, dir: string | undefined): void {
+  if (file) {
+    try {
+      rmSync(file, { force: true });
+    } catch {
+      // Best effort cleanup must not hide the launch error that triggered it.
     }
-    const file = join(dir, 'env.sh');
-    const body = sensitive
-      .map((name) => `export ${name}=${quoteShellArg(getProcessEnvironmentValue(name) as string)}`)
-      .join('\n');
-    writeFileSync(file, `${body}\n`, { mode: 0o600 });
-    return `. ${quoteShellArg(file)}; rm -f ${quoteShellArg(file)}; rmdir ${quoteShellArg(dir)} 2>/dev/null; `;
-  } catch {
-    return '';
+  }
+  if (dir) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best effort cleanup must not hide the launch error that triggered it.
+    }
   }
 }
 
 /**
- * The env map handed to `buildTmuxShellCommandWithEnv` ends up inside the
- * command string, so credential-shaped values must be stripped from it and
- * forwarded through `buildSensitiveEnvFilePrefix` instead.
+ * Forward credential-shaped variables through a private temporary transport.
+ * The returned shell prefix contains only artifact paths; the credential
+ * values are written to the transport file and loaded immediately before the
+ * Claude command. Callers must invoke cleanup() whenever launch preparation or
+ * tmux execution fails before the child shell can consume the prefix.
+ *
+ * POSIX shells source a 0600 `env.sh` file. Native Windows shells `call` a
+ * 0600-equivalent `env.cmd` fragment; its parent temp directory and file are
+ * removed by the command and by cleanup() on pre-execution failures. Windows
+ * values retain the existing percent escaping and NUL/CR/LF rejection.
  */
-function withoutSensitiveEnv(env: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(env).filter(([name]) => !isSensitiveTmuxEnvironmentVariable(name)),
+export function buildSensitiveEnvFilePrefix(vars: string[]): SensitiveEnvTransport {
+  const sensitive = vars.filter(
+    (name) => isSensitiveTmuxEnvironmentVariable(name) && getProcessEnvironmentValue(name) !== undefined,
   );
+  if (sensitive.length === 0) return emptySensitiveEnvTransport();
+
+  const nativeWindows = isNativeWindowsShell();
+  let dir: string | undefined;
+  let file: string | undefined;
+  try {
+    // Validate and encode Windows values before creating any artifacts. This
+    // preserves the command-safety contract without leaving a partial temp
+    // directory when a credential contains a rejected control character.
+    const values = sensitive.map((name) => ({
+      name,
+      value: getProcessEnvironmentValue(name) as string,
+      encoded: nativeWindows ? escapeForCmdSet(getProcessEnvironmentValue(name) as string) : null,
+    }));
+
+    dir = mkdtempSync(join(tmpdir(), 'omc-launch-env-'));
+    file = join(dir, nativeWindows ? 'env.cmd' : 'env.sh');
+    const body = nativeWindows
+      ? `@echo off\r\n${values.map(({ name, encoded }) => `set "${name}=${encoded as string}"`).join('\r\n')}\r\n`
+      : `${values.map(({ name, value }) => `export ${name}=${quoteShellArg(value)}`).join('\n')}\n`;
+    writeFileSync(file, body, { mode: 0o600 });
+
+    // mkdtempSync is private on POSIX by default, but set both modes
+    // explicitly. Windows may ignore POSIX mode bits, so retain the
+    // per-user temp ACL and treat chmod as best effort there rather than
+    // shelling out to icacls from the launcher.
+    try {
+      chmodSync(dir, 0o700);
+      chmodSync(file, 0o600);
+    } catch (error) {
+      if (!nativeWindows) throw error;
+    }
+
+    let cleaned = false;
+    const cleanup = (): void => {
+      if (cleaned) return;
+      cleaned = true;
+      removeSensitiveEnvArtifacts(file, dir);
+    };
+
+    const prefix = nativeWindows
+      ? `call ${quoteForCmd(file)} & del /f /q ${quoteForCmd(file)} >nul 2>nul & rmdir /s /q ${quoteForCmd(dir)} >nul 2>nul & `
+      : `. ${quoteShellArg(file)}; rm -f ${quoteShellArg(file)}; rmdir ${quoteShellArg(dir)} 2>/dev/null; `;
+    return { prefix, paths: [file, dir], cleanup };
+  } catch (error) {
+    removeSensitiveEnvArtifacts(file, dir);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[omc] Unable to prepare secure credential transport: ${message}`);
+  }
 }
 
 const TMUX_SESSION_ENV_VARS = new Set(['TMUX', 'TMUX_PANE', 'PSMUX_SESSION', 'CLAUDECODE']);
@@ -1199,27 +1253,49 @@ function getEffectiveTmuxEnvironment(): Record<string, string> {
  * replaces the launcher node process in the existing pane, leaving Claude as
  * the pane's foreground process after any login-shell setup and env exports.
  */
-export function buildTmuxClaudeCommand(args: string[]): string {
+interface TmuxClaudeLaunch {
+  command: string;
+  cleanup(): void;
+}
+
+function withoutSensitiveEnv(env: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(([name]) => !isSensitiveTmuxEnvironmentVariable(name)),
+  );
+}
+
+function buildTmuxClaudeLaunch(
+  args: string[],
+  options: { useExec: boolean; preflight: string },
+): TmuxClaudeLaunch {
   const forwardedEnv = getEffectiveTmuxEnvironment();
   const forwardedEnvNames = Object.keys(forwardedEnv);
   const nativeWindows = isNativeWindowsShell();
-  const rawClaudeCmd = nativeWindows
-    ? buildTmuxShellCommandWithEnv('claude', args, withoutSensitiveEnv(forwardedEnv))
-    : buildTmuxShellCommand('claude', args);
-  const envPrefix = forwardedEnvNames.length === 0
-    ? ''
-    : nativeWindows
-      ? buildSensitiveEnvFilePrefix(forwardedEnvNames)
-      : `${buildEnvExportPrefix(forwardedEnvNames)}${buildSensitiveEnvFilePrefix(forwardedEnvNames)}`;
-  const missingBinaryGuard = nativeWindows
-    ? 'where claude >nul 2>nul || (echo [omc] Error: claude CLI not found in PATH. 1>&2 & exit /b 1) && '
-    : "command -v claude >/dev/null 2>&1 || { echo '[omc] Error: claude CLI not found in PATH.' >&2; exit 127; }; ";
-
-  if (nativeWindows) {
-    return wrapWithLoginShell(`${envPrefix}${missingBinaryGuard}${rawClaudeCmd}`);
+  const transport = buildSensitiveEnvFilePrefix(forwardedEnvNames);
+  try {
+    const rawClaudeCmd = nativeWindows
+      ? buildTmuxShellCommandWithEnv('claude', args, withoutSensitiveEnv(forwardedEnv))
+      : buildTmuxShellCommand('claude', args);
+    const envPrefix = forwardedEnvNames.length === 0
+      ? ''
+      : nativeWindows
+        ? transport.prefix
+        : `${buildEnvExportPrefix(forwardedEnvNames)}${transport.prefix}`;
+    const missingBinaryGuard = nativeWindows
+      ? 'where claude >nul 2>nul || (echo [omc] Error: claude CLI not found in PATH. 1>&2 & exit /b 1) && '
+      : "command -v claude >/dev/null 2>&1 || { echo '[omc] Error: claude CLI not found in PATH.' >&2; exit 127; }; ";
+    const command = wrapWithLoginShell(
+      `${envPrefix}${options.preflight}${missingBinaryGuard}${options.useExec ? 'exec ' : ''}${rawClaudeCmd}`,
+    );
+    return { command, cleanup: transport.cleanup };
+  } catch (error) {
+    transport.cleanup();
+    throw error;
   }
+}
 
-  return wrapWithLoginShell(`${envPrefix}${missingBinaryGuard}exec ${rawClaudeCmd}`);
+export function buildTmuxClaudeCommand(args: string[]): string {
+  return buildTmuxClaudeLaunch(args, { useExec: true, preflight: '' }).command;
 }
 
 /**
@@ -1234,16 +1310,6 @@ function runClaudeOutsideTmux(
   _sessionId: string,
   options: { requireTmux?: boolean } = {},
 ): void {
-  const forwardedEnv = getEffectiveTmuxEnvironment();
-  const forwardedEnvNames = Object.keys(forwardedEnv);
-  const rawClaudeCmd = isNativeWindowsShell()
-    ? buildTmuxShellCommandWithEnv('claude', args, withoutSensitiveEnv(forwardedEnv))
-    : buildTmuxShellCommand('claude', args);
-  const envPrefix = forwardedEnvNames.length === 0
-    ? ''
-    : isNativeWindowsShell()
-      ? buildSensitiveEnvFilePrefix(forwardedEnvNames)
-      : `${buildEnvExportPrefix(forwardedEnvNames)}${buildSensitiveEnvFilePrefix(forwardedEnvNames)}`;
   // Drain any pending terminal Device Attributes (DA1) response from stdin.
   // When tmux attach-session sends a DA1 query, the terminal replies with
   // \e[?6c which lands in the pty buffer before Claude reads input.
@@ -1251,14 +1317,22 @@ function runClaudeOutsideTmux(
   // Wrap in login shell so .bashrc/.zshrc are sourced (PATH, nvm, etc.)
   // Env exports are injected after RC sourcing so they override stale tmux server env.
   const preflight = isNativeWindowsShell()
-    ? envPrefix
-    : `${envPrefix}sleep 0.3; perl -e 'use POSIX;tcflush(0,TCIFLUSH)' 2>/dev/null; `;
-  const claudeCmd = wrapWithLoginShell(`${preflight}${rawClaudeCmd}`);
+    ? ''
+    : `sleep 0.3; perl -e 'use POSIX;tcflush(0,TCIFLUSH)' 2>/dev/null; `;
   const sessionName = buildTmuxSessionName(cwd);
+  let launch: TmuxClaudeLaunch;
+  try {
+    launch = buildTmuxClaudeLaunch(args, { useExec: false, preflight });
+  } catch (error) {
+    console.error(`[omc] Error: unable to prepare Claude launch: ${error instanceof Error ? error.message : error}`);
+    throw error;
+  }
+  const claudeCmd = launch.command;
 
   try {
     tmuxExec(['new-session', '-d', '-s', sessionName, '-c', cwd, claudeCmd], { stripTmux: true, stdio: 'inherit' });
   } catch {
+    launch.cleanup();
     if (options.requireTmux) {
       abortMadmaxRequiresTmux('launch-failed');
     }
@@ -1291,6 +1365,10 @@ function runClaudeOutsideTmux(
       tmuxExec(['has-session', '-t', sessionName], { stripTmux: true, stdio: 'ignore' });
       return;
     } catch {
+      // The detached command may have exited before sourcing its transport;
+      // there is no remaining child shell that can perform its in-command
+      // cleanup, so remove artifacts before the direct fallback.
+      launch.cleanup();
       runClaudeDirect(cwd, args);
     }
   }

--- a/src/cli/tmux-utils.ts
+++ b/src/cli/tmux-utils.ts
@@ -55,14 +55,14 @@ export function isNativeWindowsShell(): boolean {
   return process.platform === 'win32' && !isUnixLikeOnWindows();
 }
 
-function quoteForCmd(arg: string): string {
+export function quoteForCmd(arg: string): string {
   assertSafeCmdValue(arg);
   if (arg.length === 0) return '""';
   if (!/[\s"%^&|<>()]/.test(arg)) return arg;
   return `"${arg.replace(/(["%])/g, '$1$1')}"`;
 }
 
-function escapeForCmdSet(value: string): string {
+export function escapeForCmdSet(value: string): string {
   assertSafeCmdValue(value);
   // The set command is embedded in a command string which is then wrapped in
   // a second cmd /c invocation. Percent signs therefore need one escaping


### PR DESCRIPTION
Follow-up to #4019, which merged at `adaeaa91f24d` **one review round before these blockers were fixed**. The credential exposure below is currently on `dev`.

## Why this exists

#4019 made the tmux launcher forward the launcher's live environment so that a credential injected after the tmux server started (`ANTHROPIC_API_KEY=... omc`) still reaches the agent. A parallel lane then added a path-only transport for credential-shaped values — a 0600 file the shell sources and deletes — because `buildEnvExportPrefix` output is handed to tmux as an argument and is therefore readable through `/proc/<pid>/cmdline` and `#{pane_start_command}`.

That transport was wired into exactly one of four launch builders. Closure review found:

1. **HIGH — native Windows/psmux exposed credentials on the command line.** Both native branches passed the complete environment record to `buildTmuxShellCommandWithEnv`, whose native branch renders every entry inline as `set "KEY=value"` inside the nested `cmd /c` string. A test even asserted that the key-derived value appeared there, pinning the leak.
2. **HIGH — POSIX outside-tmux `new-session` silently dropped credentials.** `buildEnvExportPrefix()` deliberately omits sensitive names and that builder never applied the transport, so a session created outside tmux lacked credentials that direct launch and in-pane respawn both received, failing provider auth on that path only.
3. **MEDIUM — transport failures neither cleaned up nor reported.** The helper returned a bare string, so a failed or partial `writeFileSync` collapsed to `''` and credentials vanished silently, while a unique temp directory and a possibly partial 0600 secret file stayed on disk — the `rm -f`/`rmdir` cleanup lived only inside a command that never ran.

## Change

- A single `SensitiveEnvTransport` now serves every builder: POSIX in-pane respawn, POSIX outside-tmux `new-session`, and both native Windows/psmux paths. POSIX sources a 0600 `env.sh`; native Windows `call`s a restrictive temporary `env.cmd`. Only a path ever appears in a command line.
- Sensitive names are filtered out before the native `buildTmuxShellCommandWithEnv` calls. Non-sensitive forwarding stays inline exactly as before. The existing percent escaping and NUL/CR/LF rejection are preserved — `src/cli/tmux-utils.ts` only exports those primitives so the Windows transport reuses them rather than reimplementing.
- The transport exposes its prefix, its created paths, and an idempotent `cleanup()`. Every pre-execution failure path calls it, partial artifacts are removed when a write fails, and a transport creation/write failure now throws explicitly instead of launching without credentials or falling back inline. Direct fallback remains only for genuine tmux execution failures.

## Verification

- `tsc --noEmit` clean; focused ESLint clean.
- `launch.test.ts` 183, `tmux-utils.test.ts` 53, `tmux-env-forward.integration.test.ts` 3, new `launch-secure-transport.test.ts` 1 → **4 files, 240 tests passed**.
- The native psmux assertion is inverted: it now proves the credential value is **absent** from the command string while the credential still reaches the pane environment. The integration test starts a real tmux session and proves a synthetic credential arrives in the POSIX pane and that the transport artifacts are removed afterwards.
- Mutation-proofed: reverting native sensitive filtering fails the inverted native assertions; reverting the outside-tmux transport fails the pane-credential checks; reverting failure cleanup fails the write-failure and new-session fallback cleanup checks. No `omc-launch-env` temp artifacts remained after the runs.
- `generate-inventory-graph.mjs --verify` → `verify ok`.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*