### PR TITLE
fix(hooks): register the directory-context injector so nested AGENTS.md is delivered (#4006)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -102,6 +102,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/post-tool-rules-injector.mjs",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT\"/scripts/run.cjs \"$CLAUDE_PLUGIN_ROOT\"/scripts/post-tool-directory-context-injector.mjs",
+            "timeout": 3
           }
         ]
       }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "b2d1d93d7ed4c551e2a6e99598c5755226d37b53",
-    "sourceSha256": "1e22b0cc6f1aa2cf123a97bc6b7317259f6e50f2b27ad478c626e0f51fb2852c",
+    "head": "70bf898eec2d16509ee7e683f40ab6a24aa8c885",
+    "sourceSha256": "82f68950dc2c33c1b041bd86ce8356354866e44b28e88b4aa52145b2c0873a87",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "b2d1d93d7ed4c551e2a6e99598c5755226d37b53",
-  "sourceSha256": "1e22b0cc6f1aa2cf123a97bc6b7317259f6e50f2b27ad478c626e0f51fb2852c",
+  "head": "70bf898eec2d16509ee7e683f40ab6a24aa8c885",
+  "sourceSha256": "82f68950dc2c33c1b041bd86ce8356354866e44b28e88b4aa52145b2c0873a87",
   "counts": {
     "public": {
       "skills": 41,
@@ -787,6 +787,7 @@
       "scripts/persistent-mode.mjs",
       "scripts/plugin-setup.mjs",
       "scripts/plugin-shipping-surface.mjs",
+      "scripts/post-tool-directory-context-injector.mjs",
       "scripts/post-tool-rules-injector.mjs",
       "scripts/post-tool-use-failure.mjs",
       "scripts/post-tool-verifier.mjs",
@@ -33506,6 +33507,11 @@
         "path": "scripts/plugin-shipping-surface.mjs"
       },
       {
+        "id": "scripts/post-tool-directory-context-injector.mjs",
+        "kind": "script",
+        "path": "scripts/post-tool-directory-context-injector.mjs"
+      },
+      {
         "id": "scripts/post-tool-rules-injector.mjs",
         "kind": "script",
         "path": "scripts/post-tool-rules-injector.mjs"
@@ -34389,6 +34395,11 @@
         "id": "src/__tests__/delegation-enforcer.test.ts",
         "kind": "src",
         "path": "src/__tests__/delegation-enforcer.test.ts"
+      },
+      {
+        "id": "src/__tests__/directory-context-injector-registration.test.ts",
+        "kind": "src",
+        "path": "src/__tests__/directory-context-injector-registration.test.ts"
       },
       {
         "id": "src/__tests__/directory-context-injector.test.ts",
@@ -35889,11 +35900,6 @@
         "id": "src/cli/__tests__/hud-watch.test.ts",
         "kind": "src",
         "path": "src/cli/__tests__/hud-watch.test.ts"
-      },
-      {
-        "id": "src/cli/__tests__/launch-secure-transport.test.ts",
-        "kind": "src",
-        "path": "src/cli/__tests__/launch-secure-transport.test.ts"
       },
       {
         "id": "src/cli/__tests__/launch.test.ts",
@@ -42743,6 +42749,21 @@
         "kind": "imports"
       },
       {
+        "from": "scripts/post-tool-directory-context-injector.mjs",
+        "to": "external:path",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/post-tool-directory-context-injector.mjs",
+        "to": "external:url",
+        "kind": "imports"
+      },
+      {
+        "from": "scripts/post-tool-directory-context-injector.mjs",
+        "to": "scripts/lib/stdin.mjs",
+        "kind": "imports"
+      },
+      {
         "from": "scripts/post-tool-rules-injector.mjs",
         "to": "external:path",
         "kind": "imports"
@@ -44675,6 +44696,31 @@
       {
         "from": "src/__tests__/delegation-enforcer.test.ts",
         "to": "src/features/delegation-routing/resolver.ts",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/directory-context-injector-registration.test.ts",
+        "to": "external:node:child_process",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/directory-context-injector-registration.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/directory-context-injector-registration.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/directory-context-injector-registration.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/__tests__/directory-context-injector-registration.test.ts",
+        "to": "external:vitest",
         "kind": "imports"
       },
       {
@@ -51496,31 +51542,6 @@
         "from": "src/cli/__tests__/hud-watch.test.ts",
         "to": "src/mcp/standalone-shutdown.ts",
         "kind": "type-imports"
-      },
-      {
-        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
-        "to": "external:node:fs",
-        "kind": "imports"
-      },
-      {
-        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
-        "to": "external:node:os",
-        "kind": "imports"
-      },
-      {
-        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
-        "to": "external:node:path",
-        "kind": "imports"
-      },
-      {
-        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
-        "to": "external:vitest",
-        "kind": "imports"
-      },
-      {
-        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
-        "to": "src/cli/launch.ts",
-        "kind": "imports"
       },
       {
         "from": "src/cli/__tests__/launch.test.ts",
@@ -78849,12 +78870,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6978,
-      "edgeCount": 7511,
-      "importEdgeCount": 6191,
+      "nodeCount": 6979,
+      "edgeCount": 7514,
+      "importEdgeCount": 6194,
       "registerEdgeCount": 62
     }
   },
-  "inventorySha256": "1cf792d0a5f5622af60dddd9e745930b12ccc8cd31345a413e8334b39bdfc2dc",
-  "manifestSha256": "9c9f238f376afbf26f206e90b03a39d27221ce1742f1d3aa062e827b5eac581e"
+  "inventorySha256": "5c329e1a4e7f65c9f1e9db881c4a1d10bd49d540f4f0518373b29ea856a42a37",
+  "manifestSha256": "bb61017e31c38c474fee110750612158b30cc78c5d048f25bc7bc0d3b86bd253"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,15 +5,15 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "3f483a7f7eefd3efd66517c7ff3620f1904d96bd",
-    "sourceSha256": "82f68950dc2c33c1b041bd86ce8356354866e44b28e88b4aa52145b2c0873a87",
+    "head": "c7c713cc772f9940ad740430a6b9d8475b137697",
+    "sourceSha256": "9ad695f48f699afebb5695824c9095c097778eff62cf9e76771afa39d1027866",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "3f483a7f7eefd3efd66517c7ff3620f1904d96bd",
-  "sourceSha256": "82f68950dc2c33c1b041bd86ce8356354866e44b28e88b4aa52145b2c0873a87",
+  "head": "c7c713cc772f9940ad740430a6b9d8475b137697",
+  "sourceSha256": "9ad695f48f699afebb5695824c9095c097778eff62cf9e76771afa39d1027866",
   "counts": {
     "public": {
       "skills": 41,
@@ -28,8 +28,8 @@
       "toolFiles": 61,
       "libFiles": 43,
       "templateHooks": 22,
-      "srcFiles": 1352,
-      "total": 1374
+      "srcFiles": 1353,
+      "total": 1375
     },
     "generated": {
       "distFiles": 5032,
@@ -35902,6 +35902,11 @@
         "path": "src/cli/__tests__/hud-watch.test.ts"
       },
       {
+        "id": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "kind": "src",
+        "path": "src/cli/__tests__/launch-secure-transport.test.ts"
+      },
+      {
         "id": "src/cli/__tests__/launch.test.ts",
         "kind": "src",
         "path": "src/cli/__tests__/launch.test.ts"
@@ -51542,6 +51547,31 @@
         "from": "src/cli/__tests__/hud-watch.test.ts",
         "to": "src/mcp/standalone-shutdown.ts",
         "kind": "type-imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:node:fs",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:node:os",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:node:path",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "external:vitest",
+        "kind": "imports"
+      },
+      {
+        "from": "src/cli/__tests__/launch-secure-transport.test.ts",
+        "to": "src/cli/launch.ts",
+        "kind": "imports"
       },
       {
         "from": "src/cli/__tests__/launch.test.ts",
@@ -78870,12 +78900,12 @@
       }
     ],
     "stats": {
-      "nodeCount": 6979,
-      "edgeCount": 7514,
-      "importEdgeCount": 6194,
+      "nodeCount": 6980,
+      "edgeCount": 7519,
+      "importEdgeCount": 6199,
       "registerEdgeCount": 62
     }
   },
-  "inventorySha256": "5c329e1a4e7f65c9f1e9db881c4a1d10bd49d540f4f0518373b29ea856a42a37",
-  "manifestSha256": "50ca595cba21ca91f3d5eef4930581b44789133102ef9dacb8bf22a9440d2208"
+  "inventorySha256": "dae592c0ba83bfa6e1615d2e0052f56710d645af3f283d5a7dd4c12a8d39bd95",
+  "manifestSha256": "39dff4b54fba91ec9306c05b8f11958f1346c71a49458f7fc990a8e4fbc61f4c"
 }

--- a/inventory/inventory-graph.json
+++ b/inventory/inventory-graph.json
@@ -5,14 +5,14 @@
   "provenance": {
     "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
     "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-    "head": "70bf898eec2d16509ee7e683f40ab6a24aa8c885",
+    "head": "3f483a7f7eefd3efd66517c7ff3620f1904d96bd",
     "sourceSha256": "82f68950dc2c33c1b041bd86ce8356354866e44b28e88b4aa52145b2c0873a87",
     "generatedAt": null,
     "generator": "scripts/generate-inventory-graph.mjs"
   },
   "base": "05c800f40d1ad53b42a78609d2667ef4f726808b",
   "planningHead": "0a91273e61dbbd47eb0af4c02844409251e08398",
-  "head": "70bf898eec2d16509ee7e683f40ab6a24aa8c885",
+  "head": "3f483a7f7eefd3efd66517c7ff3620f1904d96bd",
   "sourceSha256": "82f68950dc2c33c1b041bd86ce8356354866e44b28e88b4aa52145b2c0873a87",
   "counts": {
     "public": {
@@ -78877,5 +78877,5 @@
     }
   },
   "inventorySha256": "5c329e1a4e7f65c9f1e9db881c4a1d10bd49d540f4f0518373b29ea856a42a37",
-  "manifestSha256": "bb61017e31c38c474fee110750612158b30cc78c5d048f25bc7bc0d3b86bd253"
+  "manifestSha256": "50ca595cba21ca91f3d5eef4930581b44789133102ef9dacb8bf22a9440d2208"
 }

--- a/scripts/post-tool-directory-context-injector.mjs
+++ b/scripts/post-tool-directory-context-injector.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse Hook: Directory Context Injector (issue #4006 finding 1)
+ *
+ * Injects the nearest README.md / AGENTS.md files, walking up from the
+ * accessed file to the working directory root, into context when Claude
+ * reads or edits a file.
+ *
+ * Claude Code's own memory loader discovers nested CLAUDE.md only, so a
+ * nested AGENTS.md — which is exactly what `deepinit` generates — is never
+ * loaded natively. The directory-readme-injector hook implementation existed
+ * but was registered nowhere, so no install ever ran it and every nested
+ * deepinit file was inert.
+ *
+ * Dedup is per session and per resolved context-file path (see the hook's
+ * storage module), so the same AGENTS.md is injected at most once per session
+ * no matter how many files under it are touched.
+ */
+
+import { isAbsolute, join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { readStdin } from './lib/stdin.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function getRuntimeBaseDir() {
+  return process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..');
+}
+
+// Dynamic import — graceful no-op when dist/ is not built (first run / dev)
+let createDirectoryReadmeInjectorHook = null;
+try {
+  const runtimeBase = getRuntimeBaseDir();
+  const mod = await import(
+    pathToFileURL(join(runtimeBase, 'dist', 'hooks', 'directory-readme-injector', 'index.js')).href
+  );
+  createDirectoryReadmeInjectorHook = mod.createDirectoryReadmeInjectorHook;
+} catch {
+  // dist not available — skip directory context injection silently
+}
+
+/**
+ * Extract the primary file path from tool input.
+ * All tracked tools (read, write, edit, multiedit) expose file_path at the
+ * top level of tool_input.
+ */
+function extractFilePath(toolInput) {
+  if (!toolInput) return null;
+  return toolInput.file_path || toolInput.path || null;
+}
+
+async function main() {
+  // Honor the documented kill switches (issues #838, #3253) with the same
+  // `post-tool-use` event token as the other PostToolUse hooks.
+  const skipHooks = (process.env.OMC_SKIP_HOOKS || '').split(',').map((s) => s.trim());
+  if (
+    process.env.DISABLE_OMC === '1' ||
+    process.env.DISABLE_OMC === 'true' ||
+    skipHooks.includes('post-tool-use')
+  ) {
+    console.log(JSON.stringify({ continue: true }));
+    return;
+  }
+
+  try {
+    const input = await readStdin();
+    if (!input.trim()) {
+      console.log(JSON.stringify({ continue: true }));
+      return;
+    }
+
+    let data = {};
+    try { data = JSON.parse(input); } catch { /* ignore parse errors */ }
+
+    if (!createDirectoryReadmeInjectorHook) {
+      console.log(JSON.stringify({ continue: true }));
+      return;
+    }
+
+    const toolName = data.tool_name || data.toolName || '';
+    const toolInput = data.tool_input || data.toolInput || {};
+    const sessionId = data.session_id || data.sessionId || 'unknown';
+    const cwd = data.cwd || process.cwd();
+
+    const rawPath = extractFilePath(toolInput);
+    if (!rawPath) {
+      console.log(JSON.stringify({ continue: true }));
+      return;
+    }
+
+    const filePath = isAbsolute(rawPath) ? rawPath : join(cwd, rawPath);
+
+    const hook = createDirectoryReadmeInjectorHook(cwd);
+    const contextText = hook.processToolExecution(toolName, filePath, sessionId);
+
+    if (contextText) {
+      console.log(JSON.stringify({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext: contextText,
+        },
+      }));
+    } else {
+      console.log(JSON.stringify({ continue: true }));
+    }
+  } catch {
+    // Always continue on error — context injection is additive only
+    console.log(JSON.stringify({ continue: true }));
+  }
+}
+
+main();

--- a/skills/deepinit/SKILL.md
+++ b/skills/deepinit/SKILL.md
@@ -18,28 +18,46 @@ AGENTS.md files serve as **AI-readable documentation** that helps agents underst
 
 ## Hierarchical Tagging System
 
-Every AGENTS.md (except root) includes a parent reference tag:
+Every AGENTS.md (except root) includes a parent reference line:
 
 ```markdown
-<!-- Parent: ../AGENTS.md -->
+**Parent context:** `../AGENTS.md`
 ```
+
+This MUST be visible prose, never an HTML comment. Claude Code strips HTML
+comments before a memory file reaches the model, so `<!-- Parent: ... -->`,
+`<!-- Generated: ... -->` and a commented MANUAL boundary are invisible to the
+agent that is supposed to act on them.
 
 This creates a navigable hierarchy:
 ```
-/AGENTS.md                          ← Root (no parent tag)
-├── src/AGENTS.md                   ← <!-- Parent: ../AGENTS.md -->
-│   ├── src/components/AGENTS.md    ← <!-- Parent: ../AGENTS.md -->
-│   └── src/utils/AGENTS.md         ← <!-- Parent: ../AGENTS.md -->
-└── docs/AGENTS.md                  ← <!-- Parent: ../AGENTS.md -->
+/AGENTS.md                          ← Root (no parent line)
+├── src/AGENTS.md                   ← **Parent context:** `../AGENTS.md`
+│   ├── src/components/AGENTS.md    ← **Parent context:** `../AGENTS.md`
+│   └── src/utils/AGENTS.md         ← **Parent context:** `../AGENTS.md`
+└── docs/AGENTS.md                  ← **Parent context:** `../AGENTS.md`
 ```
+
+## Loading Model
+
+Stock Claude Code discovers nested `CLAUDE.md` by basename and never loads a
+nested `AGENTS.md`; a root `@AGENTS.md` import does not reach subdirectories
+either. The nested files generated here are delivered by OMC's PostToolUse
+directory-context injector, which walks up from each accessed file and injects
+the nearest `AGENTS.md`/`README.md` once per session.
+
+That means the hierarchy requires OMC's hooks to be active. When OMC hooks are
+disabled (`DISABLE_OMC=1`, `OMC_SKIP_HOOKS=post-tool-use`) or the plugin is not
+registered, add a root-level `CLAUDE.md` symlink or `@AGENTS.md` import for the
+root file and expect nested files to stay unread.
 
 ## AGENTS.md Template
 
 ```markdown
-<!-- Parent: {relative_path_to_parent}/AGENTS.md -->
-<!-- Generated: {timestamp} | Updated: {timestamp} -->
-
 # {Directory Name}
+
+**Parent context:** `{relative_path_to_parent}/AGENTS.md`
+**Generated:** {timestamp} · **Updated:** {timestamp}
 
 ## Purpose
 {One-paragraph description of what this directory contains and its role}
@@ -77,7 +95,9 @@ This creates a navigable hierarchy:
 ### External
 {Key external packages/libraries used}
 
-<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->
+## Manual Notes
+
+Notes under this heading are written by humans and preserved on regeneration.
 ```
 
 ## Execution Workflow
@@ -117,7 +137,7 @@ When AGENTS.md already exists:
 1. **Read existing content**
 2. **Identify sections**:
    - Auto-generated sections (can be updated)
-   - Manual sections (`<!-- MANUAL -->` preserved)
+   - Manual sections (the `## Manual Notes` heading and everything under it are preserved)
 3. **Compare**:
    - New files added?
    - Files removed?
@@ -133,10 +153,10 @@ After generation, run validation checks:
 
 | Check | How to Verify | Corrective Action |
 |-------|--------------|-------------------|
-| Parent references resolve | Read each AGENTS.md, check `<!-- Parent: -->` path exists | Fix path or remove orphan |
+| Parent references resolve | Read each AGENTS.md, check the `**Parent context:**` path exists | Fix path or remove orphan |
 | No orphaned AGENTS.md | Compare AGENTS.md locations to directory structure | Delete orphaned files |
 | Completeness | List all directories, check for AGENTS.md | Generate missing files |
-| Timestamps current | Check `<!-- Generated: -->` dates | Regenerate outdated files |
+| Timestamps current | Check the `**Generated:**` / `**Updated:**` dates | Regenerate outdated files |
 
 Validation script pattern:
 ```bash
@@ -144,7 +164,7 @@ Validation script pattern:
 find . -name "AGENTS.md" -type f
 
 # Check parent references
-grep -r "<!-- Parent:" --include="AGENTS.md" .
+grep -r "\*\*Parent context:\*\*" --include="AGENTS.md" .
 ```
 
 ## Smart Delegation
@@ -169,8 +189,9 @@ When encountering empty or near-empty directories:
 
 Example minimal AGENTS.md for directory-only containers:
 ```markdown
-<!-- Parent: ../AGENTS.md -->
 # {Directory Name}
+
+**Parent context:** `../AGENTS.md`
 
 ## Purpose
 Container directory for organizing related modules.
@@ -206,9 +227,9 @@ Container directory for organizing related modules.
 
 ### Root AGENTS.md
 ```markdown
-<!-- Generated: 2024-01-15 | Updated: 2024-01-15 -->
-
 # my-project
+
+**Generated:** 2024-01-15 · **Updated:** 2024-01-15
 
 ## Purpose
 A web application for managing user tasks with real-time collaboration features.
@@ -249,15 +270,17 @@ A web application for managing user tasks with real-time collaboration features.
 - TypeScript 5.x - Type safety
 - Vite - Build tool
 
-<!-- MANUAL: Custom project notes can be added below -->
+## Manual Notes
+
+Custom project notes can be added under this heading.
 ```
 
 ### Nested AGENTS.md
 ```markdown
-<!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2024-01-15 | Updated: 2024-01-15 -->
-
 # components
+
+**Parent context:** `../AGENTS.md`
+**Generated:** 2024-01-15 · **Updated:** 2024-01-15
 
 ## Purpose
 Reusable React components organized by feature and complexity.
@@ -300,7 +323,7 @@ Reusable React components organized by feature and complexity.
 - `clsx` - Conditional class names
 - `lucide-react` - Icons
 
-<!-- MANUAL: -->
+## Manual Notes
 ```
 
 ## Triggering Update Mode

--- a/src/__tests__/directory-context-injector-registration.test.ts
+++ b/src/__tests__/directory-context-injector-registration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Registration contract for the PostToolUse directory-context injector (issue #4006).
+ *
+ * The injector implementation shipped for two releases while being registered
+ * nowhere, so no install ever ran it: `deepinit` wrote nested AGENTS.md files
+ * that nothing read. These tests pin the wiring, not the walking logic (which
+ * directory-context-injector.test.ts already covers).
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SCRIPT_NAME = 'post-tool-directory-context-injector.mjs';
+const SCRIPT_PATH = join(REPO_ROOT, 'scripts', SCRIPT_NAME);
+const DIST_HOOK = join(REPO_ROOT, 'dist', 'hooks', 'directory-readme-injector', 'index.js');
+
+interface HookCommand { type: string; command: string; timeout?: number }
+interface HookGroup { matcher: string; hooks: HookCommand[] }
+
+function postToolUseCommands(): string[] {
+  const config = JSON.parse(readFileSync(join(REPO_ROOT, 'hooks', 'hooks.json'), 'utf-8')) as {
+    hooks: Record<string, HookGroup[]>;
+  };
+  return (config.hooks.PostToolUse ?? []).flatMap((group) => group.hooks.map((hook) => hook.command));
+}
+
+function runInjector(payload: unknown, env: Record<string, string> = {}): Record<string, unknown> {
+  const stdout = execFileSync(process.execPath, [SCRIPT_PATH], {
+    input: JSON.stringify(payload),
+    encoding: 'utf-8',
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: REPO_ROOT, ...env },
+  });
+  return JSON.parse(stdout.trim()) as Record<string, unknown>;
+}
+
+describe('PostToolUse directory-context injector registration (issue #4006)', () => {
+  it('ships the wrapper script', () => {
+    expect(existsSync(SCRIPT_PATH)).toBe(true);
+  });
+
+  it('registers the wrapper on PostToolUse so nested AGENTS.md is actually delivered', () => {
+    const commands = postToolUseCommands();
+    expect(commands.some((command) => command.includes(SCRIPT_NAME))).toBe(true);
+  });
+
+  it('loads the hook from the built dist path the build emits', () => {
+    const source = readFileSync(SCRIPT_PATH, 'utf-8');
+    expect(source).toContain("'dist', 'hooks', 'directory-readme-injector', 'index.js'");
+    expect(source).toContain('createDirectoryReadmeInjectorHook');
+  });
+
+  it('continues without context when stdin is empty', () => {
+    expect(runInjector('')).toEqual({ continue: true });
+  });
+
+  it('honors DISABLE_OMC and the post-tool-use skip token', () => {
+    const payload = {
+      tool_name: 'Read',
+      tool_input: { file_path: join(REPO_ROOT, 'package.json') },
+      session_id: 'kill-switch',
+      cwd: REPO_ROOT,
+    };
+    expect(runInjector(payload, { DISABLE_OMC: '1' })).toEqual({ continue: true });
+    expect(runInjector(payload, { OMC_SKIP_HOOKS: 'post-tool-use' })).toEqual({ continue: true });
+  });
+
+  it.skipIf(!existsSync(DIST_HOOK))('injects a nested AGENTS.md for a tracked tool call', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'omc-injector-e2e-'));
+    try {
+      mkdirSync(join(projectRoot, 'src', 'nested'), { recursive: true });
+      writeFileSync(join(projectRoot, 'src', 'nested', 'AGENTS.md'), '# nested\n\nNESTED-AGENTS-TOKEN\n');
+      writeFileSync(join(projectRoot, 'src', 'nested', 'code.ts'), 'export {};\n');
+
+      const result = runInjector({
+        tool_name: 'Read',
+        tool_input: { file_path: join(projectRoot, 'src', 'nested', 'code.ts') },
+        session_id: `e2e-${Date.now()}`,
+        cwd: projectRoot,
+      });
+
+      expect(result.continue).toBe(true);
+      const output = result.hookSpecificOutput as { hookEventName: string; additionalContext: string };
+      expect(output.hookEventName).toBe('PostToolUse');
+      expect(output.additionalContext).toContain('NESTED-AGENTS-TOKEN');
+      expect(output.additionalContext).toContain('[Project AGENTS:');
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/run-cjs-windows-stdio-contract.test.ts
+++ b/src/__tests__/run-cjs-windows-stdio-contract.test.ts
@@ -181,6 +181,7 @@ describe('run.cjs Windows/protocol stdio contract (#3920)', () => {
       .filter((name): name is string => Boolean(name))
       .sort();
     expect(commands).toEqual([
+      'post-tool-directory-context-injector.mjs',
       'post-tool-rules-injector.mjs',
       'post-tool-use-failure.mjs',
       'project-memory-posttool.mjs',


### PR DESCRIPTION
Closes #4006.

@stfl 님 리포트의 두 가지 결함을 모두 고쳤습니다. 재현 절차와 결론이 정확했고, 특히 "injector가 `hooks/hooks.json`에 등록되어 있지 않다"는 지적이 핵심이었습니다.

**Finding 1 — nested `AGENTS.md`가 아무도 읽지 않음.** `src/hooks/directory-readme-injector/`는 구현과 단위 테스트가 있는데도 **어디에도 등록되어 있지 않았습니다**: 래퍼 스크립트도 없고 `hooks/hooks.json`에도 없어서, 플러그인 설치든 npm 설치든 **어떤 환경에서도 실행되지 않았습니다**. `createDirectoryReadmeInjectorHook`의 유일한 참조자가 테스트였습니다. 그래서 `deepinit`이 만든 중첩 파일은 전부 사문이었습니다.

- `scripts/post-tool-directory-context-injector.mjs` 추가 — 형제 훅 `post-tool-rules-injector.mjs`와 같은 계약을 따릅니다: 동일한 킬 스위치(`DISABLE_OMC`, `OMC_SKIP_HOOKS=post-tool-use`), `dist` 미빌드 시 조용한 no-op, `hookSpecificOutput.additionalContext`로만 추가.
- `hooks/hooks.json`의 `PostToolUse`에 등록(timeout 3s).
- 세션·파일 단위 dedup은 기존 storage 모듈이 담당하므로, 같은 `AGENTS.md`는 세션당 한 번만 주입됩니다.

**Finding 2 — HTML 주석 메타데이터가 모델에 도달하지 않음.** `skills/deepinit/SKILL.md`의 템플릿에서 parent 참조·타임스탬프·MANUAL 경계를 **보이는 본문**으로 옮겼습니다(`**Parent context:** \`../AGENTS.md\``, `**Generated:** … · **Updated:** …`, `## Manual Notes`). 검증 절차의 grep과 갱신 규칙도 같이 바꿨습니다. 스킬 문서에 "중첩 계층은 네이티브 memory discovery가 아니라 이 훅이 배달한다"는 로딩 모델과, OMC 훅이 비활성일 때의 한계를 명시했습니다.

**테스트:** `src/__tests__/directory-context-injector-registration.test.ts` 추가 — 래퍼 존재, **`PostToolUse` 등록**(이번에 실제로 빠져 있던 것), dist 로드 경로, 빈 stdin/킬 스위치 no-op, 그리고 실제 stdin→stdout으로 중첩 `AGENTS.md`가 `additionalContext`에 주입되는지까지 검사합니다. `run-cjs-windows-stdio-contract`의 3s 훅 목록도 갱신했습니다.

**검증(전용 worktree):** `src/__tests__` + `tests/lint` 전체를 `origin/dev` 베이스라인과 대조해 **신규 실패 0**(이 호스트의 기존 실패 75건은 시스템 `npm`/`npx` 파손으로 베이스라인에도 동일). `tsc --noEmit` 통과, `generate:inventory --verify` ok.

**범위 밖(별도 판단 필요):** 이 레포 자체의 `src/**/AGENTS.md` 파일들도 아직 `<!-- Parent: -->` 형식이라 모델에는 parent 줄이 보이지 않습니다. 네비게이션 편의 정보라 이번 PR에서는 건드리지 않았습니다.

—
*[repo owner's gaebal-gajae (clawdbot) 🦞]*
